### PR TITLE
refactor: extract shared gate config

### DIFF
--- a/pipeline/gate.go
+++ b/pipeline/gate.go
@@ -95,9 +95,15 @@ func ApplyChain(ctx context.Context, msg *api.InternalRequest, gates []Gate, rel
 	return Continue(), nil
 }
 
+// GateConfig holds the configuration for a single gate instance.
+type GateConfig struct {
+	GateType   string         `json:"gate_type,omitempty"`
+	GateParams map[string]any `json:"gate_params,omitempty"`
+}
+
 // GateFactory defines the interface for creating Gate instances.
 type GateFactory interface {
-	CreateGate(gateType string, params map[string]string) (Gate, error)
+	CreateGate(cfg GateConfig) (Gate, error)
 }
 
 var _ Gate = DispatchGateFunc(nil)

--- a/pipeline/worker_pool.go
+++ b/pipeline/worker_pool.go
@@ -4,44 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 )
-
-// StringMap is a map[string]string that tolerates non-string JSON values
-// by converting them to their string representation during unmarshaling.
-type StringMap map[string]string
-
-func (m *StringMap) UnmarshalJSON(data []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	result := make(map[string]string, len(raw))
-	for k, v := range raw {
-		switch val := v.(type) {
-		case string:
-			result[k] = val
-		case float64:
-			result[k] = strconv.FormatFloat(val, 'f', -1, 64)
-		case bool:
-			result[k] = strconv.FormatBool(val)
-		case nil:
-			result[k] = ""
-		default:
-			return fmt.Errorf("gate_params key %q: unsupported value type %T (only strings, numbers, and booleans are allowed)", k, v)
-		}
-	}
-	*m = result
-	return nil
-}
 
 // WorkerPoolConfig defines the configuration for a worker pool,
 // specifying the concurrency limit (number of workers) and its ID.
 type WorkerPoolConfig struct {
-	ID         string    `json:"id"`
-	Workers    int       `json:"workers"`
-	GateType   string    `json:"gate_type,omitempty"`
-	GateParams StringMap `json:"gate_params,omitempty"`
+	ID         string         `json:"id"`
+	Workers    int            `json:"workers"`
+	GateType   string         `json:"gate_type,omitempty"`
+	GateParams map[string]any `json:"gate_params,omitempty"`
 }
 
 // LoadWorkerPools loads and validates worker pool configurations from a JSON file.

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -349,20 +349,26 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 	}
 }
 
-// paramString extracts a string value from params, returning defaultVal if the key is absent or empty.
+// paramString extracts a string value from params, returning defaultVal if the key is absent or nil.
+// Scalar types (string, float64, bool) are accepted; non-scalar types return defaultVal.
 func paramString(params map[string]any, key, defaultVal string) string {
 	v, ok := params[key]
 	if !ok || v == nil {
 		return defaultVal
 	}
-	s, ok := v.(string)
-	if !ok {
-		return fmt.Sprintf("%v", v)
-	}
-	if s == "" {
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return defaultVal
+		}
+		return val
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(val)
+	default:
 		return defaultVal
 	}
-	return s
 }
 
 // paramFloat extracts a float64 value from params. Accepts float64, int, or string representations.

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -31,11 +31,6 @@ import (
 // DefaultCacheTTL is the default TTL for cached Prometheus metric sources.
 const DefaultCacheTTL = 5 * time.Second
 
-type gateConfig struct {
-	GateType   string            `json:"gate_type"`
-	GateParams map[string]string `json:"gate_params"`
-}
-
 var _ pipeline.GateFactory = (*GateFactory)(nil)
 
 // GateFactory creates DispatchGate instances based on configuration.
@@ -99,24 +94,24 @@ func (f *GateFactory) Close() error {
 //     Params: query (required), fallback (default 0.0)
 //
 // For unsupported or unknown gate types, returns ConstOpenGate as a safe default.
-func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pipeline.Gate, error) {
-	switch gateType {
-	case "composite":
-		gatesJSON := params["gates"]
-		if gatesJSON == "" {
-			return nil, fmt.Errorf("composite gate requires 'gates' parameter with JSON array of gate configurations")
-		}
+func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error) {
+	params := cfg.GateParams
+	if params == nil {
+		params = map[string]any{}
+	}
 
-		var configs []gateConfig
-		if err := json.Unmarshal([]byte(gatesJSON), &configs); err != nil {
-			return nil, fmt.Errorf("composite gate failed to parse 'gates' parameter: %w", err)
+	switch cfg.GateType {
+	case "composite":
+		configs, err := paramGateConfigs(params, "gates")
+		if err != nil {
+			return nil, err
 		}
 
 		var innerGates []pipeline.Gate
-		for _, cfg := range configs {
-			gate, err := f.CreateGate(cfg.GateType, cfg.GateParams)
+		for _, innerCfg := range configs {
+			gate, err := f.CreateGate(innerCfg)
 			if err != nil {
-				return nil, fmt.Errorf("composite gate failed to create inner gate %q: %w", cfg.GateType, err)
+				return nil, fmt.Errorf("composite gate failed to create inner gate %q: %w", innerCfg.GateType, err)
 			}
 			innerGates = append(innerGates, gate)
 		}
@@ -124,19 +119,14 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 		return NewCompositeGate(innerGates...), nil
 
 	case "wait-on-refuse":
-		gateJSON := params["gate"]
-		if gateJSON == "" {
-			return nil, fmt.Errorf("wait-on-refuse gate requires a 'gate' parameter with the inner gate configuration")
-		}
-
-		var cfg gateConfig
-		if err := json.Unmarshal([]byte(gateJSON), &cfg); err != nil {
-			return nil, fmt.Errorf("wait-on-refuse gate failed to parse 'gate' parameter: %w", err)
-		}
-
-		innerGate, err := f.CreateGate(cfg.GateType, cfg.GateParams)
+		innerCfg, err := paramGateConfig(params, "gate")
 		if err != nil {
-			return nil, fmt.Errorf("wait-on-refuse gate failed to create inner gate %q: %w", cfg.GateType, err)
+			return nil, err
+		}
+
+		innerGate, err := f.CreateGate(innerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("wait-on-refuse gate failed to create inner gate %q: %w", innerCfg.GateType, err)
 		}
 
 		return NewWaitOnRefuseGate(innerGate), nil
@@ -145,7 +135,7 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 		return ConstOpenGate(), nil
 
 	case "redis":
-		addr := params["address"]
+		addr := paramString(params, "address", "")
 		if addr == "" {
 			return nil, fmt.Errorf("redis gate requires an 'address' in gate_params")
 		}
@@ -154,14 +144,11 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			client = goredis.NewClient(&goredis.Options{Addr: addr})
 			f.redisClients[addr] = client
 		}
-		budgetKey := params["budget_key"]
-		if budgetKey == "" {
-			budgetKey = "dispatch-gate-budget"
-		}
+		budgetKey := paramString(params, "budget_key", "dispatch-gate-budget")
 		return redisgate.NewRedisDispatchGate(client, budgetKey), nil
 
 	case "redis-quota":
-		addr := params["address"]
+		addr := paramString(params, "address", "")
 		if addr == "" {
 			return nil, fmt.Errorf("redis-quota gate requires an 'address' in gate_params")
 		}
@@ -171,37 +158,27 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			f.redisClients[addr] = client
 		}
 
-		attr := params["attribute"]
-		if attr == "" {
-			attr = "userid"
-		}
+		attr := paramString(params, "attribute", "userid")
 
-		mode := redisgate.QuotaMode(params["mode"])
-		if mode == "" {
-			mode = redisgate.QuotaModeRateLimit
-		}
+		mode := redisgate.QuotaMode(paramString(params, "mode", string(redisgate.QuotaModeRateLimit)))
 
-		limit, err := strconv.Atoi(params["limit"])
+		limit, err := paramInt(params, "limit", 0)
 		if err != nil {
 			return nil, fmt.Errorf("redis-quota gate requires a valid 'limit': %w", err)
 		}
-
-		windowStr := params["window"]
-		if windowStr == "" {
-			windowStr = "1m"
+		if limit == 0 {
+			return nil, fmt.Errorf("redis-quota gate requires a valid 'limit': %w", fmt.Errorf("limit not provided or zero"))
 		}
-		window, err := time.ParseDuration(windowStr)
+
+		window, err := paramDuration(params, "window", 1*time.Minute)
 		if err != nil {
 			return nil, fmt.Errorf("redis-quota gate requires a valid 'window' duration: %w", err)
 		}
 
-		prefix := params["prefix"]
-		if prefix == "" {
-			prefix = "quota:"
-		}
+		prefix := paramString(params, "prefix", "quota:")
 
 		gate := redisgate.NewRedisQuotaGate(client, attr, mode, limit, window, prefix)
-		gatingMode := redisgate.GatingMode(params["gating_mode"])
+		gatingMode := redisgate.GatingMode(paramString(params, "gating_mode", ""))
 		if gatingMode != "" {
 			gate.WithGatingMode(gatingMode)
 		}
@@ -213,11 +190,11 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			return nil, fmt.Errorf("prometheus-saturation gate type requires --prometheus-url flag to be set")
 		}
 
-		threshold, err := parseFloat("threshold", params["threshold"], 0.8)
+		threshold, err := paramFloat(params, "threshold", 0.8)
 		if err != nil {
 			return nil, err
 		}
-		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
+		fallback, err := paramFloat(params, "fallback", 0.0)
 		if err != nil {
 			return nil, err
 		}
@@ -238,31 +215,31 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			return nil, fmt.Errorf("prometheus-budget gate type requires --prometheus-url flag to be set")
 		}
 
-		pool := params["pool"]
+		pool := paramString(params, "pool", "")
 		if pool == "" {
 			return nil, fmt.Errorf("inference pool name is required for prometheus-budget gate")
 		}
-		maxConcurrency, err := parseFloat("max_concurrency", params["max_concurrency"], 100.0)
+		maxConcurrency, err := paramFloat(params, "max_concurrency", 100.0)
 		if err != nil {
 			return nil, err
 		}
 		if maxConcurrency <= 0 {
 			return nil, fmt.Errorf("max_concurrency must be positive, got %g", maxConcurrency)
 		}
-		baseline, err := parseFloat("baseline", params["baseline"], 0.05)
+		baseline, err := paramFloat(params, "baseline", 0.05)
 		if err != nil {
 			return nil, err
 		}
 		if baseline < 0 || baseline >= 1 {
 			return nil, fmt.Errorf("baseline must be in [0, 1), got %g", baseline)
 		}
-		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
+		fallback, err := paramFloat(params, "fallback", 0.0)
 		if err != nil {
 			return nil, err
 		}
 
 		promConfig := promapi.Config{Address: f.prometheusURL}
-		namespace := params["namespace"]
+		namespace := paramString(params, "namespace", "")
 
 		primary, err := NewFlowControlQueueSizePromQL(promConfig, pool, maxConcurrency, namespace)
 		if err != nil {
@@ -284,12 +261,12 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			return nil, fmt.Errorf("prometheus-query gate type requires --prometheus-url flag to be set")
 		}
 
-		query := params["query"]
+		query := paramString(params, "query", "")
 		if query == "" {
 			return nil, fmt.Errorf("prometheus-query gate requires a 'query' parameter with a PromQL expression")
 		}
 
-		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
+		fallback, err := paramFloat(params, "fallback", 0.0)
 		if err != nil {
 			return nil, err
 		}
@@ -302,62 +279,54 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 		return NewMetricDispatchGate(cachedSource(source, f.cacheTTL), 0.0, fallback), nil
 
 	case "endpoint-scrape":
-		url := params["url"]
+		url := paramString(params, "url", "")
 		if url == "" {
 			return nil, fmt.Errorf("endpoint-scrape gate requires a 'url' parameter")
 		}
-		metric := params["metric"]
+		metric := paramString(params, "metric", "")
 		if metric == "" {
 			return nil, fmt.Errorf("endpoint-scrape gate requires a 'metric' parameter")
 		}
 
-		var labels map[string]string
-		if labelsJSON := params["labels"]; labelsJSON != "" {
-			if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
-				return nil, fmt.Errorf("endpoint-scrape gate failed to parse 'labels': %w", err)
-			}
+		labels, err := paramStringMap(params, "labels")
+		if err != nil {
+			return nil, fmt.Errorf("endpoint-scrape gate failed to parse 'labels': %w", err)
 		}
 
-		maxCountPerPod, err := parseFloat("max_count_per_pod", params["max_count_per_pod"], 0)
+		maxCountPerPod, err := paramFloat(params, "max_count_per_pod", 0)
 		if err != nil {
 			return nil, err
 		}
-		baseline, err := parseFloat("baseline", params["baseline"], 0.0)
+		baseline, err := paramFloat(params, "baseline", 0.0)
 		if err != nil {
 			return nil, err
 		}
-		fallback, err := parseFloat("fallback", params["fallback"], 0.0)
+		fallback, err := paramFloat(params, "fallback", 0.0)
 		if err != nil {
 			return nil, err
 		}
 
-		var podsLabels map[string]string
-		if podsLabelsJSON := params["pods_labels"]; podsLabelsJSON != "" {
-			if err := json.Unmarshal([]byte(podsLabelsJSON), &podsLabels); err != nil {
-				return nil, fmt.Errorf("endpoint-scrape gate failed to parse 'pods_labels': %w", err)
-			}
+		podsLabels, err := paramStringMap(params, "pods_labels")
+		if err != nil {
+			return nil, fmt.Errorf("endpoint-scrape gate failed to parse 'pods_labels': %w", err)
 		}
 
-		cfg := ScrapeConfig{
+		scrapeCfg := ScrapeConfig{
 			URL:            url,
 			MetricName:     metric,
 			Labels:         labels,
 			MaxCountPerPod: maxCountPerPod,
-			PodsURL:        params["pods_url"],
-			PodsMetric:     params["pods_metric"],
+			PodsURL:        paramString(params, "pods_url", ""),
+			PodsMetric:     paramString(params, "pods_metric", ""),
 			PodsLabels:     podsLabels,
 		}
 
-		var ms MetricSource = NewScrapeMetricSource(cfg)
+		var ms MetricSource = NewScrapeMetricSource(scrapeCfg)
 		ms = cachedSource(ms, f.cacheTTL)
 		return NewMetricDispatchGate(ms, baseline, fallback), nil
 
 	case "local-max-concurrency":
-		limitStr := params["limit"]
-		if limitStr == "" {
-			return nil, fmt.Errorf("local-max-concurrency gate requires a 'limit' parameter")
-		}
-		limit, err := strconv.Atoi(limitStr)
+		limit, err := paramInt(params, "limit", 0)
 		if err != nil {
 			return nil, fmt.Errorf("local-max-concurrency gate requires a valid integer 'limit': %w", err)
 		}
@@ -365,7 +334,7 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 			return nil, fmt.Errorf("local-max-concurrency limit must be greater than 0, got %d", limit)
 		}
 		gate := NewLocalConcurrencyGate(limit)
-		gatingMode := params["gating_mode"]
+		gatingMode := paramString(params, "gating_mode", "")
 		if gatingMode != "" {
 			if gatingMode != string(GatingModeBlocking) && gatingMode != string(GatingModeClassifying) {
 				return nil, fmt.Errorf("local-max-concurrency gating_mode must be either 'blocking' or 'classifying', got %q", gatingMode)
@@ -380,15 +349,188 @@ func (f *GateFactory) CreateGate(gateType string, params map[string]string) (pip
 	}
 }
 
-func parseFloat(name, str string, defaultValue float64) (float64, error) {
-	if str == "" {
-		return defaultValue, nil
+// paramString extracts a string value from params, returning defaultVal if the key is absent or empty.
+func paramString(params map[string]any, key, defaultVal string) string {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return defaultVal
 	}
-	v, err := strconv.ParseFloat(str, 64)
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Sprintf("%v", v)
+	}
+	if s == "" {
+		return defaultVal
+	}
+	return s
+}
+
+// paramFloat extracts a float64 value from params. Accepts float64, int, or string representations.
+func paramFloat(params map[string]any, key string, defaultVal float64) (float64, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return defaultVal, nil
+	}
+	switch val := v.(type) {
+	case float64:
+		return val, nil
+	case int:
+		return float64(val), nil
+	case string:
+		if val == "" {
+			return defaultVal, nil
+		}
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s value '%s': %w", key, val, err)
+		}
+		return f, nil
+	default:
+		return 0, fmt.Errorf("invalid %s value: unsupported type %T", key, v)
+	}
+}
+
+// paramInt extracts an int value from params. Accepts float64, int, or string representations.
+func paramInt(params map[string]any, key string, defaultVal int) (int, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return defaultVal, nil
+	}
+	switch val := v.(type) {
+	case float64:
+		return int(val), nil
+	case int:
+		return val, nil
+	case string:
+		if val == "" {
+			return defaultVal, nil
+		}
+		i, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s value '%s': %w", key, val, err)
+		}
+		return i, nil
+	default:
+		return 0, fmt.Errorf("invalid %s value: unsupported type %T", key, v)
+	}
+}
+
+// paramDuration extracts a time.Duration from params. Accepts a string parseable by time.ParseDuration.
+func paramDuration(params map[string]any, key string, defaultVal time.Duration) (time.Duration, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return defaultVal, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		s = fmt.Sprintf("%v", v)
+	}
+	if s == "" {
+		return defaultVal, nil
+	}
+	d, err := time.ParseDuration(s)
 	if err != nil {
-		return 0, fmt.Errorf("invalid %s value '%s': %w", name, str, err)
+		return 0, fmt.Errorf("invalid %s value '%s': %w", key, s, err)
 	}
-	return v, nil
+	return d, nil
+}
+
+// paramStringMap extracts a map[string]string from params. Handles both
+// a JSON-encoded string value and a map[string]any value (from structured config).
+func paramStringMap(params map[string]any, key string) (map[string]string, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return nil, nil
+		}
+		var m map[string]string
+		if err := json.Unmarshal([]byte(val), &m); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", key, err)
+		}
+		return m, nil
+	case map[string]any:
+		m := make(map[string]string, len(val))
+		for k, v := range val {
+			m[k] = fmt.Sprintf("%v", v)
+		}
+		return m, nil
+	case map[string]string:
+		return val, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T for key %q", v, key)
+	}
+}
+
+// paramGateConfigs extracts a []pipeline.GateConfig from params for the composite gate.
+// Handles both a JSON-encoded string and a pre-parsed []any (from structured config).
+func paramGateConfigs(params map[string]any, key string) ([]pipeline.GateConfig, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return nil, fmt.Errorf("composite gate requires 'gates' parameter with JSON array of gate configurations")
+	}
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return nil, fmt.Errorf("composite gate requires 'gates' parameter with JSON array of gate configurations")
+		}
+		var configs []pipeline.GateConfig
+		if err := json.Unmarshal([]byte(val), &configs); err != nil {
+			return nil, fmt.Errorf("composite gate failed to parse 'gates' parameter: %w", err)
+		}
+		return configs, nil
+	case []any:
+		data, err := json.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("composite gate failed to marshal 'gates' parameter: %w", err)
+		}
+		var configs []pipeline.GateConfig
+		if err := json.Unmarshal(data, &configs); err != nil {
+			return nil, fmt.Errorf("composite gate failed to parse 'gates' parameter: %w", err)
+		}
+		return configs, nil
+	case []pipeline.GateConfig:
+		return val, nil
+	default:
+		return nil, fmt.Errorf("composite gate: unsupported type %T for 'gates' parameter", v)
+	}
+}
+
+// paramGateConfig extracts a single pipeline.GateConfig from params for the wait-on-refuse gate.
+// Handles both a JSON-encoded string and a pre-parsed map[string]any (from structured config).
+func paramGateConfig(params map[string]any, key string) (pipeline.GateConfig, error) {
+	v, ok := params[key]
+	if !ok || v == nil {
+		return pipeline.GateConfig{}, fmt.Errorf("wait-on-refuse gate requires a 'gate' parameter with the inner gate configuration")
+	}
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return pipeline.GateConfig{}, fmt.Errorf("wait-on-refuse gate requires a 'gate' parameter with the inner gate configuration")
+		}
+		var cfg pipeline.GateConfig
+		if err := json.Unmarshal([]byte(val), &cfg); err != nil {
+			return pipeline.GateConfig{}, fmt.Errorf("wait-on-refuse gate failed to parse 'gate' parameter: %w", err)
+		}
+		return cfg, nil
+	case map[string]any:
+		data, err := json.Marshal(val)
+		if err != nil {
+			return pipeline.GateConfig{}, fmt.Errorf("wait-on-refuse gate failed to marshal 'gate' parameter: %w", err)
+		}
+		var cfg pipeline.GateConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return pipeline.GateConfig{}, fmt.Errorf("wait-on-refuse gate failed to parse 'gate' parameter: %w", err)
+		}
+		return cfg, nil
+	case pipeline.GateConfig:
+		return val, nil
+	default:
+		return pipeline.GateConfig{}, fmt.Errorf("wait-on-refuse gate: unsupported type %T for 'gate' parameter", v)
+	}
 }
 
 func cachedSource(s MetricSource, ttl time.Duration) MetricSource {

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -166,8 +166,8 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 		if err != nil {
 			return nil, fmt.Errorf("redis-quota gate requires a valid 'limit': %w", err)
 		}
-		if limit == 0 {
-			return nil, fmt.Errorf("redis-quota gate requires a valid 'limit': %w", fmt.Errorf("limit not provided or zero"))
+		if limit <= 0 {
+			return nil, fmt.Errorf("redis-quota gate requires a positive 'limit', got %d", limit)
 		}
 
 		window, err := paramDuration(params, "window", 1*time.Minute)
@@ -398,6 +398,9 @@ func paramInt(params map[string]any, key string, defaultVal int) (int, error) {
 	}
 	switch val := v.(type) {
 	case float64:
+		if val != float64(int(val)) {
+			return 0, fmt.Errorf("invalid %s value: %g is not an integer", key, val)
+		}
 		return int(val), nil
 	case int:
 		return val, nil

--- a/pkg/async/inference/flowcontrol/gate_factory_composite_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_composite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,9 +32,9 @@ func TestGateFactory_CreateCompositeGate(t *testing.T) {
 			{"gate_type": "constant", "gate_params": {}},
 			{"gate_type": "constant", "gate_params": {}}
 		]`
-		gate, err := factory.CreateGate("composite", map[string]string{
+		gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "composite", GateParams: map[string]any{
 			"gates": gatesJSON,
-		})
+		}})
 
 		assert.NoError(t, err)
 		assert.NotNil(t, gate)
@@ -43,7 +44,7 @@ func TestGateFactory_CreateCompositeGate(t *testing.T) {
 	})
 
 	t.Run("Missing gates parameter", func(t *testing.T) {
-		gate, err := factory.CreateGate("composite", map[string]string{})
+		gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "composite", GateParams: map[string]any{}})
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "requires 'gates' parameter")
@@ -51,9 +52,9 @@ func TestGateFactory_CreateCompositeGate(t *testing.T) {
 	})
 
 	t.Run("Invalid JSON", func(t *testing.T) {
-		gate, err := factory.CreateGate("composite", map[string]string{
+		gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "composite", GateParams: map[string]any{
 			"gates": `[invalid json`,
-		})
+		}})
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse 'gates' parameter")
@@ -65,9 +66,9 @@ func TestGateFactory_CreateCompositeGate(t *testing.T) {
 			{"gate_type": "prometheus-saturation", "gate_params": {}}
 		]`
 		// Missing 'pool' will cause prometheus-saturation to fail
-		gate, err := factory.CreateGate("composite", map[string]string{
+		gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "composite", GateParams: map[string]any{
 			"gates": gatesJSON,
-		})
+		}})
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create inner gate \"prometheus-saturation\"")

--- a/pkg/async/inference/flowcontrol/gate_factory_params_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_params_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParamString(t *testing.T) {
+	params := map[string]any{
+		"str":   "hello",
+		"num":   42.5,
+		"bool":  true,
+		"nil":   nil,
+		"slice": []any{"a"},
+	}
+	assert.Equal(t, "hello", paramString(params, "str", ""))
+	assert.Equal(t, "42.5", paramString(params, "num", ""))
+	assert.Equal(t, "true", paramString(params, "bool", ""))
+	assert.Equal(t, "default", paramString(params, "nil", "default"))
+	assert.Equal(t, "default", paramString(params, "missing", "default"))
+	assert.Equal(t, "default", paramString(params, "slice", "default"))
+}
+
+func TestParamFloat(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]any
+		key     string
+		def     float64
+		want    float64
+		wantErr string
+	}{
+		{"native float", map[string]any{"v": 0.7}, "v", 0, 0.7, ""},
+		{"string float", map[string]any{"v": "0.7"}, "v", 0, 0.7, ""},
+		{"int as float", map[string]any{"v": 5}, "v", 0, 5.0, ""},
+		{"missing key", map[string]any{}, "v", 1.0, 1.0, ""},
+		{"nil value", map[string]any{"v": nil}, "v", 1.0, 1.0, ""},
+		{"empty string", map[string]any{"v": ""}, "v", 1.0, 1.0, ""},
+		{"invalid string", map[string]any{"v": "abc"}, "v", 0, 0, "invalid v value"},
+		{"unsupported type", map[string]any{"v": true}, "v", 0, 0, "unsupported type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := paramFloat(tt.params, tt.key, tt.def)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.InDelta(t, tt.want, got, 0.001)
+			}
+		})
+	}
+}
+
+func TestParamInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]any
+		key     string
+		def     int
+		want    int
+		wantErr string
+	}{
+		{"native int", map[string]any{"v": 5}, "v", 0, 5, ""},
+		{"float64 integer", map[string]any{"v": 10.0}, "v", 0, 10, ""},
+		{"string int", map[string]any{"v": "42"}, "v", 0, 42, ""},
+		{"missing key", map[string]any{}, "v", 7, 7, ""},
+		{"nil value", map[string]any{"v": nil}, "v", 7, 7, ""},
+		{"empty string", map[string]any{"v": ""}, "v", 7, 7, ""},
+		{"non-integer float", map[string]any{"v": 2.9}, "v", 0, 0, "is not an integer"},
+		{"invalid string", map[string]any{"v": "abc"}, "v", 0, 0, "invalid v value"},
+		{"unsupported type", map[string]any{"v": true}, "v", 0, 0, "unsupported type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := paramInt(tt.params, tt.key, tt.def)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParamDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]any
+		key     string
+		def     time.Duration
+		want    time.Duration
+		wantErr string
+	}{
+		{"string duration", map[string]any{"v": "5s"}, "v", 0, 5 * time.Second, ""},
+		{"missing key", map[string]any{}, "v", time.Minute, time.Minute, ""},
+		{"nil value", map[string]any{"v": nil}, "v", time.Minute, time.Minute, ""},
+		{"invalid string", map[string]any{"v": "xyz"}, "v", 0, 0, "invalid v value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := paramDuration(tt.params, tt.key, tt.def)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParamStringMap(t *testing.T) {
+	t.Run("json string", func(t *testing.T) {
+		params := map[string]any{"labels": `{"k":"v"}`}
+		m, err := paramStringMap(params, "labels")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"k": "v"}, m)
+	})
+
+	t.Run("structured map", func(t *testing.T) {
+		params := map[string]any{"labels": map[string]any{"k": "v", "n": 42.0}}
+		m, err := paramStringMap(params, "labels")
+		require.NoError(t, err)
+		assert.Equal(t, "v", m["k"])
+		assert.Equal(t, "42", m["n"])
+	})
+
+	t.Run("map[string]string passthrough", func(t *testing.T) {
+		params := map[string]any{"labels": map[string]string{"k": "v"}}
+		m, err := paramStringMap(params, "labels")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"k": "v"}, m)
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		m, err := paramStringMap(map[string]any{}, "labels")
+		require.NoError(t, err)
+		assert.Nil(t, m)
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		params := map[string]any{"labels": 42}
+		_, err := paramStringMap(params, "labels")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported type")
+	})
+}
+
+func TestParamGateConfigs_Structured(t *testing.T) {
+	params := map[string]any{
+		"gates": []any{
+			map[string]any{
+				"gate_type":   "constant",
+				"gate_params": map[string]any{},
+			},
+			map[string]any{
+				"gate_type":   "redis",
+				"gate_params": map[string]any{"address": "localhost:6379"},
+			},
+		},
+	}
+	configs, err := paramGateConfigs(params, "gates")
+	require.NoError(t, err)
+	require.Len(t, configs, 2)
+	assert.Equal(t, "constant", configs[0].GateType)
+	assert.Equal(t, "redis", configs[1].GateType)
+}
+
+func TestParamGateConfigs_TypedSlice(t *testing.T) {
+	params := map[string]any{
+		"gates": []pipeline.GateConfig{
+			{GateType: "constant"},
+		},
+	}
+	configs, err := paramGateConfigs(params, "gates")
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "constant", configs[0].GateType)
+}
+
+func TestParamGateConfigs_UnsupportedType(t *testing.T) {
+	params := map[string]any{"gates": 42}
+	_, err := paramGateConfigs(params, "gates")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type")
+}
+
+func TestParamGateConfig_Structured(t *testing.T) {
+	params := map[string]any{
+		"gate": map[string]any{
+			"gate_type":   "constant",
+			"gate_params": map[string]any{},
+		},
+	}
+	cfg, err := paramGateConfig(params, "gate")
+	require.NoError(t, err)
+	assert.Equal(t, "constant", cfg.GateType)
+}
+
+func TestParamGateConfig_TypedStruct(t *testing.T) {
+	params := map[string]any{
+		"gate": pipeline.GateConfig{GateType: "redis", GateParams: map[string]any{"address": "localhost:6379"}},
+	}
+	cfg, err := paramGateConfig(params, "gate")
+	require.NoError(t, err)
+	assert.Equal(t, "redis", cfg.GateType)
+}
+
+func TestParamGateConfig_UnsupportedType(t *testing.T) {
+	params := map[string]any{"gate": 42}
+	_, err := paramGateConfig(params, "gate")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type")
+}

--- a/pkg/async/inference/flowcontrol/gate_factory_test.go
+++ b/pkg/async/inference/flowcontrol/gate_factory_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +34,7 @@ func TestGateFactory_WithCacheTTL(t *testing.T) {
 
 func TestGateFactory_CreateConstantGate(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("constant", nil)
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "constant"})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
@@ -43,7 +44,7 @@ func TestGateFactory_CreateConstantGate(t *testing.T) {
 
 func TestGateFactory_UnknownGateType(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("unknown-type", nil)
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "unknown-type"})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
@@ -54,7 +55,7 @@ func TestGateFactory_UnknownGateType(t *testing.T) {
 
 func TestGateFactory_EmptyGateType(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("", nil)
+	gate, err := factory.CreateGate(pipeline.GateConfig{})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
@@ -64,7 +65,7 @@ func TestGateFactory_EmptyGateType(t *testing.T) {
 
 func TestGateFactory_PrometheusGateWithoutURL(t *testing.T) {
 	factory := NewGateFactory("") // No Prometheus URL
-	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{})
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{}})
 	assert.Error(t, err, "should return error when Prometheus URL is not set")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "prometheus-saturation gate type requires --prometheus-url flag to be set")
@@ -72,7 +73,7 @@ func TestGateFactory_PrometheusGateWithoutURL(t *testing.T) {
 
 func TestGateFactory_PrometheusGateWithoutPoolParam(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{})
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{}})
 	assert.Error(t, err, "should return error when pool parameter is missing")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "inference pool name is required")
@@ -80,9 +81,9 @@ func TestGateFactory_PrometheusGateWithoutPoolParam(t *testing.T) {
 
 func TestGateFactory_PrometheusGateWithInvalidThreshold(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{
 		"threshold": "not-a-number",
-	})
+	}})
 	assert.Error(t, err, "should return error when threshold is not a valid float")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "invalid threshold value")
@@ -90,9 +91,9 @@ func TestGateFactory_PrometheusGateWithInvalidThreshold(t *testing.T) {
 
 func TestGateFactory_PrometheusGateWithInvalidFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{
 		"fallback": "not-a-number",
-	})
+	}})
 	assert.Error(t, err, "should return error when fallback is not a valid float")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "invalid fallback value")
@@ -100,18 +101,18 @@ func TestGateFactory_PrometheusGateWithInvalidFallback(t *testing.T) {
 
 func TestGateFactory_PrometheusGateWithThresholdAndFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{
 		"pool":      "my-pool",
-		"threshold": "0.7",
-		"fallback":  "0.3",
-	})
+		"threshold": 0.7,
+		"fallback":  0.3,
+	}})
 	assert.NoError(t, err, "should create gate when threshold and fallback are valid floats")
 	assert.NotNil(t, gate)
 }
 
 func TestGateFactory_RedisGateMissingAddress(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("redis", map[string]string{})
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "redis", GateParams: map[string]any{}})
 	assert.Error(t, err, "should return error when address is missing")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "redis gate requires an 'address' in gate_params")
@@ -119,16 +120,16 @@ func TestGateFactory_RedisGateMissingAddress(t *testing.T) {
 
 func TestGateFactory_RedisGateNilParams(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("redis", nil)
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "redis"})
 	assert.Error(t, err, "should return error when params is nil")
 	assert.Nil(t, gate)
 }
 
 func TestGateFactory_RedisGateSharesClient(t *testing.T) {
 	factory := NewGateFactory("")
-	params := map[string]string{"address": "localhost:6379"}
-	gate1, err1 := factory.CreateGate("redis", params)
-	gate2, err2 := factory.CreateGate("redis", params)
+	cfg := pipeline.GateConfig{GateType: "redis", GateParams: map[string]any{"address": "localhost:6379"}}
+	gate1, err1 := factory.CreateGate(cfg)
+	gate2, err2 := factory.CreateGate(cfg)
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
 	assert.NotNil(t, gate1)
@@ -139,8 +140,8 @@ func TestGateFactory_RedisGateSharesClient(t *testing.T) {
 
 func TestGateFactory_RedisGateDifferentAddresses(t *testing.T) {
 	factory := NewGateFactory("")
-	gate1, err1 := factory.CreateGate("redis", map[string]string{"address": "host1:6379"})
-	gate2, err2 := factory.CreateGate("redis", map[string]string{"address": "host2:6379"})
+	gate1, err1 := factory.CreateGate(pipeline.GateConfig{GateType: "redis", GateParams: map[string]any{"address": "host1:6379"}})
+	gate2, err2 := factory.CreateGate(pipeline.GateConfig{GateType: "redis", GateParams: map[string]any{"address": "host2:6379"}})
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
 	assert.NotNil(t, gate1)
@@ -150,7 +151,7 @@ func TestGateFactory_RedisGateDifferentAddresses(t *testing.T) {
 
 func TestGateFactory_BudgetGateWithoutURL(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{"pool": "my-pool"})
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{"pool": "my-pool"}})
 	assert.Error(t, err, "should return error when Prometheus URL is not set")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "prometheus-budget gate type requires --prometheus-url flag to be set")
@@ -158,9 +159,9 @@ func TestGateFactory_BudgetGateWithoutURL(t *testing.T) {
 
 func TestGateFactory_BudgetGateMissingPool(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
-		"max_concurrency": "100",
-	})
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
+		"max_concurrency": 100.0,
+	}})
 	assert.Error(t, err, "should return error when pool is missing")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "inference pool name is required")
@@ -168,19 +169,19 @@ func TestGateFactory_BudgetGateMissingPool(t *testing.T) {
 
 func TestGateFactory_BudgetGateDefaultMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool": "my-pool",
-	})
+	}})
 	assert.NoError(t, err, "should use default max_concurrency=100 when not provided")
 	assert.NotNil(t, gate)
 }
 
 func TestGateFactory_BudgetGateWithZeroMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":            "my-pool",
-		"max_concurrency": "0",
-	})
+		"max_concurrency": 0.0,
+	}})
 	assert.Error(t, err)
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "max_concurrency must be positive")
@@ -188,20 +189,20 @@ func TestGateFactory_BudgetGateWithZeroMaxConcurrency(t *testing.T) {
 
 func TestGateFactory_BudgetGateWithPoolAndMaxConcurrency(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":            "my-pool",
-		"max_concurrency": "100",
-	})
+		"max_concurrency": 100.0,
+	}})
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
 }
 
 func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":     "my-pool",
 		"baseline": "not-a-number",
-	})
+	}})
 	assert.Error(t, err, "should return error when baseline is not a valid float")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "invalid baseline value")
@@ -210,18 +211,18 @@ func TestGateFactory_BudgetGateWithInvalidBaseline(t *testing.T) {
 func TestGateFactory_BudgetGateWithBaselineOutOfRange(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
 
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":     "my-pool",
-		"baseline": "1.0",
-	})
+		"baseline": 1.0,
+	}})
 	assert.Error(t, err, "baseline=1.0 should be rejected (gate would never open)")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "baseline must be in [0, 1)")
 
-	gate, err = factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err = factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":     "my-pool",
-		"baseline": "-0.1",
-	})
+		"baseline": -0.1,
+	}})
 	assert.Error(t, err, "negative baseline should be rejected")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "baseline must be in [0, 1)")
@@ -229,10 +230,10 @@ func TestGateFactory_BudgetGateWithBaselineOutOfRange(t *testing.T) {
 
 func TestGateFactory_BudgetGateWithInvalidFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":     "my-pool",
 		"fallback": "not-a-number",
-	})
+	}})
 	assert.Error(t, err, "should return error when fallback is not a valid float")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "invalid fallback value")
@@ -240,21 +241,21 @@ func TestGateFactory_BudgetGateWithInvalidFallback(t *testing.T) {
 
 func TestGateFactory_BudgetGateWithAllParams(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":            "my-pool",
-		"max_concurrency": "100",
-		"baseline":        "0.1",
-		"fallback":        "0.5",
-	})
+		"max_concurrency": 100.0,
+		"baseline":        0.1,
+		"fallback":        0.5,
+	}})
 	assert.NoError(t, err)
 	assert.NotNil(t, gate)
 }
 
 func TestGateFactory_PrometheusQueryGateWithoutURL(t *testing.T) {
 	factory := NewGateFactory("")
-	gate, err := factory.CreateGate("prometheus-query", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-query", GateParams: map[string]any{
 		"query": "up",
-	})
+	}})
 	assert.Error(t, err, "should return error when Prometheus URL is not set")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "prometheus-query gate type requires --prometheus-url flag to be set")
@@ -262,7 +263,7 @@ func TestGateFactory_PrometheusQueryGateWithoutURL(t *testing.T) {
 
 func TestGateFactory_PrometheusQueryGateMissingQuery(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-query", map[string]string{})
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-query", GateParams: map[string]any{}})
 	assert.Error(t, err, "should return error when query parameter is missing")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "requires a 'query' parameter")
@@ -270,10 +271,10 @@ func TestGateFactory_PrometheusQueryGateMissingQuery(t *testing.T) {
 
 func TestGateFactory_PrometheusQueryGateWithInvalidFallback(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-query", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-query", GateParams: map[string]any{
 		"query":    "up",
 		"fallback": "not-a-number",
-	})
+	}})
 	assert.Error(t, err, "should return error when fallback is not a valid float")
 	assert.Nil(t, gate)
 	assert.Contains(t, err.Error(), "invalid fallback value")
@@ -281,19 +282,19 @@ func TestGateFactory_PrometheusQueryGateWithInvalidFallback(t *testing.T) {
 
 func TestGateFactory_PrometheusQueryGateWithDefaults(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-query", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-query", GateParams: map[string]any{
 		"query": "up",
-	})
+	}})
 	assert.NoError(t, err, "should create gate with default fallback")
 	assert.NotNil(t, gate)
 }
 
 func TestGateFactory_PrometheusQueryGateWithAllParams(t *testing.T) {
 	factory := NewGateFactory("http://localhost:9090")
-	gate, err := factory.CreateGate("prometheus-query", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-query", GateParams: map[string]any{
 		"query":    `1 - (sum(rate(http_requests_total[5m])) / 100)`,
-		"fallback": "0.5",
-	})
+		"fallback": 0.5,
+	}})
 	assert.NoError(t, err, "should create gate with all params specified")
 	assert.NotNil(t, gate)
 }

--- a/pkg/async/inference/flowcontrol/metric_source_test.go
+++ b/pkg/async/inference/flowcontrol/metric_source_test.go
@@ -222,21 +222,21 @@ func TestNewSaturationPromQLSourceFromConfig(t *testing.T) {
 
 	t.Run("DefaultQuery", func(t *testing.T) {
 		source, err := NewSaturationPromQLSourceFromConfig(promConfig,
-			map[string]string{"pool": "my-pool"})
+			map[string]any{"pool": "my-pool"})
 		require.NoError(t, err)
 		require.Contains(t, source.expr, `1 - inference_extension_flow_control_pool_saturation{inference_pool="my-pool"}`)
 		require.NotContains(t, source.expr, "namespace")
 	})
 
 	t.Run("RequiresPool", func(t *testing.T) {
-		_, err := NewSaturationPromQLSourceFromConfig(promConfig, map[string]string{})
+		_, err := NewSaturationPromQLSourceFromConfig(promConfig, map[string]any{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "inference pool name is required")
 	})
 
 	t.Run("WithNamespace", func(t *testing.T) {
 		source, err := NewSaturationPromQLSourceFromConfig(promConfig,
-			map[string]string{"pool": "my-pool", "namespace": "prod"})
+			map[string]any{"pool": "my-pool", "namespace": "prod"})
 		require.NoError(t, err)
 		require.Contains(t, source.expr, `inference_pool="my-pool"`)
 		require.Contains(t, source.expr, `namespace="prod"`)

--- a/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
+++ b/pkg/async/inference/flowcontrol/promql_metric_source_factory.go
@@ -28,14 +28,14 @@ import (
 // NewSaturationPromQLSourceFromConfig builds a PromQLMetricSource for the saturation use case.
 // It returns a budget value (1 - saturation) by constructing a PromQL query of the form
 // "1 - inference_extension_flow_control_pool_saturation{...}", filtered by the "pool" param (required).
-func NewSaturationPromQLSourceFromConfig(promConfig promapi.Config, params map[string]string) (*PromQLMetricSource, error) {
-	inferencePool := params["pool"]
+func NewSaturationPromQLSourceFromConfig(promConfig promapi.Config, params map[string]any) (*PromQLMetricSource, error) {
+	inferencePool := paramString(params, "pool", "")
 	if inferencePool == "" {
 		return nil, fmt.Errorf("inference pool name is required for saturation PromQL")
 	}
 
 	labels := map[string]string{"inference_pool": inferencePool}
-	if ns := params["namespace"]; ns != "" {
+	if ns := paramString(params, "namespace", ""); ns != "" {
 		labels["namespace"] = ns
 	}
 

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -29,14 +29,13 @@ var resultChannels sync.Map
 const quotaExceededNackDelay = 10 * time.Second
 
 type TopicConfig struct {
-	SubscriberID       string            `json:"subscriber_id"`
-	WorkerPoolID       string            `json:"worker_pool_id"`
-	InferenceObjective string            `json:"inference_objective"`
-	RequestPathURL     string            `json:"request_path_url"`
-	IGWBaseURL         string            `json:"igw_base_url"`
-	GateType           string            `json:"gate_type"`
-	GateParams         map[string]string `json:"gate_params,omitempty"`
-	Labels             map[string]string `json:"labels,omitempty"`
+	SubscriberID       string `json:"subscriber_id"`
+	WorkerPoolID       string `json:"worker_pool_id"`
+	InferenceObjective string `json:"inference_objective"`
+	RequestPathURL     string `json:"request_path_url"`
+	IGWBaseURL         string `json:"igw_base_url"`
+	pipeline.GateConfig
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 var _ pipeline.Flow = (*PubSubMQFlow)(nil)
@@ -159,7 +158,7 @@ func NewGCPPubSubMQFlow(pubsubOpts Options, fns ...PubSubOption) (*PubSubMQFlow,
 		var gate pipeline.Gate
 		if p.gateFactory != nil && cfg.GateType != "" {
 			// Use factory to create per-topic gate
-			gate, err = p.gateFactory.CreateGate(cfg.GateType, cfg.GateParams)
+			gate, err = p.gateFactory.CreateGate(cfg.GateConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create gate for topic subscriber %q (gate_type=%q): %w", cfg.SubscriberID, cfg.GateType, err)
 			}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -22,10 +21,10 @@ import (
 )
 
 // parseGateParams parses a JSON-encoded string (from --redis.ss.gate-params)
-// into a map[string]string for gate parameter configuration.
+// into a map[string]any for gate parameter configuration.
 // Used to pass gate parameters from CLI or YAML to the gate factory.
-func parseGateParams(s string) map[string]string {
-	m := map[string]string{}
+func parseGateParams(s string) map[string]any {
+	m := map[string]any{}
 	if s == "" || s == "{}" {
 		return m
 	}
@@ -33,45 +32,16 @@ func parseGateParams(s string) map[string]string {
 	return m
 }
 
-// StringMap is a map[string]string that tolerates non-string JSON values
-// by converting them to their string representation during unmarshaling.
-type StringMap map[string]string
-
-func (m *StringMap) UnmarshalJSON(data []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	result := make(map[string]string, len(raw))
-	for k, v := range raw {
-		switch val := v.(type) {
-		case string:
-			result[k] = val
-		case float64:
-			result[k] = strconv.FormatFloat(val, 'f', -1, 64)
-		case bool:
-			result[k] = strconv.FormatBool(val)
-		case nil:
-			result[k] = ""
-		default:
-			return fmt.Errorf("gate_params key %q: unsupported value type %T (only strings, numbers, and booleans are allowed)", k, v)
-		}
-	}
-	*m = result
-	return nil
-}
-
 type queueConfig struct {
-	ID                 string            `json:"id,omitempty"`
-	QueueName          string            `json:"queue_name,omitempty"`
-	ResultQueueName    string            `json:"result_queue_name,omitempty"`
-	WorkerPoolID       string            `json:"worker_pool_id"`
-	InferenceObjective string            `json:"inference_objective"`
-	RequestPathURL     string            `json:"request_path_url"`
-	IGWBaseURL         string            `json:"igw_base_url"`
-	GateType           string            `json:"gate_type"`
-	GateParams         StringMap         `json:"gate_params,omitempty"`
-	Labels             map[string]string `json:"labels,omitempty"`
+	ID                 string `json:"id,omitempty"`
+	QueueName          string `json:"queue_name,omitempty"`
+	ResultQueueName    string `json:"result_queue_name,omitempty"`
+	WorkerPoolID       string `json:"worker_pool_id"`
+	InferenceObjective string `json:"inference_objective"`
+	RequestPathURL     string `json:"request_path_url"`
+	IGWBaseURL         string `json:"igw_base_url"`
+	pipeline.GateConfig
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type requestChannelData struct {
@@ -167,7 +137,7 @@ func NewRedisSortedSetFlow(flowOpts SortedSetFlowOptions, connOpts ConnectionOpt
 	for _, cfg := range configs {
 		var gate pipeline.Gate
 		if r.gateFactory != nil && cfg.GateType != "" {
-			gate, err = r.gateFactory.CreateGate(cfg.GateType, cfg.GateParams)
+			gate, err = r.gateFactory.CreateGate(cfg.GateConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create gate for queue %q (gate_type=%q): %w", cfg.QueueName, cfg.GateType, err)
 			}
@@ -258,8 +228,7 @@ func loadQueueConfigs(opts SortedSetFlowOptions) ([]queueConfig, error) {
 			InferenceObjective: opts.InferenceObjective,
 			IGWBaseURL:         opts.IGWBaseURL,
 			RequestPathURL:     opts.RequestPathURL,
-			GateType:           opts.GateType,
-			GateParams:         parseGateParams(opts.GateParamsJSON),
+			GateConfig:         pipeline.GateConfig{GateType: opts.GateType, GateParams: parseGateParams(opts.GateParamsJSON)},
 			WorkerPoolID:       "default",
 		}}
 	}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -23,13 +23,15 @@ import (
 // parseGateParams parses a JSON-encoded string (from --redis.ss.gate-params)
 // into a map[string]any for gate parameter configuration.
 // Used to pass gate parameters from CLI or YAML to the gate factory.
-func parseGateParams(s string) map[string]any {
+func parseGateParams(s string) (map[string]any, error) {
 	m := map[string]any{}
 	if s == "" || s == "{}" {
-		return m
+		return m, nil
 	}
-	_ = json.Unmarshal([]byte(s), &m)
-	return m
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, fmt.Errorf("failed to parse gate params JSON: %w", err)
+	}
+	return m, nil
 }
 
 type queueConfig struct {
@@ -223,12 +225,16 @@ func loadQueueConfigs(opts SortedSetFlowOptions) ([]queueConfig, error) {
 			return nil, err
 		}
 	} else {
+		gateParams, err := parseGateParams(opts.GateParamsJSON)
+		if err != nil {
+			return nil, err
+		}
 		configs = []queueConfig{{
 			QueueName:          opts.RequestQueueName,
 			InferenceObjective: opts.InferenceObjective,
 			IGWBaseURL:         opts.IGWBaseURL,
 			RequestPathURL:     opts.RequestPathURL,
-			GateConfig:         pipeline.GateConfig{GateType: opts.GateType, GateParams: parseGateParams(opts.GateParamsJSON)},
+			GateConfig:         pipeline.GateConfig{GateType: opts.GateType, GateParams: gateParams},
 			WorkerPoolID:       "default",
 		}}
 	}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -54,20 +54,20 @@ func TestParseQueueConfigs(t *testing.T) {
 					t.Errorf("expected q1, got %s", configs[0].QueueName)
 				}
 				if configs[0].GateParams["address"] != "localhost:6379" {
-					t.Errorf("expected localhost:6379, got %s", configs[0].GateParams["address"])
+					t.Errorf("expected localhost:6379, got %v", configs[0].GateParams["address"])
 				}
 			},
 		},
 		{
-			name:    "numeric gate params coerced to strings",
+			name:    "numeric gate params preserved as native types",
 			input:   `[{"queue_name":"q1","igw_base_url":"http://gw","gate_type":"prometheus-saturation","gate_params":{"threshold":0.7,"pool":"p1"}}]`,
 			wantLen: 1,
 			validate: func(t *testing.T, configs []queueConfig) {
-				if configs[0].GateParams["threshold"] != "0.7" {
-					t.Errorf("expected '0.7', got '%s'", configs[0].GateParams["threshold"])
+				if configs[0].GateParams["threshold"] != 0.7 {
+					t.Errorf("expected 0.7, got '%v'", configs[0].GateParams["threshold"])
 				}
 				if configs[0].GateParams["pool"] != "p1" {
-					t.Errorf("expected 'p1', got '%s'", configs[0].GateParams["pool"])
+					t.Errorf("expected 'p1', got '%v'", configs[0].GateParams["pool"])
 				}
 			},
 		},
@@ -115,77 +115,6 @@ func TestParseQueueConfigs(t *testing.T) {
 			}
 			if tt.validate != nil {
 				tt.validate(t, configs)
-			}
-		})
-	}
-}
-
-func TestStringMapUnmarshal(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected map[string]string
-	}{
-		{
-			name:     "string values",
-			input:    `{"key":"value"}`,
-			expected: map[string]string{"key": "value"},
-		},
-		{
-			name:     "numeric float",
-			input:    `{"threshold":0.7}`,
-			expected: map[string]string{"threshold": "0.7"},
-		},
-		{
-			name:     "integer",
-			input:    `{"limit":5}`,
-			expected: map[string]string{"limit": "5"},
-		},
-		{
-			name:     "boolean",
-			input:    `{"enabled":true}`,
-			expected: map[string]string{"enabled": "true"},
-		},
-		{
-			name:     "mixed types",
-			input:    `{"pool":"p1","threshold":0.8,"limit":100,"active":true}`,
-			expected: map[string]string{"pool": "p1", "threshold": "0.8", "limit": "100", "active": "true"},
-		},
-		{
-			name:     "null becomes empty string",
-			input:    `{"key":null}`,
-			expected: map[string]string{"key": ""},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var m StringMap
-			if err := json.Unmarshal([]byte(tt.input), &m); err != nil {
-				t.Fatalf("unmarshal error: %v", err)
-			}
-			for k, want := range tt.expected {
-				if got := m[k]; got != want {
-					t.Errorf("key %q: expected %q, got %q", k, want, got)
-				}
-			}
-		})
-	}
-}
-
-func TestStringMapRejectsNonScalar(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"nested object", `{"key":{"nested":"value"}}`},
-		{"array", `{"key":[1,2,3]}`},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var m StringMap
-			if err := json.Unmarshal([]byte(tt.input), &m); err == nil {
-				t.Error("expected error for non-scalar value, got nil")
 			}
 		})
 	}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -40,7 +40,7 @@ func NewRunner(opts *Options) *Runner {
 	return &Runner{opts: opts}
 }
 
-func (r *Runner) Run(ctx context.Context) error {
+func (r *Runner) Run(ctx context.Context) (err error) {
 	opts := r.opts
 
 	logging.InitLogging(opts.LoggingOptions(), opts.Observability.Verbosity)
@@ -49,177 +49,87 @@ func (r *Runner) Run(ctx context.Context) error {
 	setupLog := ctrl.Log.WithName("setup")
 	setupLog.Info("Logger initialized")
 
-	tracerShutdown, err := uotel.InitTracer(logr.NewContext(context.Background(), setupLog))
-	if err != nil {
-		setupLog.Error(err, "Failed to initialize OpenTelemetry tracer")
-		return err
-	}
+	baseCtx := logr.NewContext(context.Background(), setupLog)
+
+	var (
+		healthServer   *health.Server
+		gateFactory    *flowcontrol.GateFactory
+		tracerShutdown func(ctx context.Context) error
+	)
 	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err != nil {
+			setupLog.Error(err, "Runner failed")
+		}
+		shutdownCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
 		defer cancel()
-		if err := tracerShutdown(shutdownCtx); err != nil {
-			setupLog.Error(err, "Failed to shutdown tracer")
+		if healthServer != nil {
+			if err := healthServer.Shutdown(shutdownCtx); err != nil {
+				setupLog.Error(err, "Health server shutdown error")
+			}
+		}
+		if gateFactory != nil {
+			if err := gateFactory.Close(); err != nil {
+				setupLog.Error(err, "Failed to close gate factory")
+			}
+		}
+		if tracerShutdown != nil {
+			if err := tracerShutdown(shutdownCtx); err != nil {
+				setupLog.Error(err, "Failed to shutdown tracer")
+			}
 		}
 	}()
+
+	tracerShutdown, err = initTracer(baseCtx)
+	if err != nil {
+		return err
+	}
 
 	setupLog.Info("Async Processor starting", "version", version.Version, "commit", version.Commit, "buildDate", version.BuildDate)
 
 	printAllFlags(setupLog)
 
-	var workerPools []pipeline.WorkerPoolConfig
-	if opts.Worker.PoolConfigFile != "" {
-		workerPools, err = pipeline.LoadWorkerPools(opts.Worker.PoolConfigFile)
-		if err != nil {
-			setupLog.Error(err, "Failed to load pool configuration file")
-			return err
-		}
-		setupLog.Info("Loaded named pools config", "count", len(workerPools))
-	} else {
-		workerPools = []pipeline.WorkerPoolConfig{{
-			ID:      "default",
-			Workers: opts.Worker.Concurrency,
-		}}
-		setupLog.Info("No queue/pool configs set. Created default pool", "workers", opts.Worker.Concurrency)
-	}
-
-	gateFactory := flowcontrol.NewGateFactoryWithCacheTTL(opts.Prometheus.URL, opts.Prometheus.CacheTTL)
-	defer func() {
-		if err := gateFactory.Close(); err != nil {
-			setupLog.Error(err, "Failed to close gate factory")
-		}
-	}()
-
-	var policy pipeline.RequestMergePolicy
-	switch opts.Queue.MergePolicy {
-	case "random-robin":
-		policy = async.NewRandomRobinPolicy()
-	default:
-		return fmt.Errorf("unknown request merge policy: %s", opts.Queue.MergePolicy)
-	}
-
-	var impl pipeline.Flow
-	switch opts.Queue.Impl {
-	case "redis-pubsub":
-		flow, err := redis.NewRedisMQFlow(opts.Redis, opts.RedisConnection, redis.WithRedisTracing(opts.Observability.RedisTracing), redis.WithWorkerPools(workerPools))
-		if err != nil {
-			setupLog.Error(err, "Failed to create Redis pub/sub flow")
-			return err
-		}
-		impl = flow
-	case "redis-sortedset":
-		flow, err := redis.NewRedisSortedSetFlow(opts.RedisSortedSet, opts.RedisConnection, redis.WithGateFactory(gateFactory), redis.WithSortedSetRedisTracing(opts.Observability.RedisTracing), redis.WithSortedSetWorkerPools(workerPools))
-		if err != nil {
-			setupLog.Error(err, "Failed to create Redis sorted-set flow")
-			return err
-		}
-		impl = flow
-		setupLog.Info("Using Redis sorted-set flow with per-queue gating")
-	case "gcp-pubsub":
-		flow, err := pubsub.NewGCPPubSubMQFlow(opts.PubSub, pubsub.WithWorkerPools(workerPools))
-		if err != nil {
-			setupLog.Error(err, "Failed to create GCP PubSub flow")
-			return err
-		}
-		impl = flow
-	case "gcp-pubsub-gated":
-		flow, err := pubsub.NewGCPPubSubMQFlow(opts.PubSub, pubsub.WithGateFactory(gateFactory), pubsub.WithWorkerPools(workerPools))
-		if err != nil {
-			setupLog.Error(err, "Failed to create GCP PubSub gated flow")
-			return err
-		}
-		impl = flow
-		setupLog.Info("Using GCP PubSub flow with per-queue gating")
-	default:
-		return fmt.Errorf("unknown message queue implementation: %s", opts.Queue.Impl)
-	}
-
-	metrics.Register(metrics.GetAsyncProcessorCollectors(impl.Characteristics().SupportsMessageLatency)...)
-
-	var checker health.Checker
-	if hc, ok := impl.(pipeline.HealthChecker); ok {
-		checker = hc.HealthCheck
-	}
-	healthServer := health.NewServer(opts.Server.HealthPort, checker, setupLog.WithName("health"))
-	healthLn, err := healthServer.ListenAndServe()
+	poolsMap, totalConcurrency, err := loadWorkerPools(opts.Worker, setupLog)
 	if err != nil {
-		setupLog.Error(err, "Failed to bind health server")
 		return err
 	}
-	go func() {
-		if err := healthServer.Serve(healthLn); err != nil {
-			setupLog.Error(err, "Health server failed")
-		}
-	}()
 
-	signalCtx := ctx
+	gateFactory = flowcontrol.NewGateFactoryWithCacheTTL(opts.Prometheus.URL, opts.Prometheus.CacheTTL)
 
-	drainCtx, drainCancel := context.WithCancel(logr.NewContext(context.Background(), setupLog))
+	policy, err := loadRequestMergePolicy(opts.Queue.MergePolicy)
+	if err != nil {
+		return err
+	}
+
+	flow, err := loadFlow(opts, gateFactory, poolsMap)
+	if err != nil {
+		return err
+	}
+
+	metrics.Register(metrics.GetAsyncProcessorCollectors(flow.Characteristics().SupportsMessageLatency)...)
+
+	healthServer, err = initHealthServer(flow, opts.Server, setupLog)
+	if err != nil {
+		return err
+	}
+
+	if err = startMetricsServer(ctx, opts.Server, setupLog); err != nil {
+		return err
+	}
+
+	inferenceClient, err := initInferenceClient(opts.TLS, totalConcurrency)
+	if err != nil {
+		return err
+	}
+
+	transforms, err := loadTransforms(ctx, opts.TransformConfigFile, setupLog)
+	if err != nil {
+		return err
+	}
+
+	drainCtx, drainCancel := context.WithCancel(baseCtx)
 	defer drainCancel()
 
-	metricsServerOptions := metricsserver.Options{
-		BindAddress: fmt.Sprintf(":%d", opts.Server.MetricsPort),
-		FilterProvider: func() func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
-			if opts.Server.MetricsEndpointAuth {
-				return filters.WithAuthenticationAndAuthorization
-			}
-			return nil
-		}(),
-	}
-	restConfig := ctrl.GetConfigOrDie()
-
-	msrv, err := metricsserver.NewServer(metricsServerOptions, restConfig, http.DefaultClient)
-	if err != nil {
-		setupLog.Error(err, "Failed to create metrics server")
-		return err
-	}
-	go msrv.Start(signalCtx) //nolint:errcheck
-
-	tlsConfig, err := buildTLSConfig(opts.TLS)
-	if err != nil {
-		setupLog.Error(err, "Failed to build TLS configuration")
-		return err
-	}
-
-	totalConcurrency := 0
-	poolsMap := make(map[string]pipeline.WorkerPoolConfig)
-	for _, p := range workerPools {
-		if p.Workers <= 0 {
-			p.Workers = opts.Worker.Concurrency
-		}
-		poolsMap[p.ID] = p
-		totalConcurrency += p.Workers
-		metrics.SetPoolWorkerLimit(p.ID, float64(p.Workers))
-	}
-
-	inferenceTransport := &http.Transport{
-		MaxIdleConns:        100,
-		MaxIdleConnsPerHost: totalConcurrency,
-		IdleConnTimeout:     90 * time.Second,
-		TLSClientConfig:     tlsConfig,
-	}
-	inferenceHTTPClient := &http.Client{Transport: otelhttp.NewTransport(inferenceTransport,
-		otelhttp.WithSpanNameFormatter(func(_ string, _ *http.Request) string {
-			return "http-request"
-		}),
-	)}
-	inferenceClient := asyncworker.NewHTTPInferenceClient(inferenceHTTPClient)
-
-	var transforms *transform.Chain
-	if opts.TransformConfigFile != "" {
-		cfg, err := transform.LoadConfig(opts.TransformConfigFile)
-		if err != nil {
-			setupLog.Error(err, "Failed to load transform configuration file")
-			return err
-		}
-		transforms, err = transform.BuildChain(cfg.RequestTransforms, plugins.NewHandle(signalCtx))
-		if err != nil {
-			setupLog.Error(err, "Failed to build request transform chain")
-			return err
-		}
-		setupLog.Info("Loaded request transform plugins", "count", transforms.Len())
-	}
-
-	dispatch := policy.MergeRequestChannels(impl.RequestChannels(), poolsMap)
+	dispatch := policy.MergeRequestChannels(flow.RequestChannels(), poolsMap)
 
 	poolGates := make(map[string]pipeline.Gate)
 	for poolID, pool := range poolsMap {
@@ -236,10 +146,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 	for poolID, mergedChan := range dispatch.Channels {
-		pool, ok := poolsMap[poolID]
-		if !ok {
-			return fmt.Errorf("pool %s not found", poolID)
-		}
+		pool := poolsMap[poolID]
 		workersCount := pool.Workers
 		poolGate := poolGates[poolID]
 
@@ -248,25 +155,25 @@ func (r *Runner) Run(ctx context.Context) error {
 			wg.Add(1)
 			go func(mergedChan chan pipeline.EmbelishedRequestMessage, poolGate pipeline.Gate) {
 				defer wg.Done()
-				asyncworker.WorkerWithGate(signalCtx, drainCtx, impl.Characteristics(), inferenceClient, mergedChan, impl.RetryChannel(), impl.ResultChannel(), opts.Worker.RequestTimeout, transforms, poolGate)
+				asyncworker.WorkerWithGate(ctx, drainCtx, flow.Characteristics(), inferenceClient, mergedChan, flow.RetryChannel(), flow.ResultChannel(), opts.Worker.RequestTimeout, transforms, poolGate)
 			}(mergedChan, poolGate)
 		}
 	}
 
-	impl.Start(signalCtx)
+	flow.Start(ctx)
 	healthServer.SetReady()
 
-	if reporter, ok := impl.(pipeline.BacklogReporter); ok && opts.Queue.BacklogPollInterval > 0 {
-		go pollBacklog(signalCtx, reporter, opts.Queue.BacklogPollInterval)
+	if reporter, ok := flow.(pipeline.BacklogReporter); ok && opts.Queue.BacklogPollInterval > 0 {
+		go pollBacklog(ctx, reporter, opts.Queue.BacklogPollInterval)
 	} else if !ok {
 		setupLog.Info("Selected flow does not support broker backlog metrics", "message-queue-impl", opts.Queue.Impl)
 	}
 
-	<-signalCtx.Done()
+	<-ctx.Done()
 	healthServer.SetNotReady()
 
 	setupLog.Info("Signal received, stopping message consumption")
-	impl.StopConsuming()
+	flow.StopConsuming()
 
 	setupLog.Info("Draining in-flight requests", "timeout", opts.Worker.DrainTimeout)
 	done := make(chan struct{})
@@ -280,15 +187,151 @@ func (r *Runner) Run(ctx context.Context) error {
 		wg.Wait()
 	}
 
-	impl.Shutdown()
-
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer shutdownCancel()
-	if err := healthServer.Shutdown(shutdownCtx); err != nil {
-		setupLog.Error(err, "Health server shutdown error")
-	}
+	flow.Shutdown()
 
 	return nil
+}
+
+func initTracer(baseCtx context.Context) (func(context.Context) error, error) {
+	shutdown, err := uotel.InitTracer(baseCtx)
+	if err != nil {
+		logr.FromContextOrDiscard(baseCtx).Error(err, "Failed to initialize OpenTelemetry tracer")
+		return nil, err
+	}
+	return shutdown, nil
+}
+
+func loadWorkerPools(workerConfig WorkerConfig, setupLog logr.Logger) (poolsMap map[string]pipeline.WorkerPoolConfig, totalConcurrency int, err error) {
+	var pools []pipeline.WorkerPoolConfig
+	if workerConfig.PoolConfigFile != "" {
+		pools, err = pipeline.LoadWorkerPools(workerConfig.PoolConfigFile)
+		if err != nil {
+			return nil, -1, err
+		}
+		setupLog.Info("Loaded named pools config", "count", len(pools))
+	} else {
+		pools = []pipeline.WorkerPoolConfig{{
+			ID:      "default",
+			Workers: workerConfig.Concurrency,
+		}}
+		setupLog.Info("No queue/pool configs set. Created default pool", "workers", workerConfig.Concurrency)
+	}
+
+	poolsMap = make(map[string]pipeline.WorkerPoolConfig)
+	for _, p := range pools {
+		if p.Workers <= 0 {
+			p.Workers = workerConfig.Concurrency
+		}
+		poolsMap[p.ID] = p
+		totalConcurrency += p.Workers
+		metrics.SetPoolWorkerLimit(p.ID, float64(p.Workers))
+	}
+	return poolsMap, totalConcurrency, err
+
+}
+
+func loadRequestMergePolicy(name string) (pipeline.RequestMergePolicy, error) {
+	switch name {
+	case "random-robin":
+		return async.NewRandomRobinPolicy(), nil
+	default:
+		return nil, fmt.Errorf("unknown request merge policy: %s", name)
+	}
+}
+
+func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[string]pipeline.WorkerPoolConfig) (pipeline.Flow, error) {
+	workerPools := make([]pipeline.WorkerPoolConfig, 0, len(poolsMap))
+	for _, p := range poolsMap {
+		workerPools = append(workerPools, p)
+	}
+	switch opts.Queue.Impl {
+	case "redis-pubsub":
+		return redis.NewRedisMQFlow(opts.Redis, opts.RedisConnection, redis.WithRedisTracing(opts.Observability.RedisTracing), redis.WithWorkerPools(workerPools))
+	case "redis-sortedset":
+		return redis.NewRedisSortedSetFlow(opts.RedisSortedSet, opts.RedisConnection, redis.WithGateFactory(gateFactory), redis.WithSortedSetRedisTracing(opts.Observability.RedisTracing), redis.WithSortedSetWorkerPools(workerPools))
+	case "gcp-pubsub":
+		return pubsub.NewGCPPubSubMQFlow(opts.PubSub, pubsub.WithWorkerPools(workerPools))
+	case "gcp-pubsub-gated":
+		return pubsub.NewGCPPubSubMQFlow(opts.PubSub, pubsub.WithGateFactory(gateFactory), pubsub.WithWorkerPools(workerPools))
+	default:
+		return nil, fmt.Errorf("unknown message queue implementation: %s", opts.Queue.Impl)
+	}
+}
+
+func initHealthServer(impl pipeline.Flow, serverCfg ServerConfig, setupLog logr.Logger) (*health.Server, error) {
+	var checker health.Checker
+	if hc, ok := impl.(pipeline.HealthChecker); ok {
+		checker = hc.HealthCheck
+	}
+	healthServer := health.NewServer(serverCfg.HealthPort, checker, setupLog.WithName("health"))
+	healthLn, err := healthServer.ListenAndServe()
+	if err != nil {
+		setupLog.Error(err, "Failed to bind health server")
+		return nil, err
+	}
+	go func() {
+		if err := healthServer.Serve(healthLn); err != nil {
+			setupLog.Error(err, "Health server failed")
+		}
+	}()
+	return healthServer, nil
+}
+
+func startMetricsServer(ctx context.Context, serverCfg ServerConfig, setupLog logr.Logger) error {
+	metricsServerOptions := metricsserver.Options{
+		BindAddress: fmt.Sprintf(":%d", serverCfg.MetricsPort),
+		FilterProvider: func() func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
+			if serverCfg.MetricsEndpointAuth {
+				return filters.WithAuthenticationAndAuthorization
+			}
+			return nil
+		}(),
+	}
+	restConfig := ctrl.GetConfigOrDie()
+
+	msrv, err := metricsserver.NewServer(metricsServerOptions, restConfig, http.DefaultClient)
+	if err != nil {
+		setupLog.Error(err, "Failed to create metrics server")
+		return err
+	}
+	go msrv.Start(ctx) //nolint:errcheck
+	return nil
+}
+
+func initInferenceClient(tlsCfg TLSConfig, totalConcurrency int) (*asyncworker.HTTPInferenceClient, error) {
+	tlsConfig, err := buildTLSConfig(tlsCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS configuration: %w", err)
+	}
+
+	inferenceTransport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: totalConcurrency,
+		IdleConnTimeout:     90 * time.Second,
+		TLSClientConfig:     tlsConfig,
+	}
+	inferenceHTTPClient := &http.Client{Transport: otelhttp.NewTransport(inferenceTransport,
+		otelhttp.WithSpanNameFormatter(func(_ string, _ *http.Request) string {
+			return "http-request"
+		}),
+	)}
+	return asyncworker.NewHTTPInferenceClient(inferenceHTTPClient), nil
+}
+
+func loadTransforms(ctx context.Context, configFile string, setupLog logr.Logger) (*transform.Chain, error) {
+	if configFile == "" {
+		return nil, nil
+	}
+	cfg, err := transform.LoadConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load transform configuration: %w", err)
+	}
+	chain, err := transform.BuildChain(cfg.RequestTransforms, plugins.NewHandle(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request transform chain: %w", err)
+	}
+	setupLog.Info("Loaded request transform plugins", "count", chain.Len())
+	return chain, nil
 }
 
 func buildTLSConfig(cfg TLSConfig) (*tls.Config, error) {

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -134,7 +134,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	poolGates := make(map[string]pipeline.Gate)
 	for poolID, pool := range poolsMap {
 		if pool.GateType != "" {
-			gate, err := gateFactory.CreateGate(pipeline.GateConfig{GateType: pool.GateType, GateParams: toAnyMap(pool.GateParams)})
+			gate, err := gateFactory.CreateGate(pipeline.GateConfig{GateType: pool.GateType, GateParams: pool.GateParams})
 			if err != nil {
 				setupLog.Error(err, "Failed to create pool gate", "poolID", poolID, "gateType", pool.GateType)
 				os.Exit(1)
@@ -399,17 +399,6 @@ func pollBacklog(ctx context.Context, reporter pipeline.BacklogReporter, interva
 			poll()
 		}
 	}
-}
-
-func toAnyMap(m map[string]string) map[string]any {
-	if m == nil {
-		return nil
-	}
-	result := make(map[string]any, len(m))
-	for k, v := range m {
-		result[k] = v
-	}
-	return result
 }
 
 var sensitiveFlags = map[string]bool{

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -134,7 +134,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	poolGates := make(map[string]pipeline.Gate)
 	for poolID, pool := range poolsMap {
 		if pool.GateType != "" {
-			gate, err := gateFactory.CreateGate(pool.GateType, pool.GateParams)
+			gate, err := gateFactory.CreateGate(pipeline.GateConfig{GateType: pool.GateType, GateParams: toAnyMap(pool.GateParams)})
 			if err != nil {
 				setupLog.Error(err, "Failed to create pool gate", "poolID", poolID, "gateType", pool.GateType)
 				os.Exit(1)
@@ -399,6 +399,17 @@ func pollBacklog(ctx context.Context, reporter pipeline.BacklogReporter, interva
 			poll()
 		}
 	}
+}
+
+func toAnyMap(m map[string]string) map[string]any {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
 }
 
 var sensitiveFlags = map[string]bool{

--- a/test/integration/endpoint_scrape_gate_factory_test.go
+++ b/test/integration/endpoint_scrape_gate_factory_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,13 +36,13 @@ func TestGateFactory_EndpointScrape_StaticMaxCount(t *testing.T) {
 
 	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 200*time.Millisecond)
 
-	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "endpoint-scrape", GateParams: map[string]any{
 		"url":               server.URL,
 		"metric":            "vllm:num_requests_waiting",
-		"max_count_per_pod": "10",
-		"baseline":          "0.0",
-		"fallback":          "0.0",
-	})
+		"max_count_per_pod": 10.0,
+		"baseline":          0.0,
+		"fallback":          0.0,
+	}})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -79,12 +80,12 @@ pool_saturation{name="pool-a"} 0.6
 	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
 
 	// No max_count_per_pod → metric value used directly as saturation
-	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "endpoint-scrape", GateParams: map[string]any{
 		"url":      server.URL,
 		"metric":   "pool_saturation",
 		"labels":   `{"name":"pool-a"}`,
-		"baseline": "0.1",
-	})
+		"baseline": 0.1,
+	}})
 	require.NoError(t, err)
 
 	// saturation=0.6 → budget=1-0.6=0.4 → minus baseline 0.1 → 0.3
@@ -110,14 +111,14 @@ ready_pods{name="pool-a"} 3
 
 	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
 
-	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "endpoint-scrape", GateParams: map[string]any{
 		"url":               simServer.URL,
 		"metric":            "vllm:num_requests_waiting",
-		"max_count_per_pod": "10",
+		"max_count_per_pod": 10.0,
 		"pods_url":          podsServer.URL,
 		"pods_metric":       "ready_pods",
 		"pods_labels":       `{"name":"pool-a"}`,
-	})
+	}})
 	require.NoError(t, err)
 
 	// value=6, pods=3, maxCountPerPod=10 → maxCount=30 → saturation=0.2 → budget=0.8
@@ -128,14 +129,14 @@ ready_pods{name="pool-a"} 3
 func TestGateFactory_EndpointScrape_MissingParams(t *testing.T) {
 	factory := flowcontrol.NewGateFactory("")
 
-	_, err := factory.CreateGate("endpoint-scrape", map[string]string{
+	_, err := factory.CreateGate(pipeline.GateConfig{GateType: "endpoint-scrape", GateParams: map[string]any{
 		"metric": "some_metric",
-	})
+	}})
 	assert.Error(t, err, "Should fail when url is missing")
 
-	_, err = factory.CreateGate("endpoint-scrape", map[string]string{
+	_, err = factory.CreateGate(pipeline.GateConfig{GateType: "endpoint-scrape", GateParams: map[string]any{
 		"url": "http://localhost:8000/metrics",
-	})
+	}})
 	assert.Error(t, err, "Should fail when metric is missing")
 }
 
@@ -147,11 +148,11 @@ func TestGateFactory_EndpointScrape_FallbackOnError(t *testing.T) {
 
 	factory := flowcontrol.NewGateFactoryWithCacheTTL("", 0)
 
-	gate, err := factory.CreateGate("endpoint-scrape", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "endpoint-scrape", GateParams: map[string]any{
 		"url":      server.URL,
 		"metric":   "any",
-		"fallback": "0.5",
-	})
+		"fallback": 0.5,
+	}})
 	require.NoError(t, err)
 
 	budget := gate.Budget(context.Background())

--- a/test/integration/gate_factory_redis_test.go
+++ b/test/integration/gate_factory_redis_test.go
@@ -20,14 +20,14 @@ func TestGateFactory_RedisQuota_ConcurrencyParsing(t *testing.T) {
 	s := miniredis.RunT(t)
 	factory := flowcontrol.NewGateFactory("")
 
-	gate, err := factory.CreateGate("redis-quota", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "redis-quota", GateParams: map[string]any{
 		"address":   s.Addr(),
 		"attribute": "model",
 		"mode":      "concurrency",
-		"limit":     "2",
+		"limit":     2,
 		"window":    "30s",
 		"prefix":    "test:",
-	})
+	}})
 	require.NoError(t, err)
 	require.NotNil(t, gate)
 
@@ -79,12 +79,12 @@ func TestGateFactory_RedisQuota_RateLimitParsing(t *testing.T) {
 	s := miniredis.RunT(t)
 	factory := flowcontrol.NewGateFactory("")
 
-	gate, err := factory.CreateGate("redis-quota", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "redis-quota", GateParams: map[string]any{
 		"address": s.Addr(),
 		"mode":    "rate-limit",
-		"limit":   "3",
+		"limit":   3,
 		"window":  "1m",
-	})
+	}})
 	require.NoError(t, err)
 	require.NotNil(t, gate)
 
@@ -111,15 +111,15 @@ func TestGateFactory_RedisQuota_RateLimitParsing(t *testing.T) {
 func TestGateFactory_RedisQuota_MissingParams(t *testing.T) {
 	factory := flowcontrol.NewGateFactory("")
 
-	_, err := factory.CreateGate("redis-quota", map[string]string{
-		"limit": "5",
-	})
+	_, err := factory.CreateGate(pipeline.GateConfig{GateType: "redis-quota", GateParams: map[string]any{
+		"limit": 5,
+	}})
 	assert.Error(t, err, "Should fail when address is missing")
 
 	s := miniredis.RunT(t)
-	_, err = factory.CreateGate("redis-quota", map[string]string{
+	_, err = factory.CreateGate(pipeline.GateConfig{GateType: "redis-quota", GateParams: map[string]any{
 		"address": s.Addr(),
-	})
+	}})
 	assert.Error(t, err, "Should fail when limit is missing")
 }
 
@@ -129,10 +129,10 @@ func TestGateFactory_RedisQuota_DefaultParams(t *testing.T) {
 	s := miniredis.RunT(t)
 	factory := flowcontrol.NewGateFactory("")
 
-	gate, err := factory.CreateGate("redis-quota", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "redis-quota", GateParams: map[string]any{
 		"address": s.Addr(),
-		"limit":   "1",
-	})
+		"limit":   1,
+	}})
 	require.NoError(t, err)
 
 	// Default attribute is "userid", default mode is "rate-limit".

--- a/test/integration/prometheus_gate_factory_test.go
+++ b/test/integration/prometheus_gate_factory_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/llm-d-incubation/llm-d-async/pipeline"
 	"github.com/llm-d-incubation/llm-d-async/pkg/async/inference/flowcontrol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,11 +39,11 @@ func TestGateFactory_PrometheusSaturation_EndToEnd(t *testing.T) {
 
 	factory := flowcontrol.NewGateFactoryWithCacheTTL(server.URL, 200*time.Millisecond)
 
-	gate, err := factory.CreateGate("prometheus-saturation", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{
 		"pool":      "my-pool",
-		"threshold": "0.8",
-		"fallback":  "0.0",
-	})
+		"threshold": 0.8,
+		"fallback":  0.0,
+	}})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -83,12 +84,12 @@ func TestGateFactory_PrometheusBudget_EndToEnd(t *testing.T) {
 
 	factory := flowcontrol.NewGateFactoryWithCacheTTL(server.URL, 100*time.Millisecond)
 
-	gate, err := factory.CreateGate("prometheus-budget", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-budget", GateParams: map[string]any{
 		"pool":            "my-pool",
-		"max_concurrency": "100",
-		"baseline":        "0.05",
-		"fallback":        "0.0",
-	})
+		"max_concurrency": 100.0,
+		"baseline":        0.05,
+		"fallback":        0.0,
+	}})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -113,15 +114,15 @@ func TestGateFactory_PrometheusSaturation_MissingParams(t *testing.T) {
 	factory := flowcontrol.NewGateFactory("")
 
 	// Missing prometheusURL.
-	_, err := factory.CreateGate("prometheus-saturation", map[string]string{
+	_, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{
 		"pool": "my-pool",
-	})
+	}})
 	assert.Error(t, err, "Should fail when prometheus URL is empty")
 
 	factory2 := flowcontrol.NewGateFactory("http://localhost:9090")
 
 	// Missing pool param.
-	_, err = factory2.CreateGate("prometheus-saturation", map[string]string{})
+	_, err = factory2.CreateGate(pipeline.GateConfig{GateType: "prometheus-saturation", GateParams: map[string]any{}})
 	assert.Error(t, err, "Should fail when pool is missing")
 }
 
@@ -146,10 +147,10 @@ func TestGateFactory_PrometheusQuery_EndToEnd(t *testing.T) {
 
 	factory := flowcontrol.NewGateFactoryWithCacheTTL(server.URL, 200*time.Millisecond)
 
-	gate, err := factory.CreateGate("prometheus-query", map[string]string{
+	gate, err := factory.CreateGate(pipeline.GateConfig{GateType: "prometheus-query", GateParams: map[string]any{
 		"query":    promQL,
-		"fallback": "0.0",
-	})
+		"fallback": 0.0,
+	}})
 	require.NoError(t, err)
 
 	ctx := context.Background()


### PR DESCRIPTION
## What does this PR do?

Refactors common parsing code for Gates to a single place (under `pipeline/gate.go`), exports a common `GateConfig` struct, and uses it everywhere; the unified parser accepts a typed JSON, and additional gate-specific config is now passed as `map[string]any` (instead of map[string]string`, which caused all typed values to be coerced)

~~Notice this is stacked on #287, so ignore the corresponding commit b99a773a5067cd5232563de72b183359dc003ebe (PR is hence draft for now)~~

## Why is this change needed?

Simplify Gate handling, currently there was quite a bit of duplication. It is also a step further towards improving the config parsing described in #284 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Stacked on top of https://github.com/llm-d-incubation/llm-d-async/pull/287, related to https://github.com/llm-d-incubation/llm-d-async/issues/284