### PR TITLE
Add tier-priority merge policy and gate + refactor merge policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ make deploy-ap-on-k8s
 
 ## Command line parameters
 - `concurrency`: The number of concurrent workers (per pool if unspecified), default is 8.
-- `request-merge-policy`: Currently only supporting <u>random-robin</u> policy.
+- `request-merge-policy-config`: Path to the JSON configuration file containing the request merge policy specification (`type` and `parameters`). If not specified, defaults to the `random-robin` policy.
 - `message-queue-impl`: Implementation of the queueing system. Options are <u>gcp-pubsub</u> for GCP PubSub, <u>gcp-pubsub-gated</u> for GCP PubSub with per-topic gating, <u>redis-sortedset</u> for Redis Sorted Set (persisted and sorted), and <u>redis-pubsub</u> for ephemeral Redis-based implementation.
 - `pool-config-file`: Path to the JSON configuration file containing the worker pool definitions. If omitted, a single `"default"` worker pool is created with concurrency determined by the global `concurrency` flag.
 
@@ -147,6 +147,7 @@ For more fine-grained control, configure gates per queue in your configuration f
 - `prometheus-budget`: Computes a dispatch budget D using a cascade of two Prometheus metric sources. Both sources compute `max_SYS = ready_pods × max_concurrency` dynamically. The primary source uses the EPP flow control queue size: `D = 1 − (queue_size / max_SYS)`. If the primary is unavailable, it falls back to a secondary source using vLLM and pool metrics: `D = 1 − (running_requests / max_SYS)`. The gate closes when D ≤ B (baseline); callers compute `N = max_SYS × (D − B)`. See [docs/dispatch-budget.md](docs/dispatch-budget.md) for details.
 - `prometheus-query`: Evaluates an arbitrary user-supplied PromQL expression as the dispatch budget. The expression must resolve to an instant vector with a single sample whose value is in [0, 1]. Unlike `prometheus-saturation` and `prometheus-budget`, this gate does not construct queries internally — the user provides the complete PromQL expression. Values outside [0, 1] are clamped.
 - `endpoint-scrape`: Scrapes a raw Prometheus `/metrics` endpoint directly (no Prometheus server required). Extracts a named metric, computes saturation, and returns the available budget. Supports two modes: **direct saturation** (metric value is already in [0, 1], e.g., from the EPP) and **computed saturation** (raw count divided by `max_count_per_pod`, e.g., `vllm:num_requests_waiting`). Optionally scrapes a second endpoint for dynamic pod count.
+- `tier-priority-admission`: Implements a three-way admission verdict based on saturation, queue tier, and reservation classification. Saturation is determined by evaluating an inner gate: if the inner gate returns `ActionRefuse`, the pool is considered saturated. If the pool is saturated: (1) returns `ActionWait` if classification is `reserved` (parking worker threads cleanly); (2) drops immediately with a `429` status payload if tier is `interactive` and classification is `overflow`; (3) returns `ActionRefuse` to place back in the queue if tier is `async` or `batch` and classification is `overflow`. If not saturated, returns `ActionContinue`.
 
 **Example Configuration with Per-Queue Gates:**
 
@@ -322,6 +323,11 @@ For more fine-grained control, configure gates per queue in your configuration f
   deployments without a dedicated Prometheus instance. Use `max_count_per_pod` with `pods_url`/`pods_metric`
   for dynamic scaling, or set `max_count_per_pod` to a static value for single-pod setups.
 
+- `tier-priority-admission`:
+  - `saturation_gate` (**required**): The type string of the inner gate used to evaluate pool saturation (e.g. `"prometheus-query"`).
+  - `saturation_gate_params` (optional): JSON-serialized string of parameters for the inner saturation gate.
+  - `tier_label` (optional): The label key to check the queue's SLA tier. Default is `"tier"`.
+
 ## Request Messages and Consumption
 
 The async processor expects request messages to have the following format:
@@ -368,7 +374,25 @@ Instead of performing a single global merge, the policy groups input channels by
 
 This per-pool topology provides complete backpressure and queue-level isolation: a slow or saturated pool will block only its own merged channel, leaving other pools completely unaffected and free to process requests.
 
-Currently the only policy supported is `Random Robin Policy` which randomly picks messages from all queues configured for a given pool.
+#### Configuration
+
+The merge policy is configured using the `--request-merge-policy-config` CLI flag. It points to a JSON configuration file specifying the policy `type` and optional custom `parameters`:
+
+```json
+{
+  "type": "tier-priority",
+  "parameters": {
+    "priority_header": "x-gateway-priority"
+  }
+}
+```
+
+#### Supported Policies
+
+1. **`random-robin`**: Randomly picks messages from all queues configured for a given pool. This is the default policy and accepts no parameters.
+2. **`tier-priority`**: Buckets requests into 6 strict priority lanes using routing tags (`(classification, tier)`). Within each bucket, it round-robins across different client channels and stamps the chosen priority header (`x-gateway-priority` by default).
+   - **Parameters**:
+     - `priority_header` (optional, string): The HTTP header name used to pass the priority value downstream to the inference scheduler. Default is `"x-gateway-priority"`.
 
 ## Request Body Transforms
 

--- a/README.md
+++ b/README.md
@@ -391,8 +391,10 @@ The merge policy is configured using the `--request-merge-policy-config` CLI fla
 
 1. **`random-robin`**: Randomly picks messages from all queues configured for a given pool. This is the default policy and accepts no parameters.
 2. **`tier-priority`**: Buckets requests into 6 strict priority lanes using routing tags (`(classification, tier)`). Within each bucket, it round-robins across different client channels and stamps the chosen priority header (`x-gateway-priority` by default).
+   - **Note**: The `tier-priority` merge policy assumes that all messages within a single queue share the same priority. Message classification relies on the FIFO order of an individual queue, and a message's classification does not change after it is pulled off the queue.
    - **Parameters**:
      - `priority_header` (optional, string): The HTTP header name used to pass the priority value downstream to the inference scheduler. Default is `"x-gateway-priority"`.
+     - `tier_label` (optional, string): The label name on `InternalRequest.Labels` used to look up the request's priority tier. Default is `"tier"`.
 
 ## Request Body Transforms
 

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -16,6 +16,14 @@ const (
 
 const LabelClassification = "classification"
 
+type PriorityTier string
+
+const (
+	TierInteractive PriorityTier = "interactive"
+	TierAsync       PriorityTier = "async"
+	TierBatch       PriorityTier = "batch"
+)
+
 // InternalRouting holds the resolved, authoritative routing fields used by
 // infrastructure (producers, workers, retry logic). These are not part of the
 // caller-facing contract and should not be set by callers directly.

--- a/charts/async-processor/templates/ap-configmap.yaml
+++ b/charts/async-processor/templates/ap-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig }}
+{{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,5 +15,8 @@ data:
   {{- end }}
   {{- if .Values.ap.transformConfig }}
   transform-config.json: {{ .Values.ap.transformConfig | toJson | quote }}
+  {{- end }}
+  {{- if .Values.ap.requestMergePolicyConfig }}
+  request-merge-policy.json: {{ .Values.ap.requestMergePolicyConfig | toJson | quote }}
   {{- end }}
 {{- end }}

--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -117,6 +117,9 @@ spec:
           {{- if .Values.ap.transformConfig }}
           - --transform-config-file=/etc/async-processor/config/transform-config.json
           {{- end }}
+          {{- if .Values.ap.requestMergePolicyConfig }}
+          - --request-merge-policy-config=/etc/async-processor/config/request-merge-policy.json
+          {{- end }}
           - --concurrency={{ .Values.ap.concurrency | default 8 }}
           - --drain-timeout={{ .Values.ap.drainTimeout | default "2m" }}
           - --health-port={{ .Values.ap.health.port | default 8081 }}
@@ -209,9 +212,9 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.tls.secretName }}
+        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig .Values.ap.tls.secretName }}
         volumeMounts:
-          {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig }}
+          {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
           - name: ap-config
             mountPath: /etc/async-processor/config
             readOnly: true
@@ -224,9 +227,9 @@ spec:
         {{- end }}
       serviceAccountName: {{ include "async-processor.fullname" . }}
       terminationGracePeriodSeconds: 130
-      {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.tls.secretName }}
+      {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig .Values.ap.tls.secretName }}
       volumes:
-        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig }}
+        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
         - name: ap-config
           configMap:
             name: {{ include "async-processor.fullname" . }}-config

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -47,6 +47,9 @@ ap:
   #       parameters:
   #         providers: ["whisper"]
   transformConfig: {}
+  # Request merge policy configuration. When set, rendered to a config file and passed
+  # via --request-merge-policy-config.
+  requestMergePolicyConfig: {}
   otel:
     # OTLP gRPC endpoint for trace collection. Examples:
     #   Dev (Jaeger all-in-one):     "http://jaeger.default.svc.cluster.local:4317"

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -132,24 +132,24 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 		return NewWaitOnRefuseGate(innerGate), nil
 
 	case "tier-priority-admission":
-		satGateType := params["saturation_gate"]
+		satGateType := paramString(params, "saturation_gate", "")
 		if satGateType == "" {
 			return nil, fmt.Errorf("tier-priority-admission gate requires a 'saturation_gate' parameter")
 		}
-		satGateParamsJSON := params["saturation_gate_params"]
-		var satGateParams map[string]string
-		if satGateParamsJSON != "" {
-			if err := json.Unmarshal([]byte(satGateParamsJSON), &satGateParams); err != nil {
-				return nil, fmt.Errorf("tier-priority-admission gate failed to parse 'saturation_gate_params': %w", err)
-			}
+		satGateParams, err := paramMapAny(params, "saturation_gate_params")
+		if err != nil {
+			return nil, fmt.Errorf("tier-priority-admission gate failed to parse 'saturation_gate_params': %w", err)
 		}
 
-		satGate, err := f.CreateGate(satGateType, satGateParams)
+		satGate, err := f.CreateGate(pipeline.GateConfig{
+			GateType:   satGateType,
+			GateParams: satGateParams,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("tier-priority-admission gate failed to create saturation gate %q: %w", satGateType, err)
 		}
 
-		tierLabel := params["tier_label"]
+		tierLabel := paramString(params, "tier_label", "tier")
 		return NewTierPriorityAdmissionGate(satGate, tierLabel), nil
 
 	case "constant":
@@ -568,4 +568,33 @@ func cachedSource(s MetricSource, ttl time.Duration) MetricSource {
 		return NewCachedMetricSource(s, ttl)
 	}
 	return s
+}
+
+// paramMapAny extracts a map[string]any from params.
+func paramMapAny(params map[string]any, key string) (map[string]any, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return nil, nil
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(val), &m); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", key, err)
+		}
+		return m, nil
+	case map[string]any:
+		return val, nil
+	case map[string]string:
+		m := make(map[string]any, len(val))
+		for k, valStr := range val {
+			m[k] = valStr
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T for key %q", v, key)
+	}
 }

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -131,6 +131,27 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 
 		return NewWaitOnRefuseGate(innerGate), nil
 
+	case "tier-priority-admission":
+		satGateType := params["saturation_gate"]
+		if satGateType == "" {
+			return nil, fmt.Errorf("tier-priority-admission gate requires a 'saturation_gate' parameter")
+		}
+		satGateParamsJSON := params["saturation_gate_params"]
+		var satGateParams map[string]string
+		if satGateParamsJSON != "" {
+			if err := json.Unmarshal([]byte(satGateParamsJSON), &satGateParams); err != nil {
+				return nil, fmt.Errorf("tier-priority-admission gate failed to parse 'saturation_gate_params': %w", err)
+			}
+		}
+
+		satGate, err := f.CreateGate(satGateType, satGateParams)
+		if err != nil {
+			return nil, fmt.Errorf("tier-priority-admission gate failed to create saturation gate %q: %w", satGateType, err)
+		}
+
+		tierLabel := params["tier_label"]
+		return NewTierPriorityAdmissionGate(satGate, tierLabel), nil
+
 	case "constant":
 		return ConstOpenGate(), nil
 

--- a/pkg/async/inference/flowcontrol/tier_priority_gate.go
+++ b/pkg/async/inference/flowcontrol/tier_priority_gate.go
@@ -26,7 +26,7 @@ func NewTierPriorityAdmissionGate(saturationGate pipeline.Gate, tierLabel string
 }
 
 func (g *TierPriorityAdmissionGate) Budget(ctx context.Context) float64 {
-	return 1.0
+	return g.saturationGate.Budget(ctx)
 }
 
 func (g *TierPriorityAdmissionGate) Apply(ctx context.Context, msg *api.InternalRequest, releases *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
@@ -51,7 +51,7 @@ func (g *TierPriorityAdmissionGate) Apply(ctx context.Context, msg *api.Internal
 		tier = msg.Labels[g.tierLabel]
 	}
 
-	if tier == "interactive" && classification == api.ClassificationOverflow {
+	if tier == string(api.TierInteractive) && classification == api.ClassificationOverflow {
 		result := &api.ResultMessage{
 			ID:      msg.PublicRequest.ReqID(),
 			Payload: `{"error": "Too Many Requests", "code": 429}`,

--- a/pkg/async/inference/flowcontrol/tier_priority_gate.go
+++ b/pkg/async/inference/flowcontrol/tier_priority_gate.go
@@ -1,0 +1,64 @@
+package flowcontrol
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+)
+
+var _ pipeline.Gate = (*TierPriorityAdmissionGate)(nil)
+
+type TierPriorityAdmissionGate struct {
+	saturationGate pipeline.Gate
+	tierLabel      string
+}
+
+func NewTierPriorityAdmissionGate(saturationGate pipeline.Gate, tierLabel string) *TierPriorityAdmissionGate {
+	if tierLabel == "" {
+		tierLabel = "tier"
+	}
+	return &TierPriorityAdmissionGate{
+		saturationGate: saturationGate,
+		tierLabel:      tierLabel,
+	}
+}
+
+func (g *TierPriorityAdmissionGate) Budget(ctx context.Context) float64 {
+	return 1.0
+}
+
+func (g *TierPriorityAdmissionGate) Apply(ctx context.Context, msg *api.InternalRequest, releases *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
+	satRes, err := g.saturationGate.Apply(ctx, msg, releases)
+	if err != nil {
+		return pipeline.Verdict{}, fmt.Errorf("saturation gate failed: %w", err)
+	}
+
+	isSaturated := satRes.Action == pipeline.ActionRefuse
+
+	if !isSaturated {
+		return pipeline.Continue(), nil
+	}
+
+	classification := msg.GetClassification()
+	if classification == api.ClassificationReserved {
+		return pipeline.Wait(), nil
+	}
+
+	tier := ""
+	if msg.Labels != nil {
+		tier = msg.Labels[g.tierLabel]
+	}
+
+	if tier == "interactive" && classification == api.ClassificationOverflow {
+		result := &api.ResultMessage{
+			ID:      msg.PublicRequest.ReqID(),
+			Payload: `{"error": "Too Many Requests", "code": 429}`,
+			Routing: msg.InternalRouting,
+		}
+		return pipeline.Drop(result), nil
+	}
+
+	return pipeline.Refuse(), nil
+}

--- a/pkg/async/inference/flowcontrol/tier_priority_gate_test.go
+++ b/pkg/async/inference/flowcontrol/tier_priority_gate_test.go
@@ -1,0 +1,98 @@
+package flowcontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTierPriorityAdmissionGate_Budget(t *testing.T) {
+	satGate := DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 })
+	gate := NewTierPriorityAdmissionGate(satGate, "tier")
+	assert.Equal(t, 1.0, gate.Budget(context.Background()))
+}
+
+func TestTierPriorityAdmissionGate_Apply(t *testing.T) {
+	satGate := DispatchGateFunc(func(ctx context.Context) float64 { return 0.0 })   // Always returns Refuse (Saturated)
+	unsatGate := DispatchGateFunc(func(ctx context.Context) float64 { return 1.0 }) // Always returns Continue (Unsaturated)
+
+	t.Run("Not saturated - Continue", func(t *testing.T) {
+		gate := NewTierPriorityAdmissionGate(unsatGate, "tier")
+		msg := api.NewInternalRequest(api.InternalRouting{
+			Labels: map[string]string{
+				"tier": "interactive",
+			},
+		}, &api.RequestMessage{ID: "req"})
+		msg.SetClassification(api.ClassificationReserved)
+
+		var releases []pipeline.GateReleaseFunc
+		res, err := gate.Apply(context.Background(), msg, &releases)
+		assert.NoError(t, err)
+		assert.Equal(t, pipeline.ActionContinue, res.Action)
+	})
+
+	t.Run("Saturated - Reserved - Wait", func(t *testing.T) {
+		gate := NewTierPriorityAdmissionGate(satGate, "tier")
+		msg := api.NewInternalRequest(api.InternalRouting{
+			Labels: map[string]string{
+				"tier": "interactive",
+			},
+		}, &api.RequestMessage{ID: "req"})
+		msg.SetClassification(api.ClassificationReserved)
+
+		var releases []pipeline.GateReleaseFunc
+		res, err := gate.Apply(context.Background(), msg, &releases)
+		assert.NoError(t, err)
+		assert.Equal(t, pipeline.ActionWait, res.Action)
+	})
+
+	t.Run("Saturated - Overflow Interactive - Drop 429", func(t *testing.T) {
+		gate := NewTierPriorityAdmissionGate(satGate, "tier")
+		msg := api.NewInternalRequest(api.InternalRouting{
+			Labels: map[string]string{
+				"tier": "interactive",
+			},
+		}, &api.RequestMessage{ID: "req"})
+		msg.SetClassification(api.ClassificationOverflow)
+
+		var releases []pipeline.GateReleaseFunc
+		res, err := gate.Apply(context.Background(), msg, &releases)
+		assert.NoError(t, err)
+		assert.Equal(t, pipeline.ActionDrop, res.Action)
+		assert.NotNil(t, res.Result)
+		assert.Contains(t, res.Result.Payload, `"code": 429`)
+	})
+
+	t.Run("Saturated - Overflow Async - Refuse", func(t *testing.T) {
+		gate := NewTierPriorityAdmissionGate(satGate, "tier")
+		msg := api.NewInternalRequest(api.InternalRouting{
+			Labels: map[string]string{
+				"tier": "async",
+			},
+		}, &api.RequestMessage{ID: "req"})
+		msg.SetClassification(api.ClassificationOverflow)
+
+		var releases []pipeline.GateReleaseFunc
+		res, err := gate.Apply(context.Background(), msg, &releases)
+		assert.NoError(t, err)
+		assert.Equal(t, pipeline.ActionRefuse, res.Action)
+	})
+
+	t.Run("Saturated - Overflow Batch - Refuse", func(t *testing.T) {
+		gate := NewTierPriorityAdmissionGate(satGate, "tier")
+		msg := api.NewInternalRequest(api.InternalRouting{
+			Labels: map[string]string{
+				"tier": "batch",
+			},
+		}, &api.RequestMessage{ID: "req"})
+		msg.SetClassification(api.ClassificationOverflow)
+
+		var releases []pipeline.GateReleaseFunc
+		res, err := gate.Apply(context.Background(), msg, &releases)
+		assert.NoError(t, err)
+		assert.Equal(t, pipeline.ActionRefuse, res.Action)
+	})
+}

--- a/pkg/async/mergepolicy/loader.go
+++ b/pkg/async/mergepolicy/loader.go
@@ -1,0 +1,33 @@
+package mergepolicy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	_ "github.com/llm-d-incubation/llm-d-async/pkg/async/mergepolicy/randomrobin"
+	_ "github.com/llm-d-incubation/llm-d-async/pkg/async/mergepolicy/tierpriority"
+)
+
+// MergePolicySpec represents the JSON configuration structure for a request merge policy.
+type MergePolicySpec struct {
+	Type       string          `json:"type"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+}
+
+// LoadMergePolicyConfig reads and parses a request merge policy configuration JSON file.
+func LoadMergePolicyConfig(path string) (MergePolicySpec, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path from trusted CLI flag
+	if err != nil {
+		return MergePolicySpec{}, fmt.Errorf("failed to read merge policy config file: %w", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var cfg MergePolicySpec
+	if err := dec.Decode(&cfg); err != nil {
+		return MergePolicySpec{}, fmt.Errorf("failed to unmarshal merge policy config: %w", err)
+	}
+	return cfg, nil
+}

--- a/pkg/async/mergepolicy/loader_test.go
+++ b/pkg/async/mergepolicy/loader_test.go
@@ -1,0 +1,63 @@
+package mergepolicy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadMergePolicyConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "merge-policy-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	t.Run("valid config", func(t *testing.T) {
+		configPath := filepath.Join(tmpDir, "valid.json")
+		content := `{
+			"type": "tier-priority",
+			"parameters": {
+				"priority_header": "x-gateway-priority"
+			}
+		}`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		spec, err := LoadMergePolicyConfig(configPath)
+		if err != nil {
+			t.Fatalf("unexpected error loading config: %v", err)
+		}
+
+		if spec.Type != "tier-priority" {
+			t.Errorf("expected type 'tier-priority', got %q", spec.Type)
+		}
+
+		var params map[string]string
+		if err := json.Unmarshal(spec.Parameters, &params); err != nil {
+			t.Fatalf("failed to unmarshal parameters: %v", err)
+		}
+
+		if params["priority_header"] != "x-gateway-priority" {
+			t.Errorf("expected priority_header 'x-gateway-priority', got %q", params["priority_header"])
+		}
+	})
+
+	t.Run("invalid unknown fields", func(t *testing.T) {
+		configPath := filepath.Join(tmpDir, "invalid.json")
+		content := `{
+			"type": "tier-priority",
+			"unknown_field": "error"
+		}`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		_, err := LoadMergePolicyConfig(configPath)
+		if err == nil {
+			t.Error("expected error due to unknown field, got nil")
+		}
+	})
+}

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
@@ -1,6 +1,7 @@
-package async
+package randomrobin
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -8,15 +9,31 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
 )
 
-func NewRandomRobinPolicy() pipeline.RequestMergePolicy {
-	return &RandomRobinPolicy{}
+func init() {
+	plugins.MustRegister("random-robin", func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
+		return NewRandomRobinPolicy(name), nil
+	})
+}
+
+func NewRandomRobinPolicy(name string) *RandomRobinPolicy {
+	return &RandomRobinPolicy{name: name}
 }
 
 var _ pipeline.RequestMergePolicy = (*RandomRobinPolicy)(nil)
+var _ plugins.Plugin = (*RandomRobinPolicy)(nil)
 
 type RandomRobinPolicy struct {
+	name string
+}
+
+func (r *RandomRobinPolicy) TypedName() plugins.TypedName {
+	return plugins.TypedName{
+		Type: "random-robin",
+		Name: r.name,
+	}
 }
 
 func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) pipeline.PoolDispatch {

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
@@ -1,4 +1,4 @@
-package async
+package randomrobin
 
 import (
 	"fmt"
@@ -33,7 +33,7 @@ func TestProcessAllChannels(t *testing.T) {
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURL: "http://gw", RequestPathURL: "/v1"},
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURL: "http://gw", RequestPathURL: "/v1"},
 	}
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 
 	// Send messages to each channel
 	for i, ch := range channels {
@@ -70,7 +70,7 @@ func TestProcessAllChannels(t *testing.T) {
 }
 
 func TestEmptyChannelsReturnsClosed(t *testing.T) {
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 	merged := policy.MergeRequestChannels(nil, nil)
 	if len(merged.Channels) != 0 {
 		t.Fatalf("expected 0 channels in dispatch, got %d", len(merged.Channels))
@@ -87,7 +87,7 @@ func TestMetaAlignmentAfterChannelClosure(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-a": {ID: "pool-a", Workers: 1},
 	}
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 	merged := policy.MergeRequestChannels(channels, pools)
 	mergedChannel := merged.Channels["pool-a"]
 
@@ -166,7 +166,7 @@ func TestPerMessageEndpointOverridesChannelURL(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"my-pool": {ID: "my-pool", Workers: 1},
 	}
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 
 	// One message with endpoint, one without.
 	ch.Channel <- irWithEndpoint("with-ep", "/v1/custom")
@@ -230,7 +230,7 @@ func TestURLJoinPathHandlesSlashes(t *testing.T) {
 			}
 			close(ch.Channel)
 
-			policy := NewRandomRobinPolicy()
+			policy := NewRandomRobinPolicy("test")
 			merged := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
 			mergedChannel := merged.Channels["test-pool"]
 
@@ -266,7 +266,7 @@ func TestPerRequestHeadersMerged(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"test-pool": {ID: "test-pool", Workers: 1},
 	}
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 
 	ch.Channel <- irWithHeaders("custom", map[string]string{
 		"Authorization": "Bearer tok",
@@ -318,7 +318,7 @@ func TestMergedChannelIsBuffered(t *testing.T) {
 	for i := range numChannels {
 		channels[i] = pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1), IGWBaseURL: "http://gw", RequestPathURL: "/v1"}
 	}
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"default": {ID: "default", Workers: 1},
 	}
@@ -350,7 +350,7 @@ func TestMergeRequestChannels_PanicOnMissingPool(t *testing.T) {
 	channels := []pipeline.RequestChannel{
 		{WorkerPoolID: "non-existent-pool"},
 	}
-	policy := NewRandomRobinPolicy()
+	policy := NewRandomRobinPolicy("test")
 
 	defer func() {
 		if r := recover(); r == nil {

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -1,0 +1,292 @@
+package tierpriority
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"sync"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
+)
+
+func init() {
+	plugins.MustRegister("tier-priority", func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
+		var params struct {
+			PriorityHeader string `json:"priority_header"`
+		}
+		if len(parameters) > 0 {
+			if err := json.Unmarshal(parameters, &params); err != nil {
+				return nil, fmt.Errorf("failed to parse tier-priority parameters: %w", err)
+			}
+		}
+		if params.PriorityHeader == "" {
+			params.PriorityHeader = "x-gateway-priority"
+		}
+		return NewTierPriorityPolicy(name, params.PriorityHeader), nil
+	})
+}
+
+func NewTierPriorityPolicy(name string, priorityHeader string) *TierPriorityPolicy {
+	return &TierPriorityPolicy{
+		name:           name,
+		priorityHeader: priorityHeader,
+	}
+}
+
+var _ pipeline.RequestMergePolicy = (*TierPriorityPolicy)(nil)
+var _ plugins.Plugin = (*TierPriorityPolicy)(nil)
+
+type TierPriorityPolicy struct {
+	name           string
+	priorityHeader string
+}
+
+func (p *TierPriorityPolicy) TypedName() plugins.TypedName {
+	return plugins.TypedName{
+		Type: "tier-priority",
+		Name: p.name,
+	}
+}
+
+type msgAndMeta struct {
+	ir     *api.InternalRequest
+	chMeta pipeline.RequestChannel
+}
+
+type bucket struct {
+	queues  map[string][]msgAndMeta
+	keys    []string
+	nextIdx int
+}
+
+func newBucket() *bucket {
+	return &bucket{
+		queues: make(map[string][]msgAndMeta),
+	}
+}
+
+func (b *bucket) push(key string, mm msgAndMeta) {
+	q, exists := b.queues[key]
+	if !exists {
+		b.keys = append(b.keys, key)
+	}
+	b.queues[key] = append(q, mm)
+}
+
+func (b *bucket) pop() (msgAndMeta, bool) {
+	if len(b.keys) == 0 {
+		return msgAndMeta{}, false
+	}
+
+	startIdx := b.nextIdx
+	for {
+		key := b.keys[b.nextIdx]
+		q := b.queues[key]
+		if len(q) > 0 {
+			mm := q[0]
+			b.queues[key] = q[1:]
+			b.nextIdx = (b.nextIdx + 1) % len(b.keys)
+			return mm, true
+		}
+		b.nextIdx = (b.nextIdx + 1) % len(b.keys)
+		if b.nextIdx == startIdx {
+			return msgAndMeta{}, false
+		}
+	}
+}
+
+type scheduler struct {
+	mu            sync.Mutex
+	cond          *sync.Cond
+	totalBuffered int
+	maxBuffered   int
+	closed        bool
+	activeReaders int
+	buckets       [6]*bucket
+}
+
+func newScheduler(maxBuffered int, activeReaders int) *scheduler {
+	s := &scheduler{
+		maxBuffered:   maxBuffered,
+		activeReaders: activeReaders,
+	}
+	s.cond = sync.NewCond(&s.mu)
+	for i := range s.buckets {
+		s.buckets[i] = newBucket()
+	}
+	return s
+}
+
+func getPriorityIndex(ir *api.InternalRequest) int {
+	tierPri := 2 // default to batch (lowest priority tier)
+	if ir.Labels != nil {
+		switch ir.Labels["tier"] {
+		case "interactive":
+			tierPri = 0
+		case "async":
+			tierPri = 1
+		case "batch":
+			tierPri = 2
+		}
+	}
+
+	classPri := 1 // default to overflow
+	if ir.GetClassification() == api.ClassificationReserved {
+		classPri = 0
+	}
+
+	return classPri*3 + tierPri
+}
+
+func (s *scheduler) Push(ir *api.InternalRequest, chMeta pipeline.RequestChannel) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for s.totalBuffered >= s.maxBuffered && !s.closed {
+		s.cond.Wait()
+	}
+
+	if s.closed {
+		return false
+	}
+
+	pri := getPriorityIndex(ir)
+	key := fmt.Sprintf("%p", chMeta.Channel)
+
+	s.buckets[pri].push(key, msgAndMeta{ir: ir, chMeta: chMeta})
+	s.totalBuffered++
+	s.cond.Broadcast()
+	return true
+}
+
+func (s *scheduler) Pop() (msgAndMeta, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for s.totalBuffered == 0 {
+		if s.activeReaders == 0 || s.closed {
+			return msgAndMeta{}, false
+		}
+		s.cond.Wait()
+	}
+
+	for _, b := range s.buckets {
+		if mm, ok := b.pop(); ok {
+			s.totalBuffered--
+			s.cond.Broadcast()
+			return mm, true
+		}
+	}
+
+	return msgAndMeta{}, false
+}
+
+func (s *scheduler) DecrementReaders() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeReaders--
+	s.cond.Broadcast()
+}
+
+func (s *scheduler) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	s.cond.Broadcast()
+}
+
+func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) pipeline.PoolDispatch {
+	channelsByPool := make(map[string][]pipeline.RequestChannel)
+	for _, ch := range channels {
+		workerPoolID := ch.WorkerPoolID
+		if workerPoolID == "" {
+			workerPoolID = "default"
+		}
+		if _, ok := pools[workerPoolID]; !ok {
+			panic(fmt.Sprintf("worker pool %q not found in pools map", workerPoolID))
+		}
+		channelsByPool[workerPoolID] = append(channelsByPool[workerPoolID], ch)
+	}
+
+	dispatch := pipeline.PoolDispatch{
+		Channels: make(map[string]chan pipeline.EmbelishedRequestMessage),
+	}
+
+	for workerPoolID, poolChs := range channelsByPool {
+		mergedChannel := make(chan pipeline.EmbelishedRequestMessage, len(poolChs))
+		dispatch.Channels[workerPoolID] = mergedChannel
+
+		if len(poolChs) == 0 {
+			close(mergedChannel)
+			continue
+		}
+
+		s := newScheduler(1000, len(poolChs))
+
+		for _, ch := range poolChs {
+			go func(ch pipeline.RequestChannel, s *scheduler) {
+				defer s.DecrementReaders()
+				for {
+					val, ok := <-ch.Channel
+					if !ok {
+						break
+					}
+					if val == nil {
+						continue
+					}
+					if !s.Push(val, ch) {
+						break
+					}
+				}
+			}(ch, s)
+		}
+
+		go func(workerPoolID string, s *scheduler, mergedChannel chan pipeline.EmbelishedRequestMessage, priorityHeader string) {
+			defer close(mergedChannel)
+			defer s.Close()
+			for {
+				mm, ok := s.Pop()
+				if !ok {
+					break
+				}
+				ir := mm.ir
+				chMeta := mm.chMeta
+
+				requestPath := chMeta.RequestPathURL
+				if ep := ir.PublicRequest.ReqEndpoint(); ep != "" {
+					requestPath = ep
+				}
+				requestURL, _ := url.JoinPath(chMeta.IGWBaseURL, requestPath)
+				headers := map[string]string{
+					"Content-Type": "application/json",
+				}
+				if chMeta.InferenceObjective != "" {
+					headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
+				}
+				for k, v := range ir.PublicRequest.ReqHeaders() {
+					headers[k] = v
+				}
+
+				pri := getPriorityIndex(ir)
+				if priorityHeader != "" {
+					headers[priorityHeader] = strconv.Itoa(pri)
+				}
+
+				erm := pipeline.EmbelishedRequestMessage{
+					InternalRequest: ir,
+					HttpHeaders:     headers,
+					RequestURL:      requestURL,
+					WorkerPoolID:    workerPoolID,
+				}
+				metrics.IncQueueDepth(ir.QueueID, ir.RequestQueueName, workerPoolID)
+				mergedChannel <- erm
+			}
+		}(workerPoolID, s, mergedChannel, p.priorityHeader)
+	}
+
+	return dispatch
+}

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -17,6 +17,7 @@ func init() {
 	plugins.MustRegister("tier-priority", func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 		var params struct {
 			PriorityHeader string `json:"priority_header"`
+			TierLabel      string `json:"tier_label"`
 		}
 		if len(parameters) > 0 {
 			if err := json.Unmarshal(parameters, &params); err != nil {
@@ -26,14 +27,21 @@ func init() {
 		if params.PriorityHeader == "" {
 			params.PriorityHeader = "x-gateway-priority"
 		}
-		return NewTierPriorityPolicy(name, params.PriorityHeader), nil
+		if params.TierLabel == "" {
+			params.TierLabel = "tier"
+		}
+		return NewTierPriorityPolicy(name, params.PriorityHeader, params.TierLabel), nil
 	})
 }
 
-func NewTierPriorityPolicy(name string, priorityHeader string) *TierPriorityPolicy {
+func NewTierPriorityPolicy(name string, priorityHeader string, tierLabel string) *TierPriorityPolicy {
+	if tierLabel == "" {
+		tierLabel = "tier"
+	}
 	return &TierPriorityPolicy{
 		name:           name,
 		priorityHeader: priorityHeader,
+		tierLabel:      tierLabel,
 	}
 }
 
@@ -43,6 +51,7 @@ var _ plugins.Plugin = (*TierPriorityPolicy)(nil)
 type TierPriorityPolicy struct {
 	name           string
 	priorityHeader string
+	tierLabel      string
 }
 
 func (p *TierPriorityPolicy) TypedName() plugins.TypedName {
@@ -61,6 +70,7 @@ type bucket struct {
 	queues  map[string][]msgAndMeta
 	keys    []string
 	nextIdx int
+	size    int
 }
 
 func newBucket() *bucket {
@@ -75,6 +85,7 @@ func (b *bucket) push(key string, mm msgAndMeta) {
 		b.keys = append(b.keys, key)
 	}
 	b.queues[key] = append(q, mm)
+	b.size++
 }
 
 func (b *bucket) pop() (msgAndMeta, bool) {
@@ -82,21 +93,25 @@ func (b *bucket) pop() (msgAndMeta, bool) {
 		return msgAndMeta{}, false
 	}
 
-	startIdx := b.nextIdx
-	for {
-		key := b.keys[b.nextIdx]
-		q := b.queues[key]
-		if len(q) > 0 {
-			mm := q[0]
-			b.queues[key] = q[1:]
-			b.nextIdx = (b.nextIdx + 1) % len(b.keys)
-			return mm, true
+	key := b.keys[b.nextIdx]
+	q := b.queues[key]
+	mm := q[0]
+	b.queues[key] = q[1:]
+	b.size--
+
+	if len(b.queues[key]) == 0 {
+		b.keys = append(b.keys[:b.nextIdx], b.keys[b.nextIdx+1:]...)
+		delete(b.queues, key)
+		if len(b.keys) > 0 {
+			b.nextIdx = b.nextIdx % len(b.keys)
+		} else {
+			b.nextIdx = 0
 		}
+	} else {
 		b.nextIdx = (b.nextIdx + 1) % len(b.keys)
-		if b.nextIdx == startIdx {
-			return msgAndMeta{}, false
-		}
 	}
+
+	return mm, true
 }
 
 type scheduler struct {
@@ -104,15 +119,17 @@ type scheduler struct {
 	cond          *sync.Cond
 	totalBuffered int
 	maxBuffered   int
+	tierLabel     string
 	closed        bool
 	activeReaders int
 	buckets       [6]*bucket
 }
 
-func newScheduler(maxBuffered int, activeReaders int) *scheduler {
+func newScheduler(maxBuffered int, activeReaders int, tierLabel string) *scheduler {
 	s := &scheduler{
 		maxBuffered:   maxBuffered,
 		activeReaders: activeReaders,
+		tierLabel:     tierLabel,
 	}
 	s.cond = sync.NewCond(&s.mu)
 	for i := range s.buckets {
@@ -121,15 +138,15 @@ func newScheduler(maxBuffered int, activeReaders int) *scheduler {
 	return s
 }
 
-func getPriorityIndex(ir *api.InternalRequest) int {
+func getPriorityIndex(ir *api.InternalRequest, tierLabel string) int {
 	tierPri := 2 // default to batch (lowest priority tier)
 	if ir.Labels != nil {
-		switch ir.Labels["tier"] {
-		case "interactive":
+		switch ir.Labels[tierLabel] {
+		case string(api.TierInteractive):
 			tierPri = 0
-		case "async":
+		case string(api.TierAsync):
 			tierPri = 1
-		case "batch":
+		case string(api.TierBatch):
 			tierPri = 2
 		}
 	}
@@ -146,7 +163,10 @@ func (s *scheduler) Push(ir *api.InternalRequest, chMeta pipeline.RequestChannel
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for s.totalBuffered >= s.maxBuffered && !s.closed {
+	pri := getPriorityIndex(ir, s.tierLabel)
+
+	// Backpressure: block only if this specific bucket is full
+	for s.buckets[pri].size >= s.maxBuffered && !s.closed {
 		s.cond.Wait()
 	}
 
@@ -154,9 +174,7 @@ func (s *scheduler) Push(ir *api.InternalRequest, chMeta pipeline.RequestChannel
 		return false
 	}
 
-	pri := getPriorityIndex(ir)
 	key := fmt.Sprintf("%p", chMeta.Channel)
-
 	s.buckets[pri].push(key, msgAndMeta{ir: ir, chMeta: chMeta})
 	s.totalBuffered++
 	s.cond.Broadcast()
@@ -225,7 +243,7 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 			continue
 		}
 
-		s := newScheduler(1000, len(poolChs))
+		s := newScheduler(1000, len(poolChs), p.tierLabel)
 
 		for _, ch := range poolChs {
 			go func(ch pipeline.RequestChannel, s *scheduler) {
@@ -245,7 +263,7 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 			}(ch, s)
 		}
 
-		go func(workerPoolID string, s *scheduler, mergedChannel chan pipeline.EmbelishedRequestMessage, priorityHeader string) {
+		go func(workerPoolID string, s *scheduler, mergedChannel chan pipeline.EmbelishedRequestMessage, priorityHeader string, tierLabel string) {
 			defer close(mergedChannel)
 			defer s.Close()
 			for {
@@ -271,7 +289,7 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 					headers[k] = v
 				}
 
-				pri := getPriorityIndex(ir)
+				pri := getPriorityIndex(ir, tierLabel)
 				if priorityHeader != "" {
 					headers[priorityHeader] = strconv.Itoa(pri)
 				}
@@ -285,7 +303,7 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 				metrics.IncQueueDepth(ir.QueueID, ir.RequestQueueName, workerPoolID)
 				mergedChannel <- erm
 			}
-		}(workerPoolID, s, mergedChannel, p.priorityHeader)
+		}(workerPoolID, s, mergedChannel, p.priorityHeader, p.tierLabel)
 	}
 
 	return dispatch

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
@@ -1,0 +1,178 @@
+package tierpriority
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+)
+
+func irWithLabels(id string, labels map[string]string) *api.InternalRequest {
+	ir := api.NewInternalRequest(api.InternalRouting{
+		Labels: labels,
+	}, &api.RequestMessage{
+		ID:       id,
+		Created:  1,
+		Deadline: 9999999999,
+	})
+	return ir
+}
+
+func TestTierPriorityOrdering(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 10),
+		WorkerPoolID: "pool-p",
+		IGWBaseURL:   "http://gw",
+	}
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-p": {ID: "pool-p", Workers: 1},
+	}
+	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority")
+
+	// Message 1: overflow + batch => Priority 5
+	m1 := irWithLabels("msg-5", map[string]string{
+		"tier":                  "batch",
+		api.LabelClassification: string(api.ClassificationOverflow),
+	})
+	// Message 2: reserved + interactive => Priority 0
+	m2 := irWithLabels("msg-0", map[string]string{
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+	// Message 3: reserved + async => Priority 1
+	m3 := irWithLabels("msg-1", map[string]string{
+		"tier":                  "async",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+	// Message 4: overflow + interactive => Priority 3
+	m4 := irWithLabels("msg-3", map[string]string{
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationOverflow),
+	})
+
+	// Send them in mixed order
+	ch.Channel <- m1
+	ch.Channel <- m2
+	ch.Channel <- m3
+	ch.Channel <- m4
+	close(ch.Channel)
+
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
+	merged := dispatch.Channels["pool-p"]
+
+	expectedOrder := []struct {
+		id       string
+		priority string
+	}{
+		{"msg-0", "0"},
+		{"msg-1", "1"},
+		{"msg-3", "3"},
+		{"msg-5", "5"},
+	}
+
+	deadline := time.After(3 * time.Second)
+	for i, expected := range expectedOrder {
+		select {
+		case msg := <-merged:
+			if msg.PublicRequest.ReqID() != expected.id {
+				t.Errorf("[%d] expected request ID %q, got %q", i, expected.id, msg.PublicRequest.ReqID())
+			}
+			pHeader := msg.HttpHeaders["x-gateway-priority"]
+			if pHeader != expected.priority {
+				t.Errorf("[%d] expected priority header %q, got %q", i, expected.priority, pHeader)
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for message %d", i)
+		}
+	}
+}
+
+func TestSchedulerRoundRobin(t *testing.T) {
+	s := newScheduler(10, 2)
+
+	a1 := irWithLabels("a1", map[string]string{
+		"team":                  "team-a",
+		"model":                 "model-1",
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+	a2 := irWithLabels("a2", map[string]string{
+		"team":                  "team-a",
+		"model":                 "model-1",
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+	b1 := irWithLabels("b1", map[string]string{
+		"team":                  "team-b",
+		"model":                 "model-2",
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+	b2 := irWithLabels("b2", map[string]string{
+		"team":                  "team-b",
+		"model":                 "model-2",
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+
+	chA := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)}
+	chB := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)}
+	s.Push(a1, chA)
+	s.Push(a2, chA)
+	s.Push(b1, chB)
+	s.Push(b2, chB)
+
+	var order []string
+	for range 4 {
+		mm, ok := s.Pop()
+		if !ok {
+			t.Fatal("expected message")
+		}
+		order = append(order, mm.ir.PublicRequest.ReqID())
+	}
+
+	expected := []string{"a1", "b1", "a2", "b2"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d elements, got %d", len(expected), len(order))
+	}
+	for i, v := range expected {
+		if order[i] != v {
+			t.Errorf("at index %d: expected %q, got %q", i, v, order[i])
+		}
+	}
+}
+
+func TestTierPriorityFallback(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 2),
+		WorkerPoolID: "pool-fb",
+		IGWBaseURL:   "http://gw",
+	}
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-fb": {ID: "pool-fb", Workers: 1},
+	}
+	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority")
+
+	// Message with missing labels should map to lowest priority (5)
+	m := irWithLabels("missing-labels", nil)
+	ch.Channel <- m
+	close(ch.Channel)
+
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
+	merged := dispatch.Channels["pool-fb"]
+
+	select {
+	case msg := <-merged:
+		if msg.PublicRequest.ReqID() != "missing-labels" {
+			t.Errorf("expected missing-labels, got %q", msg.PublicRequest.ReqID())
+		}
+		pHeader := msg.HttpHeaders["x-gateway-priority"]
+		if pHeader != strconv.Itoa(5) {
+			t.Errorf("expected priority header 5 for fallback, got %q", pHeader)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+}

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
@@ -1,6 +1,7 @@
 package tierpriority
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ func TestTierPriorityOrdering(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-p": {ID: "pool-p", Workers: 1},
 	}
-	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority")
+	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority", "tier")
 
 	// Message 1: overflow + batch => Priority 5
 	m1 := irWithLabels("msg-5", map[string]string{
@@ -90,7 +91,7 @@ func TestTierPriorityOrdering(t *testing.T) {
 }
 
 func TestSchedulerRoundRobin(t *testing.T) {
-	s := newScheduler(10, 2)
+	s := newScheduler(10, 2, "tier")
 
 	a1 := irWithLabels("a1", map[string]string{
 		"team":                  "team-a",
@@ -153,7 +154,7 @@ func TestTierPriorityFallback(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-fb": {ID: "pool-fb", Workers: 1},
 	}
-	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority")
+	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority", "tier")
 
 	// Message with missing labels should map to lowest priority (5)
 	m := irWithLabels("missing-labels", nil)
@@ -174,5 +175,120 @@ func TestTierPriorityFallback(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out")
+	}
+}
+
+func TestTierPriorityCustomLabel(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 2),
+		WorkerPoolID: "pool-fb",
+		IGWBaseURL:   "http://gw",
+	}
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-fb": {ID: "pool-fb", Workers: 1},
+	}
+	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority", "my_custom_tier")
+
+	// Message with my_custom_tier label
+	m := irWithLabels("custom-label-msg", map[string]string{
+		"my_custom_tier":        "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+	ch.Channel <- m
+	close(ch.Channel)
+
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
+	merged := dispatch.Channels["pool-fb"]
+
+	select {
+	case msg := <-merged:
+		if msg.PublicRequest.ReqID() != "custom-label-msg" {
+			t.Errorf("expected custom-label-msg, got %q", msg.PublicRequest.ReqID())
+		}
+		pHeader := msg.HttpHeaders["x-gateway-priority"]
+		if pHeader != "0" {
+			t.Errorf("expected priority header 0, got %q", pHeader)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestBucketKeyCleanup(t *testing.T) {
+	b := newBucket()
+	chA := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)}
+	chB := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)}
+	keyA := fmt.Sprintf("%p", chA.Channel)
+	keyB := fmt.Sprintf("%p", chB.Channel)
+
+	irA := irWithLabels("a1", nil)
+	irB := irWithLabels("b1", nil)
+
+	b.push(keyA, msgAndMeta{ir: irA, chMeta: chA})
+	b.push(keyB, msgAndMeta{ir: irB, chMeta: chB})
+
+	if len(b.keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(b.keys))
+	}
+
+	_, ok := b.pop()
+	if !ok {
+		t.Fatal("expected to pop item")
+	}
+	if len(b.keys) != 1 {
+		t.Errorf("expected 1 key remaining after pop of empty queue, got %d", len(b.keys))
+	}
+
+	_, ok = b.pop()
+	if !ok {
+		t.Fatal("expected to pop second item")
+	}
+	if len(b.keys) != 0 {
+		t.Errorf("expected 0 keys remaining, got %d", len(b.keys))
+	}
+	if len(b.queues) != 0 {
+		t.Errorf("expected map to be empty, got %v", b.queues)
+	}
+}
+
+func TestPerBucketLimitsNonBlocking(t *testing.T) {
+	// scheduler with capacity 1 per bucket
+	s := newScheduler(1, 1, "tier")
+
+	chA := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)}
+	chB := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)}
+
+	// Message 1: overflow + batch => Priority 5
+	m1 := irWithLabels("msg-5", map[string]string{
+		"tier":                  "batch",
+		api.LabelClassification: string(api.ClassificationOverflow),
+	})
+
+	// Message 2: reserved + interactive => Priority 0
+	m2 := irWithLabels("msg-0", map[string]string{
+		"tier":                  "interactive",
+		api.LabelClassification: string(api.ClassificationReserved),
+	})
+
+	// Pushing m1 to bucket 5 succeeds
+	if ok := s.Push(m1, chA); !ok {
+		t.Fatal("expected push to succeed")
+	}
+
+	// Pushing another message to bucket 5 would block because capacity is 1.
+	// But pushing m2 to bucket 0 should succeed immediately because bucket 0 is empty.
+	done := make(chan bool)
+	go func() {
+		if ok := s.Push(m2, chB); !ok {
+			t.Error("expected push of m2 to succeed")
+		}
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Succeeded immediately without blocking!
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("push to empty bucket blocked")
 	}
 }

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -35,9 +35,9 @@ type WorkerConfig struct {
 }
 
 type QueueConfig struct {
-	Impl                string
-	MergePolicy         string
-	BacklogPollInterval time.Duration
+	Impl                  string
+	MergePolicyConfigFile string
+	BacklogPollInterval   time.Duration
 }
 
 type ObservabilityConfig struct {
@@ -86,7 +86,6 @@ func NewOptions() *Options {
 			},
 			Queue: QueueConfig{
 				Impl:                "redis-pubsub",
-				MergePolicy:         "random-robin",
 				BacklogPollInterval: 15 * time.Second,
 			},
 			Observability: ObservabilityConfig{
@@ -116,7 +115,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.Worker.DrainTimeout, "drain-timeout", o.Worker.DrainTimeout, "maximum time to wait for in-flight requests to complete after SIGTERM")
 	fs.StringVar(&o.Worker.PoolConfigFile, "pool-config-file", o.Worker.PoolConfigFile, "Path to the pools configuration JSON file")
 
-	fs.StringVar(&o.Queue.MergePolicy, "request-merge-policy", o.Queue.MergePolicy, "The request merge policy to use. Supported policies: random-robin")
+	fs.StringVar(&o.Queue.MergePolicyConfigFile, "request-merge-policy-config", o.Queue.MergePolicyConfigFile, "Path to the request merge policy configuration JSON file (empty defaults to random-robin)")
 	fs.StringVar(&o.Queue.Impl, "message-queue-impl", o.Queue.Impl, "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
 	fs.DurationVar(&o.Queue.BacklogPollInterval, "metrics-backlog-poll-interval", o.Queue.BacklogPollInterval, "interval to poll the broker for queue backlog metrics (0 disables); only applies to flows that support it (redis-sortedset, gcp-pubsub)")
 
@@ -166,16 +165,12 @@ func (o *Options) Complete() error {
 }
 
 var (
-	validQueueImpls    = []string{"redis-pubsub", "redis-sortedset", "gcp-pubsub", "gcp-pubsub-gated"}
-	validMergePolicies = []string{"random-robin"}
+	validQueueImpls = []string{"redis-pubsub", "redis-sortedset", "gcp-pubsub", "gcp-pubsub-gated"}
 )
 
 func (o *Options) Validate() error {
 	if !contains(validQueueImpls, o.Queue.Impl) {
 		return fmt.Errorf("--message-queue-impl must be one of: %s", strings.Join(validQueueImpls, ", "))
-	}
-	if !contains(validMergePolicies, o.Queue.MergePolicy) {
-		return fmt.Errorf("--request-merge-policy must be one of: %s", strings.Join(validMergePolicies, ", "))
 	}
 	if strings.HasPrefix(o.Queue.Impl, "redis") && o.RedisConnection.URL == "" {
 		return fmt.Errorf("--redis.url (or REDIS_URL env var) is required when using %s", o.Queue.Impl)

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -15,8 +15,8 @@ import (
 	"github.com/llm-d-incubation/llm-d-async/internal/logging"
 	uotel "github.com/llm-d-incubation/llm-d-async/internal/otel"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
-	"github.com/llm-d-incubation/llm-d-async/pkg/async"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/mergepolicy"
 	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker"
 	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
@@ -95,7 +95,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 
 	gateFactory = flowcontrol.NewGateFactoryWithCacheTTL(opts.Prometheus.URL, opts.Prometheus.CacheTTL)
 
-	policy, err := loadRequestMergePolicy(opts.Queue.MergePolicy)
+	policy, err := loadRequestMergePolicy(opts.Queue.MergePolicyConfigFile, ctx)
 	if err != nil {
 		return err
 	}
@@ -230,13 +230,36 @@ func loadWorkerPools(workerConfig WorkerConfig, setupLog logr.Logger) (poolsMap 
 
 }
 
-func loadRequestMergePolicy(name string) (pipeline.RequestMergePolicy, error) {
-	switch name {
-	case "random-robin":
-		return async.NewRandomRobinPolicy(), nil
-	default:
-		return nil, fmt.Errorf("unknown request merge policy: %s", name)
+func loadRequestMergePolicy(configPath string, ctx context.Context) (pipeline.RequestMergePolicy, error) {
+	var spec mergepolicy.MergePolicySpec
+	if configPath != "" {
+		var err error
+		spec, err = mergepolicy.LoadMergePolicyConfig(configPath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		spec = mergepolicy.MergePolicySpec{
+			Type: "random-robin",
+		}
 	}
+
+	factory, ok := plugins.Lookup(spec.Type)
+	if !ok {
+		return nil, fmt.Errorf("unknown request merge policy type: %s", spec.Type)
+	}
+
+	plugin, err := factory("default", spec.Parameters, plugins.NewHandle(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request merge policy %q: %w", spec.Type, err)
+	}
+
+	policy, ok := plugin.(pipeline.RequestMergePolicy)
+	if !ok {
+		return nil, fmt.Errorf("plugin type %q does not implement RequestMergePolicy", spec.Type)
+	}
+
+	return policy, nil
 }
 
 func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[string]pipeline.WorkerPoolConfig) (pipeline.Flow, error) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -332,6 +332,7 @@ func applyManifests() {
 		{"prometheus-query", helmValuesDir + "/prometheus-query.yaml"},
 		{"endpoint-scrape", helmValuesDir + "/endpoint-scrape.yaml"},
 		{"short-drain", helmValuesDir + "/short-drain.yaml"},
+		{"tier-priority", helmValuesDir + "/tier-priority.yaml"},
 	} {
 		helmInstall(r.name, r.values, map[string]string{
 			"ap.image.repository": imageRepo,
@@ -559,6 +560,7 @@ func doRedeployEPPWithFlowControl() {
 		"prometheus-query-async-processor",
 		"endpoint-scrape-async-processor",
 		"short-drain-async-processor",
+		"tier-priority-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "restart", "deployment/"+deploy)
@@ -576,6 +578,7 @@ func doRedeployEPPWithFlowControl() {
 		"prometheus-query-async-processor",
 		"endpoint-scrape-async-processor",
 		"short-drain-async-processor",
+		"tier-priority-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "status", "deployment/"+deploy, "--timeout=120s")

--- a/test/e2e/e2e_tier_priority_test.go
+++ b/test/e2e/e2e_tier_priority_test.go
@@ -1,0 +1,152 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/llm-d-incubation/llm-d-async/api"
+)
+
+var _ = ginkgo.Describe("Tier Priority Admission and Merge Policy E2E", ginkgo.Ordered, func() {
+	var ctx context.Context
+
+	ginkgo.BeforeAll(func() {
+		redeployEPPWithFlowControl()
+	})
+
+	ginkgo.BeforeEach(func() {
+		ctx = context.Background()
+		setSimWaitingRequests(simAdminURL, 0)
+		rdb.Del(ctx, tierPriorityInteractiveQueue) //nolint:errcheck
+		rdb.Del(ctx, tierPriorityAsyncQueue)       //nolint:errcheck
+		rdb.Del(ctx, tierPriorityResultQueue)      //nolint:errcheck
+
+		// Ensure the queues are completely empty before starting the test.
+		gomega.Eventually(func() int64 {
+			return rdb.ZCard(ctx, tierPriorityInteractiveQueue).Val() +
+				rdb.ZCard(ctx, tierPriorityAsyncQueue).Val() +
+				rdb.LLen(ctx, tierPriorityResultQueue).Val()
+		}, 10*time.Second, 1*time.Second).Should(gomega.Equal(int64(0)))
+	})
+
+	ginkgo.It("processes messages from both interactive and async queues when not saturated", func() {
+		setSimWaitingRequests(simAdminURL, 0)
+		waitForSaturation(promURL, envoyURL, func(v float64) bool { return v < 0.5 })
+
+		// Enqueue an interactive overflow request.
+		routingInt := api.InternalRouting{
+			RequestQueueName: tierPriorityInteractiveQueue,
+			Labels: map[string]string{
+				"tier": "interactive",
+			},
+		}
+		routingInt.SetClassification(api.ClassificationOverflow)
+		msgInt := makeRequestMessage("tp-interactive-ok", 5*time.Minute)
+		enqueueMessageWithRouting(ctx, rdb, tierPriorityInteractiveQueue, msgInt, routingInt)
+
+		// Enqueue an async overflow request.
+		routingAsync := api.InternalRouting{
+			RequestQueueName: tierPriorityAsyncQueue,
+			Labels: map[string]string{
+				"tier": "async",
+			},
+		}
+		routingAsync.SetClassification(api.ClassificationOverflow)
+		msgAsync := makeRequestMessage("tp-async-ok", 5*time.Minute)
+		enqueueMessageWithRouting(ctx, rdb, tierPriorityAsyncQueue, msgAsync, routingAsync)
+
+		// Wait for both to be processed successfully.
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, tierPriorityResultQueue)
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 2))
+
+		results := make(map[string]*api.ResultMessage)
+		for i := 0; i < 2; i++ {
+			res := popResult(ctx, rdb, tierPriorityResultQueue)
+			gomega.Expect(res).NotTo(gomega.BeNil())
+			results[res.ID] = res
+		}
+
+		gomega.Expect(results).To(gomega.HaveKey("tp-interactive-ok"))
+		gomega.Expect(results).To(gomega.HaveKey("tp-async-ok"))
+		gomega.Expect(results["tp-interactive-ok"].Payload).NotTo(gomega.ContainSubstring("Too Many Requests"))
+		gomega.Expect(results["tp-async-ok"].Payload).NotTo(gomega.ContainSubstring("Too Many Requests"))
+	})
+
+	ginkgo.It("enforces tier-priority admission rules when saturated", func() {
+		// Drive saturation high.
+		setSimWaitingRequests(simAdminURL, 10)
+		waitForSaturation(promURL, envoyURL, func(v float64) bool { return v >= 0.7 })
+
+		// 1. Enqueue interactive overflow -> should be immediately dropped with 429.
+		routingIntOF := api.InternalRouting{
+			RequestQueueName: tierPriorityInteractiveQueue,
+			Labels: map[string]string{
+				"tier": "interactive",
+			},
+		}
+		routingIntOF.SetClassification(api.ClassificationOverflow)
+		msgIntOF := makeRequestMessage("tp-interactive-of", 5*time.Minute)
+		enqueueMessageWithRouting(ctx, rdb, tierPriorityInteractiveQueue, msgIntOF, routingIntOF)
+
+		// 2. Enqueue async overflow -> should be refused (remains/retried in queue).
+		routingAsyncOF := api.InternalRouting{
+			RequestQueueName: tierPriorityAsyncQueue,
+			Labels: map[string]string{
+				"tier": "async",
+			},
+		}
+		routingAsyncOF.SetClassification(api.ClassificationOverflow)
+		msgAsyncOF := makeRequestMessage("tp-async-of", 5*time.Minute)
+		enqueueMessageWithRouting(ctx, rdb, tierPriorityAsyncQueue, msgAsyncOF, routingAsyncOF)
+
+		// 3. Enqueue interactive reserved -> should wait (remain in queue).
+		routingIntRes := api.InternalRouting{
+			RequestQueueName: tierPriorityInteractiveQueue,
+			Labels: map[string]string{
+				"tier": "interactive",
+			},
+		}
+		routingIntRes.SetClassification(api.ClassificationReserved)
+		msgIntRes := makeRequestMessage("tp-interactive-res", 5*time.Minute)
+		enqueueMessageWithRouting(ctx, rdb, tierPriorityInteractiveQueue, msgIntRes, routingIntRes)
+
+		// Eventually, only the dropped interactive overflow message should generate a result (429).
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, tierPriorityResultQueue)
+		}, 45*time.Second, 1*time.Second).Should(gomega.Equal(int64(1)))
+
+		dropResult := popResult(ctx, rdb, tierPriorityResultQueue)
+		gomega.Expect(dropResult).NotTo(gomega.BeNil())
+		gomega.Expect(dropResult.ID).To(gomega.Equal("tp-interactive-of"))
+		gomega.Expect(dropResult.Payload).To(gomega.ContainSubstring("Too Many Requests"))
+
+		// Ensure no other results are produced while remaining saturated.
+		gomega.Consistently(func() int64 {
+			return getResultCount(ctx, rdb, tierPriorityResultQueue)
+		}, 10*time.Second, 1*time.Second).Should(gomega.Equal(int64(0)))
+
+		// Restore saturation to low.
+		setSimWaitingRequests(simAdminURL, 0)
+		waitForSaturation(promURL, envoyURL, func(v float64) bool { return v < 0.5 })
+
+		// Once saturation clears, the remaining async-overflow and interactive-reserved requests
+		// should be processed successfully.
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, tierPriorityResultQueue)
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 2))
+
+		results := make(map[string]*api.ResultMessage)
+		for i := 0; i < 2; i++ {
+			res := popResult(ctx, rdb, tierPriorityResultQueue)
+			gomega.Expect(res).NotTo(gomega.BeNil())
+			results[res.ID] = res
+		}
+
+		gomega.Expect(results).To(gomega.HaveKey("tp-async-of"))
+		gomega.Expect(results).To(gomega.HaveKey("tp-interactive-res"))
+	})
+})

--- a/test/e2e/helm/tier-priority.yaml
+++ b/test/e2e/helm/tier-priority.yaml
@@ -1,0 +1,37 @@
+ap:
+  imagePullPolicy: Never
+  messageQueueImpl: "redis-sortedset"
+  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
+  prometheusCacheTTL: "0s"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  requestMergePolicyConfig:
+    type: "tier-priority"
+    parameters:
+      priority_header: "x-gateway-priority"
+  workerPools:
+    - id: "default"
+      workers: 1
+      gate_type: "tier-priority-admission"
+      gate_params:
+        saturation_gate: "prometheus-saturation"
+        saturation_gate_params: '{"pool":"e2e-pool","threshold":"0.8"}'
+        tier_label: "tier"
+  redis:
+    enabled: true
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
+    resultQueueName: "tier-priority-result-list"
+    pollIntervalMs: 500
+    batchSize: 10
+    queuesConfig:
+      - queue_name: "tier-priority-interactive"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+      - queue_name: "tier-priority-async"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -34,12 +34,27 @@ const (
 
 	shortDrainRequestQueue = "short-drain-request-sortedset"
 	shortDrainResultQueue  = "short-drain-result-list"
+
+	tierPriorityInteractiveQueue = "tier-priority-interactive"
+	tierPriorityAsyncQueue       = "tier-priority-async"
+	tierPriorityResultQueue      = "tier-priority-result-list"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 func enqueueMessage(ctx context.Context, rdb *redis.Client, queue string, msg api.RequestMessage) {
 	ir := api.NewInternalRequest(api.InternalRouting{}, &msg)
+	data, err := json.Marshal(ir)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	err = rdb.ZAdd(ctx, queue, redis.Z{
+		Score:  float64(msg.Deadline),
+		Member: string(data),
+	}).Err()
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+}
+
+func enqueueMessageWithRouting(ctx context.Context, rdb *redis.Client, queue string, msg api.RequestMessage, routing api.InternalRouting) {
+	ir := api.NewInternalRequest(routing, &msg)
 	data, err := json.Marshal(ir)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	err = rdb.ZAdd(ctx, queue, redis.Z{

--- a/test/integration/merge_policy_test.go
+++ b/test/integration/merge_policy_test.go
@@ -9,7 +9,7 @@ import (
 
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
-	ap "github.com/llm-d-incubation/llm-d-async/pkg/async"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/mergepolicy/randomrobin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,7 +39,7 @@ func TestRandomRobinPolicy_ConcurrentProducers(t *testing.T) {
 		},
 	}
 
-	policy := ap.NewRandomRobinPolicy()
+	policy := randomrobin.NewRandomRobinPolicy("test")
 	dispatch := policy.MergeRequestChannels(channels, pools)
 	mergedChan := dispatch.Channels["test-pool"]
 

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	ap "github.com/llm-d-incubation/llm-d-async/pkg/async"
+	randomrobin "github.com/llm-d-incubation/llm-d-async/pkg/async/mergepolicy/randomrobin"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/llm-d-incubation/llm-d-async/api"
@@ -77,7 +77,7 @@ func TestRedisImpl(t *testing.T) {
 			Workers: 1,
 		},
 	}
-	dispatch := ap.NewRandomRobinPolicy().MergeRequestChannels(flow.RequestChannels(), pools)
+	dispatch := randomrobin.NewRandomRobinPolicy("test").MergeRequestChannels(flow.RequestChannels(), pools)
 	mergedChannel := dispatch.Channels["default"]
 
 	select {

--- a/test/integration/tier_priority_integration_test.go
+++ b/test/integration/tier_priority_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
+	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTierPriorityGate_Integration(t *testing.T) {
+	serverHitCount := 0
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		serverHitCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"success"}`))
+	}))
+	defer server.Close()
+
+	client := asyncworker.NewHTTPInferenceClient(server.Client())
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 5)
+	retryChannel := make(chan pipeline.RetryMessage, 5)
+	resultChannel := make(chan asyncapi.ResultMessage, 5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var isSaturated bool
+	var satMu sync.Mutex
+	satGate := flowcontrol.DispatchGateFunc(func(ctx context.Context) float64 {
+		satMu.Lock()
+		defer satMu.Unlock()
+		if isSaturated {
+			return 0.0
+		}
+		return 1.0
+	})
+
+	gate := flowcontrol.NewTierPriorityAdmissionGate(satGate, "tier")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		asyncworker.WorkerWithGate(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false},
+			client, requestChannel, retryChannel, resultChannel, 5*time.Minute, nil, gate)
+	}()
+
+	t.Run("Saturated - Interactive - Overflow => Drop with 429", func(t *testing.T) {
+		satMu.Lock()
+		isSaturated = true
+		satMu.Unlock()
+
+		ir := asyncapi.NewInternalRequest(
+			asyncapi.InternalRouting{
+				RequestQueueName: "test-queue",
+				Labels: map[string]string{
+					"tier": "interactive",
+				},
+			},
+			&asyncapi.RequestMessage{
+				ID:       "req-drop",
+				Created:  time.Now().Unix(),
+				Deadline: time.Now().Add(5 * time.Minute).Unix(),
+				Payload:  map[string]any{"model": "test"},
+			},
+		)
+		ir.SetClassification(asyncapi.ClassificationOverflow)
+
+		requestChannel <- pipeline.EmbelishedRequestMessage{
+			InternalRequest: ir,
+			RequestURL:      server.URL + "/v1/completions",
+		}
+
+		select {
+		case res := <-resultChannel:
+			assert.Equal(t, "req-drop", res.ID)
+			assert.Contains(t, res.Payload, `"code": 429`)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for drop result")
+		}
+	})
+
+	t.Run("Saturated - Async - Overflow => Refuse (Retry)", func(t *testing.T) {
+		satMu.Lock()
+		isSaturated = true
+		satMu.Unlock()
+
+		ir := asyncapi.NewInternalRequest(
+			asyncapi.InternalRouting{
+				RequestQueueName: "test-queue",
+				Labels: map[string]string{
+					"tier": "async",
+				},
+			},
+			&asyncapi.RequestMessage{
+				ID:       "req-refuse",
+				Created:  time.Now().Unix(),
+				Deadline: time.Now().Add(5 * time.Minute).Unix(),
+				Payload:  map[string]any{"model": "test"},
+			},
+		)
+		ir.SetClassification(asyncapi.ClassificationOverflow)
+
+		requestChannel <- pipeline.EmbelishedRequestMessage{
+			InternalRequest: ir,
+			RequestURL:      server.URL + "/v1/completions",
+		}
+
+		select {
+		case retryMsg := <-retryChannel:
+			assert.Equal(t, "req-refuse", retryMsg.PublicRequest.ReqID())
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for retry message")
+		}
+	})
+
+	t.Run("Saturated - Batch - Overflow => Refuse (Retry)", func(t *testing.T) {
+		satMu.Lock()
+		isSaturated = true
+		satMu.Unlock()
+
+		ir := asyncapi.NewInternalRequest(
+			asyncapi.InternalRouting{
+				RequestQueueName: "test-queue",
+				Labels: map[string]string{
+					"tier": "batch",
+				},
+			},
+			&asyncapi.RequestMessage{
+				ID:       "req-refuse-batch",
+				Created:  time.Now().Unix(),
+				Deadline: time.Now().Add(5 * time.Minute).Unix(),
+				Payload:  map[string]any{"model": "test"},
+			},
+		)
+		ir.SetClassification(asyncapi.ClassificationOverflow)
+
+		requestChannel <- pipeline.EmbelishedRequestMessage{
+			InternalRequest: ir,
+			RequestURL:      server.URL + "/v1/completions",
+		}
+
+		select {
+		case retryMsg := <-retryChannel:
+			assert.Equal(t, "req-refuse-batch", retryMsg.PublicRequest.ReqID())
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for retry message")
+		}
+	})
+
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
## What does this PR do?

1. add tier-priority merge policy that merges requests in priority lanes by (tier, classification).
2. add tier-priority admission gate that (continues, waits, drops with 429, refuse/redeliver to MQ) a message based on tier, classification, and saturation.
3. refactor merge policies use JSON configurations and register as plugins.

## Why is this change needed?

Fixes: https://github.com/llm-d-incubation/llm-d-async/issues/216
Fixes: https://github.com/llm-d-incubation/llm-d-async/issues/209

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
