### PR TITLE
Preserve HTTP status and surface non-HTTP failures in async results

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,5 +1,7 @@
 package api
 
+import "encoding/json"
+
 // Request is the public interface for submitting requests to the async queue.
 // It exposes only the caller-visible fields. Concrete types like RequestMessage,
 // RedisRequest, and PubSubRequest satisfy this interface.
@@ -58,11 +60,71 @@ var (
 	_ Request = (*PubSubRequest)(nil)
 )
 
-// ResultMessage is the async inference result returned to callers. ID and Payload are
-// JSON fields; Routing and Metadata are infrastructure pass-through (json:"-").
+// ResultMessage is the async inference result returned to callers.
+//
+// Wire-format semantics:
+//   - StatusCode > 0: an HTTP response was received. Payload contains the response body.
+//   - StatusCode == 0: no HTTP response. ErrorCode/ErrorMessage describe the failure.
+//
+// Routing and Metadata are infrastructure pass-through (json:"-").
 type ResultMessage struct {
-	ID       string            `json:"id"`
-	Payload  string            `json:"payload"`
-	Routing  InternalRouting   `json:"-"`
-	Metadata map[string]string `json:"-"`
+	ID           string            `json:"id"`
+	StatusCode   int               `json:"status_code,omitempty"`
+	Payload      string            `json:"payload"`
+	ErrorCode    string            `json:"error_code,omitempty"`
+	ErrorMessage string            `json:"error_message,omitempty"`
+	Routing      InternalRouting   `json:"-"`
+	Metadata     map[string]string `json:"-"`
+}
+
+// Error codes for non-HTTP failures surfaced in ResultMessage.ErrorCode.
+// These are result-level codes describing why a request could not be completed.
+const (
+	ErrCodeDeadlineExceeded = "DEADLINE_EXCEEDED"
+	ErrCodeGateDropped      = "GATE_DROPPED"
+	ErrCodeGateError        = "GATE_ERROR"
+	ErrCodeInferenceError   = "INFERENCE_ERROR"
+	ErrCodeInvalidRequest   = "INVALID_REQUEST"
+)
+
+// NewErrorResult builds a non-HTTP error ResultMessage.
+// errorCode must be one of the ErrCode* constants; errMsg is a human-readable description.
+// Payload is populated with a JSON error object for backward compatibility with
+// consumers that only read Payload.
+func NewErrorResult(req Request, routing InternalRouting, errorCode, errMsg string) ResultMessage {
+	errorPayload := map[string]string{"error": errMsg}
+	payloadBytes, err := json.Marshal(errorPayload)
+	if err != nil {
+		payloadBytes = []byte(`{"error": "internal error"}`)
+	}
+	return ResultMessage{
+		ID:           req.ReqID(),
+		Payload:      string(payloadBytes),
+		ErrorCode:    errorCode,
+		ErrorMessage: errMsg,
+		Routing:      routing,
+		Metadata:     req.ReqMetadata(),
+	}
+}
+
+// NewHTTPResult builds a ResultMessage for any HTTP response (success or error).
+// statusCode is the actual HTTP status code; responseBody is the raw body.
+func NewHTTPResult(req Request, routing InternalRouting, statusCode int, responseBody []byte) ResultMessage {
+	return ResultMessage{
+		ID:         req.ReqID(),
+		StatusCode: statusCode,
+		Payload:    string(responseBody),
+		Routing:    routing,
+		Metadata:   req.ReqMetadata(),
+	}
+}
+
+// NewGateDroppedResult builds a ResultMessage for a gate-dropped request.
+func NewGateDroppedResult(req Request, routing InternalRouting) ResultMessage {
+	return NewErrorResult(req, routing, ErrCodeGateDropped, "Pool gating dropped request")
+}
+
+// NewDeadlineExceededResult builds a ResultMessage for deadline expiry.
+func NewDeadlineExceededResult(req Request, routing InternalRouting) ResultMessage {
+	return NewErrorResult(req, routing, ErrCodeDeadlineExceeded, "deadline exceeded")
 }

--- a/api/inference_client.go
+++ b/api/inference_client.go
@@ -6,7 +6,12 @@ import "context"
 // This interface allows for pluggable implementations beyond the default HTTP client.
 type InferenceClient interface {
 	// SendRequest sends an inference request to the specified URL with the given headers and payload.
-	// Returns the response body and any error that occurred.
+	// Returns the response body, the HTTP status code, and any error that occurred.
+	//
+	// statusCode is the actual HTTP status code from the upstream response. It is non-zero
+	// whenever an HTTP response was received (including error responses like 4xx/5xx).
+	// A zero statusCode means no HTTP response was obtained (e.g. transport/network failure).
+	//
 	// Errors should implement InferenceError to provide an ErrorCategory via Category().
 	// ErrorCategory determines retry and shedding behavior through its Fatal() and Sheddable() methods:
 	//   - ErrCategoryRateLimit:  retryable, sheddable (e.g. 429)
@@ -16,5 +21,5 @@ type InferenceClient interface {
 	//   - ErrCategoryParse:      not retryable
 	//   - ErrCategoryUnknown:    not retryable
 	// A nil error indicates a successful response.
-	SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) (responseBody []byte, err error)
+	SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) (responseBody []byte, statusCode int, err error)
 }

--- a/api/inference_client.go
+++ b/api/inference_client.go
@@ -2,15 +2,24 @@ package api
 
 import "context"
 
+// InferenceResponse holds the HTTP response from an upstream inference request.
+// StatusCode is non-zero whenever an HTTP response was received (including 4xx/5xx).
+// A zero StatusCode means no HTTP response was obtained (e.g. transport/network failure).
+// Body contains the response body; it may be partial if a read error occurred.
+type InferenceResponse struct {
+	StatusCode int
+	Body       []byte
+}
+
 // InferenceClient defines the interface for sending inference requests.
 // This interface allows for pluggable implementations beyond the default HTTP client.
 type InferenceClient interface {
 	// SendRequest sends an inference request to the specified URL with the given headers and payload.
-	// Returns the response body, the HTTP status code, and any error that occurred.
 	//
-	// statusCode is the actual HTTP status code from the upstream response. It is non-zero
-	// whenever an HTTP response was received (including error responses like 4xx/5xx).
-	// A zero statusCode means no HTTP response was obtained (e.g. transport/network failure).
+	// On success (nil error), the returned *InferenceResponse is always non-nil.
+	// On error, *InferenceResponse may still be non-nil if the upstream sent an HTTP
+	// response (e.g. 4xx/5xx); callers should check resp.StatusCode > 0 to determine
+	// whether an HTTP response was received.
 	//
 	// Errors should implement InferenceError to provide an ErrorCategory via Category().
 	// ErrorCategory determines retry and shedding behavior through its Fatal() and Sheddable() methods:
@@ -20,6 +29,5 @@ type InferenceClient interface {
 	//   - ErrCategoryAuth:       not retryable
 	//   - ErrCategoryParse:      not retryable
 	//   - ErrCategoryUnknown:    not retryable
-	// A nil error indicates a successful response.
-	SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) (responseBody []byte, statusCode int, err error)
+	SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) (*InferenceResponse, error)
 }

--- a/api/inference_error.go
+++ b/api/inference_error.go
@@ -42,6 +42,7 @@ type ClientError struct {
 	Message       string
 	RawError      error         // original error if available
 	RetryAfter    time.Duration // server-specified retry delay from Retry-After header (0 means not set)
+	StatusCode    int           // HTTP status code; 0 means no HTTP response was received
 }
 
 func (e *ClientError) Error() string {

--- a/pkg/asyncworker/http_client.go
+++ b/pkg/asyncworker/http_client.go
@@ -25,10 +25,10 @@ func NewHTTPInferenceClient(client *http.Client) *HTTPInferenceClient {
 }
 
 // SendRequest implements InferenceClient for HTTP-based inference requests.
-func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, error) {
+func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
 	request, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
 	if err != nil {
-		return nil, &asyncapi.ClientError{
+		return nil, 0, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryInvalidReq,
 			Message:       "failed to create request",
 			RawError:      err,
@@ -41,7 +41,7 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 
 	result, err := h.client.Do(request)
 	if err != nil {
-		return nil, &asyncapi.ClientError{
+		return nil, 0, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryUnknown,
 			Message:       "failed to send request",
 			RawError:      err,
@@ -51,44 +51,47 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 
 	body, err := io.ReadAll(result.Body)
 	if err != nil {
-		// Response read errors are retryable as the request may have succeeded
-		return nil, &asyncapi.ClientError{
+		return nil, result.StatusCode, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryServer,
 			Message:       "failed to read response",
 			RawError:      err,
+			StatusCode:    result.StatusCode,
 		}
 	}
 
 	// Check for rate limiting / load shedding (429)
 	if result.StatusCode == 429 {
 		retryAfter, _ := parseRetryAfter(result.Header.Get("Retry-After"))
-		return body, &asyncapi.ClientError{
+		return body, result.StatusCode, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryRateLimit,
 			Message:       fmt.Sprintf("rate limited: status code %d", result.StatusCode),
 			RawError:      nil,
 			RetryAfter:    retryAfter,
+			StatusCode:    result.StatusCode,
 		}
 	}
 
 	// Check for client errors (4xx, non-429)
 	if result.StatusCode >= 400 && result.StatusCode < 500 {
-		return body, &asyncapi.ClientError{
+		return body, result.StatusCode, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryInvalidReq,
 			Message:       fmt.Sprintf("client error: status code %d", result.StatusCode),
 			RawError:      nil,
+			StatusCode:    result.StatusCode,
 		}
 	}
 
 	// Check for server errors (5xx)
 	if result.StatusCode >= 500 && result.StatusCode < 600 {
-		return body, &asyncapi.ClientError{
+		return body, result.StatusCode, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryServer,
 			Message:       fmt.Sprintf("server error: status code %d", result.StatusCode),
 			RawError:      nil,
+			StatusCode:    result.StatusCode,
 		}
 	}
 
-	return body, nil
+	return body, result.StatusCode, nil
 }
 
 // parseRetryAfter parses a Retry-After header value, which can be either

--- a/pkg/asyncworker/http_client.go
+++ b/pkg/asyncworker/http_client.go
@@ -25,10 +25,10 @@ func NewHTTPInferenceClient(client *http.Client) *HTTPInferenceClient {
 }
 
 // SendRequest implements InferenceClient for HTTP-based inference requests.
-func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, headers map[string]string, payload []byte) (*asyncapi.InferenceResponse, error) {
 	request, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
 	if err != nil {
-		return nil, 0, &asyncapi.ClientError{
+		return nil, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryInvalidReq,
 			Message:       "failed to create request",
 			RawError:      err,
@@ -41,7 +41,7 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 
 	result, err := h.client.Do(request)
 	if err != nil {
-		return nil, 0, &asyncapi.ClientError{
+		return nil, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryUnknown,
 			Message:       "failed to send request",
 			RawError:      err,
@@ -51,7 +51,7 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 
 	body, err := io.ReadAll(result.Body)
 	if err != nil {
-		return nil, result.StatusCode, &asyncapi.ClientError{
+		return &asyncapi.InferenceResponse{StatusCode: result.StatusCode, Body: body}, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryServer,
 			Message:       "failed to read response",
 			RawError:      err,
@@ -59,39 +59,35 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 		}
 	}
 
-	// Check for rate limiting / load shedding (429)
+	resp := &asyncapi.InferenceResponse{StatusCode: result.StatusCode, Body: body}
+
 	if result.StatusCode == 429 {
 		retryAfter, _ := parseRetryAfter(result.Header.Get("Retry-After"))
-		return body, result.StatusCode, &asyncapi.ClientError{
+		return resp, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryRateLimit,
 			Message:       fmt.Sprintf("rate limited: status code %d", result.StatusCode),
-			RawError:      nil,
 			RetryAfter:    retryAfter,
 			StatusCode:    result.StatusCode,
 		}
 	}
 
-	// Check for client errors (4xx, non-429)
 	if result.StatusCode >= 400 && result.StatusCode < 500 {
-		return body, result.StatusCode, &asyncapi.ClientError{
+		return resp, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryInvalidReq,
 			Message:       fmt.Sprintf("client error: status code %d", result.StatusCode),
-			RawError:      nil,
 			StatusCode:    result.StatusCode,
 		}
 	}
 
-	// Check for server errors (5xx)
 	if result.StatusCode >= 500 && result.StatusCode < 600 {
-		return body, result.StatusCode, &asyncapi.ClientError{
+		return resp, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryServer,
 			Message:       fmt.Sprintf("server error: status code %d", result.StatusCode),
-			RawError:      nil,
 			StatusCode:    result.StatusCode,
 		}
 	}
 
-	return body, result.StatusCode, nil
+	return resp, nil
 }
 
 // parseRetryAfter parses a Retry-After header value, which can be either

--- a/pkg/asyncworker/http_client_test.go
+++ b/pkg/asyncworker/http_client_test.go
@@ -23,12 +23,15 @@ func TestSendRequest_success(t *testing.T) {
 		}, nil
 	}))
 
-	got, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	got, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if string(got) != body {
 		t.Errorf("body = %q, want %q", string(got), body)
+	}
+	if sc != http.StatusOK {
+		t.Errorf("statusCode = %d, want %d", sc, http.StatusOK)
 	}
 }
 
@@ -47,7 +50,7 @@ func TestSendRequest_headersForwarded(t *testing.T) {
 		"X-Custom":     "value1",
 		"Content-Type": "application/json",
 	}
-	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", headers, []byte(`{}`))
+	_, _, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", headers, []byte(`{}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -68,7 +71,7 @@ func TestSendRequest_rateLimitWithoutRetryAfter(t *testing.T) {
 		}, nil
 	}))
 
-	body, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	body, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 429 response")
 	}
@@ -78,6 +81,12 @@ func TestSendRequest_rateLimitWithoutRetryAfter(t *testing.T) {
 	}
 	if ce.ErrorCategory != asyncapi.ErrCategoryRateLimit {
 		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryRateLimit)
+	}
+	if ce.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want %d", ce.StatusCode, http.StatusTooManyRequests)
+	}
+	if sc != http.StatusTooManyRequests {
+		t.Errorf("returned statusCode = %d, want %d", sc, http.StatusTooManyRequests)
 	}
 	if ce.RetryAfter != 0 {
 		t.Errorf("RetryAfter = %v, want 0 (no header)", ce.RetryAfter)
@@ -98,7 +107,7 @@ func TestSendRequest_rateLimitWithRetryAfter(t *testing.T) {
 		}, nil
 	}))
 
-	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	_, _, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 429 response")
 	}
@@ -120,7 +129,7 @@ func TestSendRequest_clientError(t *testing.T) {
 		}, nil
 	}))
 
-	body, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	body, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 400 response")
 	}
@@ -130,6 +139,12 @@ func TestSendRequest_clientError(t *testing.T) {
 	}
 	if ce.ErrorCategory != asyncapi.ErrCategoryInvalidReq {
 		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryInvalidReq)
+	}
+	if ce.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", ce.StatusCode, http.StatusBadRequest)
+	}
+	if sc != http.StatusBadRequest {
+		t.Errorf("returned statusCode = %d, want %d", sc, http.StatusBadRequest)
 	}
 	if len(body) == 0 {
 		t.Error("expected response body to be returned with 4xx error")
@@ -145,7 +160,7 @@ func TestSendRequest_serverError(t *testing.T) {
 		}, nil
 	}))
 
-	body, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	body, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 500 response")
 	}
@@ -155,6 +170,12 @@ func TestSendRequest_serverError(t *testing.T) {
 	}
 	if ce.ErrorCategory != asyncapi.ErrCategoryServer {
 		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryServer)
+	}
+	if ce.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", ce.StatusCode, http.StatusInternalServerError)
+	}
+	if sc != http.StatusInternalServerError {
+		t.Errorf("returned statusCode = %d, want %d", sc, http.StatusInternalServerError)
 	}
 	if len(body) == 0 {
 		t.Error("expected response body to be returned with 5xx error")
@@ -166,7 +187,7 @@ func TestSendRequest_transportError(t *testing.T) {
 		return nil, fmt.Errorf("connection refused")
 	}))
 
-	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	_, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for transport failure")
 	}
@@ -177,6 +198,12 @@ func TestSendRequest_transportError(t *testing.T) {
 	if ce.ErrorCategory != asyncapi.ErrCategoryUnknown {
 		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryUnknown)
 	}
+	if ce.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0 for transport error", ce.StatusCode)
+	}
+	if sc != 0 {
+		t.Errorf("returned statusCode = %d, want 0 for transport error", sc)
+	}
 }
 
 func TestSendRequest_invalidURL(t *testing.T) {
@@ -185,7 +212,7 @@ func TestSendRequest_invalidURL(t *testing.T) {
 		return nil, nil
 	}))
 
-	_, err := client.SendRequest(context.Background(), "://invalid", nil, []byte(`{}`))
+	_, _, err := client.SendRequest(context.Background(), "://invalid", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for invalid URL")
 	}
@@ -207,7 +234,7 @@ func TestSendRequest_contextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := client.SendRequest(ctx, "http://localhost/v1/completions", nil, []byte(`{}`))
+	_, _, err := client.SendRequest(ctx, "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -218,6 +245,40 @@ func TestSendRequest_contextCancellation(t *testing.T) {
 	if ce.ErrorCategory != asyncapi.ErrCategoryUnknown {
 		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryUnknown)
 	}
+}
+
+func TestSendRequest_bodyReadFailurePreservesStatusCode(t *testing.T) {
+	client := NewHTTPInferenceClient(NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(&failReader{}),
+			Header:     make(http.Header),
+		}, nil
+	}))
+
+	_, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error for body read failure")
+	}
+	var ce *asyncapi.ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ClientError, got %T", err)
+	}
+	if ce.ErrorCategory != asyncapi.ErrCategoryServer {
+		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryServer)
+	}
+	if sc != http.StatusOK {
+		t.Errorf("returned statusCode = %d, want %d (response was received)", sc, http.StatusOK)
+	}
+	if ce.StatusCode != http.StatusOK {
+		t.Errorf("ClientError.StatusCode = %d, want %d", ce.StatusCode, http.StatusOK)
+	}
+}
+
+type failReader struct{}
+
+func (f *failReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("simulated read error")
 }
 
 func TestNewHTTPInferenceClient(t *testing.T) {

--- a/pkg/asyncworker/http_client_test.go
+++ b/pkg/asyncworker/http_client_test.go
@@ -23,15 +23,15 @@ func TestSendRequest_success(t *testing.T) {
 		}, nil
 	}))
 
-	got, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	resp, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(got) != body {
-		t.Errorf("body = %q, want %q", string(got), body)
+	if string(resp.Body) != body {
+		t.Errorf("body = %q, want %q", string(resp.Body), body)
 	}
-	if sc != http.StatusOK {
-		t.Errorf("statusCode = %d, want %d", sc, http.StatusOK)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("statusCode = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestSendRequest_headersForwarded(t *testing.T) {
 		"X-Custom":     "value1",
 		"Content-Type": "application/json",
 	}
-	_, _, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", headers, []byte(`{}`))
+	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", headers, []byte(`{}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestSendRequest_rateLimitWithoutRetryAfter(t *testing.T) {
 		}, nil
 	}))
 
-	body, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	resp, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 429 response")
 	}
@@ -85,14 +85,14 @@ func TestSendRequest_rateLimitWithoutRetryAfter(t *testing.T) {
 	if ce.StatusCode != http.StatusTooManyRequests {
 		t.Errorf("StatusCode = %d, want %d", ce.StatusCode, http.StatusTooManyRequests)
 	}
-	if sc != http.StatusTooManyRequests {
-		t.Errorf("returned statusCode = %d, want %d", sc, http.StatusTooManyRequests)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("returned statusCode = %d, want %d", resp.StatusCode, http.StatusTooManyRequests)
 	}
 	if ce.RetryAfter != 0 {
 		t.Errorf("RetryAfter = %v, want 0 (no header)", ce.RetryAfter)
 	}
-	if string(body) != respBody {
-		t.Errorf("body = %q, want %q", string(body), respBody)
+	if string(resp.Body) != respBody {
+		t.Errorf("body = %q, want %q", string(resp.Body), respBody)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestSendRequest_rateLimitWithRetryAfter(t *testing.T) {
 		}, nil
 	}))
 
-	_, _, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 429 response")
 	}
@@ -129,7 +129,7 @@ func TestSendRequest_clientError(t *testing.T) {
 		}, nil
 	}))
 
-	body, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	resp, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 400 response")
 	}
@@ -143,10 +143,10 @@ func TestSendRequest_clientError(t *testing.T) {
 	if ce.StatusCode != http.StatusBadRequest {
 		t.Errorf("StatusCode = %d, want %d", ce.StatusCode, http.StatusBadRequest)
 	}
-	if sc != http.StatusBadRequest {
-		t.Errorf("returned statusCode = %d, want %d", sc, http.StatusBadRequest)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("returned statusCode = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
-	if len(body) == 0 {
+	if len(resp.Body) == 0 {
 		t.Error("expected response body to be returned with 4xx error")
 	}
 }
@@ -160,7 +160,7 @@ func TestSendRequest_serverError(t *testing.T) {
 		}, nil
 	}))
 
-	body, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	resp, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 500 response")
 	}
@@ -174,10 +174,10 @@ func TestSendRequest_serverError(t *testing.T) {
 	if ce.StatusCode != http.StatusInternalServerError {
 		t.Errorf("StatusCode = %d, want %d", ce.StatusCode, http.StatusInternalServerError)
 	}
-	if sc != http.StatusInternalServerError {
-		t.Errorf("returned statusCode = %d, want %d", sc, http.StatusInternalServerError)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("returned statusCode = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
 	}
-	if len(body) == 0 {
+	if len(resp.Body) == 0 {
 		t.Error("expected response body to be returned with 5xx error")
 	}
 }
@@ -187,7 +187,7 @@ func TestSendRequest_transportError(t *testing.T) {
 		return nil, fmt.Errorf("connection refused")
 	}))
 
-	_, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	resp, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for transport failure")
 	}
@@ -201,8 +201,8 @@ func TestSendRequest_transportError(t *testing.T) {
 	if ce.StatusCode != 0 {
 		t.Errorf("StatusCode = %d, want 0 for transport error", ce.StatusCode)
 	}
-	if sc != 0 {
-		t.Errorf("returned statusCode = %d, want 0 for transport error", sc)
+	if resp != nil {
+		t.Errorf("resp = %+v, want nil for transport error", resp)
 	}
 }
 
@@ -212,7 +212,7 @@ func TestSendRequest_invalidURL(t *testing.T) {
 		return nil, nil
 	}))
 
-	_, _, err := client.SendRequest(context.Background(), "://invalid", nil, []byte(`{}`))
+	_, err := client.SendRequest(context.Background(), "://invalid", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for invalid URL")
 	}
@@ -234,7 +234,7 @@ func TestSendRequest_contextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, err := client.SendRequest(ctx, "http://localhost/v1/completions", nil, []byte(`{}`))
+	_, err := client.SendRequest(ctx, "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -256,7 +256,7 @@ func TestSendRequest_bodyReadFailurePreservesStatusCode(t *testing.T) {
 		}, nil
 	}))
 
-	_, sc, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	resp, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
 	if err == nil {
 		t.Fatal("expected error for body read failure")
 	}
@@ -267,8 +267,11 @@ func TestSendRequest_bodyReadFailurePreservesStatusCode(t *testing.T) {
 	if ce.ErrorCategory != asyncapi.ErrCategoryServer {
 		t.Errorf("category = %s, want %s", ce.ErrorCategory, asyncapi.ErrCategoryServer)
 	}
-	if sc != http.StatusOK {
-		t.Errorf("returned statusCode = %d, want %d (response was received)", sc, http.StatusOK)
+	if resp == nil {
+		t.Fatal("expected non-nil response when HTTP response was received")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("returned statusCode = %d, want %d (response was received)", resp.StatusCode, http.StatusOK)
 	}
 	if ce.StatusCode != http.StatusOK {
 		t.Errorf("ClientError.StatusCode = %d, want %d", ce.StatusCode, http.StatusOK)

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -112,13 +112,13 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 							if errors.Is(err, context.DeadlineExceeded) || gateCtx.Err() != nil {
 								metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 								select {
-								case resultChannel <- CreateDeadlineExceededResultMessage(msg.PublicRequest, msg.InternalRouting):
+								case resultChannel <- asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting):
 								case <-requestCtx.Done():
 								}
 								return
 							}
 							select {
-							case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Pool gating error: %s", err.Error())):
+							case resultChannel <- asyncapi.NewErrorResult(msg.PublicRequest, msg.InternalRouting, asyncapi.ErrCodeGateError, fmt.Sprintf("Pool gating error: %s", err.Error())):
 							case <-requestCtx.Done():
 							}
 							return
@@ -133,7 +133,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 							if verdict.Result != nil {
 								resultMsg = *verdict.Result
 							} else {
-								resultMsg = CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, "Pool gating dropped request")
+								resultMsg = asyncapi.NewGateDroppedResult(msg.PublicRequest, msg.InternalRouting)
 							}
 							select {
 							case resultChannel <- resultMsg:
@@ -159,7 +159,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 							case <-gateCtx.Done():
 								metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 								select {
-								case resultChannel <- CreateDeadlineExceededResultMessage(msg.PublicRequest, msg.InternalRouting):
+								case resultChannel <- asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting):
 								case <-requestCtx.Done():
 								}
 								return
@@ -215,7 +215,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						span.SetAttributes(attribute.String(uotel.AttrErrorCategory, string(asyncapi.ErrCategoryInvalidReq)))
 						metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
 						select {
-						case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to transform request body: %s", terr.Error())):
+						case resultChannel <- asyncapi.NewErrorResult(msg.PublicRequest, msg.InternalRouting, asyncapi.ErrCodeInvalidRequest, fmt.Sprintf("Failed to transform request body: %s", terr.Error())):
 						case <-requestCtx.Done():
 						}
 						return
@@ -226,17 +226,18 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 
 					logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
 					inferenceStart := time.Now()
-					responseBody, err := client.SendRequest(reqCtx, msg.RequestURL, sendHeaders, sendPayload)
+					responseBody, statusCode, err := client.SendRequest(reqCtx, msg.RequestURL, sendHeaders, sendPayload)
 					metrics.RecordInferenceLatency(float64(time.Since(inferenceStart).Milliseconds()), queueID, queueName, msg.WorkerPoolID)
 
 					if err == nil {
 						metrics.RecordSuccessfulReq(queueID, queueName, msg.WorkerPoolID)
 						select {
 						case resultChannel <- asyncapi.ResultMessage{
-							ID:       msg.PublicRequest.ReqID(),
-							Payload:  string(responseBody),
-							Routing:  msg.InternalRouting,
-							Metadata: msg.PublicRequest.ReqMetadata(),
+							ID:         msg.PublicRequest.ReqID(),
+							StatusCode: statusCode,
+							Payload:    string(responseBody),
+							Routing:    msg.InternalRouting,
+							Metadata:   msg.PublicRequest.ReqMetadata(),
 						}:
 						case <-requestCtx.Done():
 						}
@@ -260,8 +261,17 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						span.SetStatus(codes.Error, "inference request failed")
 						span.SetAttributes(attribute.String(uotel.AttrErrorCategory, inferenceErrorCategory(err)))
 						metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
+
+						var resultMsg asyncapi.ResultMessage
+						if statusCode > 0 {
+							resultMsg = asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, statusCode, responseBody)
+						} else {
+							resultMsg = asyncapi.NewErrorResult(msg.PublicRequest, msg.InternalRouting,
+								asyncapi.ErrCodeInferenceError,
+								fmt.Sprintf("Failed to send request to inference: %s", err.Error()))
+						}
 						select {
-						case resultChannel <- CreateErrorResultMessage(msg.PublicRequest, msg.InternalRouting, fmt.Sprintf("Failed to send request to inference: %s", err.Error())):
+						case resultChannel <- resultMsg:
 						case <-requestCtx.Done():
 						}
 						return
@@ -276,7 +286,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 					if errors.As(err, &clientErr) {
 						retryAfter = clientErr.RetryAfter
 					}
-					retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter)
+					retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter, statusCode, responseBody)
 				}
 				sendInferenceRequest()
 			}
@@ -297,7 +307,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	if deadline <= 0 {
 		metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- CreateErrorResultMessage(r, msg.InternalRouting, "Failed: deadline is missing or invalid (Unix seconds)."):
+		case resultChannel <- asyncapi.NewErrorResult(r, msg.InternalRouting, asyncapi.ErrCodeInvalidRequest, "Failed: deadline is missing or invalid (Unix seconds)."):
 		case <-ctx.Done():
 		}
 		return nil
@@ -306,7 +316,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	if deadline < time.Now().Unix() {
 		metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- CreateDeadlineExceededResultMessage(r, msg.InternalRouting):
+		case resultChannel <- asyncapi.NewDeadlineExceededResult(r, msg.InternalRouting):
 		case <-ctx.Done():
 		}
 		return nil
@@ -316,7 +326,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	if err != nil {
 		metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- CreateErrorResultMessage(r, msg.InternalRouting, fmt.Sprintf("Failed to marshal message's payload: %s", err.Error())):
+		case resultChannel <- asyncapi.NewErrorResult(r, msg.InternalRouting, asyncapi.ErrCodeInvalidRequest, fmt.Sprintf("Failed to marshal message's payload: %s", err.Error())):
 		case <-ctx.Done():
 		}
 		return nil
@@ -328,7 +338,7 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	if err := transforms.Validate(payloadBytes, r.ReqMetadata(), deadline); err != nil {
 		metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- CreateErrorResultMessage(r, msg.InternalRouting, fmt.Sprintf("Failed to validate request for transform: %s", err.Error())):
+		case resultChannel <- asyncapi.NewErrorResult(r, msg.InternalRouting, asyncapi.ErrCodeInvalidRequest, fmt.Sprintf("Failed to validate request for transform: %s", err.Error())):
 		case <-ctx.Done():
 		}
 		return nil
@@ -337,8 +347,13 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 	return payloadBytes
 }
 
-// If it is not after deadline, just publish again.
-func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration) {
+// retryMessage re-enqueues the request for another attempt, or emits a final
+// result if the deadline cannot accommodate another retry.
+//
+// lastStatusCode and lastResponseBody carry the most recent HTTP response (if any)
+// so that when retries are exhausted the actual HTTP status/body is surfaced
+// rather than a generic "deadline exceeded" non-HTTP error.
+func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration, lastStatusCode int, lastResponseBody []byte) {
 	if msg.PublicRequest == nil {
 		return
 	}
@@ -349,7 +364,7 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	if secondsToDeadline <= 0 {
 		metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- CreateDeadlineExceededResultMessage(msg.PublicRequest, msg.InternalRouting):
+		case resultChannel <- deadlineExhaustedResult(msg, lastStatusCode, lastResponseBody):
 		case <-ctx.Done():
 		}
 		return
@@ -365,7 +380,7 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	if finalDuration >= float64(secondsToDeadline) {
 		metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- CreateDeadlineExceededResultMessage(msg.PublicRequest, msg.InternalRouting):
+		case resultChannel <- deadlineExhaustedResult(msg, lastStatusCode, lastResponseBody):
 		case <-ctx.Done():
 		}
 		return
@@ -382,24 +397,14 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	}
 }
 
-// CreateErrorResultMessage builds a ResultMessage using the public request identity;
-// metadata is read directly from req.ReqMetadata().
-func CreateErrorResultMessage(req asyncapi.Request, routing asyncapi.InternalRouting, errMsg string) asyncapi.ResultMessage {
-	errorPayload := map[string]string{"error": errMsg}
-	payloadBytes, err := json.Marshal(errorPayload)
-	if err != nil {
-		payloadBytes = []byte(`{"error": "internal error"}`)
+// deadlineExhaustedResult returns the appropriate result message when retries
+// are exhausted. If we have a last HTTP response, surface it (preserving the
+// actual status/body). Otherwise emit a non-HTTP deadline-exceeded error.
+func deadlineExhaustedResult(msg pipeline.EmbelishedRequestMessage, lastStatusCode int, lastResponseBody []byte) asyncapi.ResultMessage {
+	if lastStatusCode > 0 {
+		return asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, lastStatusCode, lastResponseBody)
 	}
-	return asyncapi.ResultMessage{
-		ID:       req.ReqID(),
-		Payload:  string(payloadBytes),
-		Routing:  routing,
-		Metadata: req.ReqMetadata(),
-	}
-}
-
-func CreateDeadlineExceededResultMessage(req asyncapi.Request, routing asyncapi.InternalRouting) asyncapi.ResultMessage {
-	return CreateErrorResultMessage(req, routing, "deadline exceeded")
+	return asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting)
 }
 
 // headersWithContentType returns a copy of headers with Content-Type set to

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -110,6 +110,13 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						verdict, err = poolGate.Apply(gateCtx, msg.InternalRequest, &poolReleases)
 						if err != nil {
 							if errors.Is(err, context.DeadlineExceeded) || gateCtx.Err() != nil {
+								if requestCtx.Err() != nil && !errors.Is(requestCtx.Err(), context.DeadlineExceeded) {
+									retryChannel <- pipeline.RetryMessage{
+										EmbelishedRequestMessage: msg,
+										BackoffDurationSeconds:   0,
+									}
+									return
+								}
 								metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 								select {
 								case resultChannel <- asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting):
@@ -157,6 +164,13 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						if verdict.Action == pipeline.ActionWait {
 							select {
 							case <-gateCtx.Done():
+								if requestCtx.Err() != nil && !errors.Is(requestCtx.Err(), context.DeadlineExceeded) {
+									retryChannel <- pipeline.RetryMessage{
+										EmbelishedRequestMessage: msg,
+										BackoffDurationSeconds:   0,
+									}
+									return
+								}
 								metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 								select {
 								case resultChannel <- asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting):
@@ -226,19 +240,13 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 
 					logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
 					inferenceStart := time.Now()
-					responseBody, statusCode, err := client.SendRequest(reqCtx, msg.RequestURL, sendHeaders, sendPayload)
+					resp, err := client.SendRequest(reqCtx, msg.RequestURL, sendHeaders, sendPayload)
 					metrics.RecordInferenceLatency(float64(time.Since(inferenceStart).Milliseconds()), queueID, queueName, msg.WorkerPoolID)
 
 					if err == nil {
 						metrics.RecordSuccessfulReq(queueID, queueName, msg.WorkerPoolID)
 						select {
-						case resultChannel <- asyncapi.ResultMessage{
-							ID:         msg.PublicRequest.ReqID(),
-							StatusCode: statusCode,
-							Payload:    string(responseBody),
-							Routing:    msg.InternalRouting,
-							Metadata:   msg.PublicRequest.ReqMetadata(),
-						}:
+						case resultChannel <- asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, resp.StatusCode, resp.Body):
 						case <-requestCtx.Done():
 						}
 						return
@@ -263,8 +271,8 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						metrics.RecordFailedReq(queueID, queueName, msg.WorkerPoolID)
 
 						var resultMsg asyncapi.ResultMessage
-						if statusCode > 0 {
-							resultMsg = asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, statusCode, responseBody)
+						if resp != nil && resp.StatusCode > 0 {
+							resultMsg = asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, resp.StatusCode, resp.Body)
 						} else {
 							resultMsg = asyncapi.NewErrorResult(msg.PublicRequest, msg.InternalRouting,
 								asyncapi.ErrCodeInferenceError,
@@ -286,7 +294,11 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 					if errors.As(err, &clientErr) {
 						retryAfter = clientErr.RetryAfter
 					}
-					retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter, statusCode, responseBody)
+					var lastResp asyncapi.InferenceResponse
+					if resp != nil {
+						lastResp = *resp
+					}
+					retryMessage(requestCtx, msg, retryChannel, resultChannel, retryAfter, lastResp)
 				}
 				sendInferenceRequest()
 			}
@@ -350,10 +362,10 @@ func validateAndMarshal(ctx context.Context, resultChannel chan asyncapi.ResultM
 // retryMessage re-enqueues the request for another attempt, or emits a final
 // result if the deadline cannot accommodate another retry.
 //
-// lastStatusCode and lastResponseBody carry the most recent HTTP response (if any)
-// so that when retries are exhausted the actual HTTP status/body is surfaced
-// rather than a generic "deadline exceeded" non-HTTP error.
-func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration, lastStatusCode int, lastResponseBody []byte) {
+// lastResp carries the most recent HTTP response (if any) so that when retries
+// are exhausted the actual HTTP status/body is surfaced rather than a generic
+// "deadline exceeded" non-HTTP error.
+func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, retryChannel chan pipeline.RetryMessage, resultChannel chan asyncapi.ResultMessage, retryAfter time.Duration, lastResp asyncapi.InferenceResponse) {
 	if msg.PublicRequest == nil {
 		return
 	}
@@ -364,7 +376,7 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	if secondsToDeadline <= 0 {
 		metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- deadlineExhaustedResult(msg, lastStatusCode, lastResponseBody):
+		case resultChannel <- deadlineExhaustedResult(msg, lastResp):
 		case <-ctx.Done():
 		}
 		return
@@ -380,7 +392,7 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	if finalDuration >= float64(secondsToDeadline) {
 		metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
 		select {
-		case resultChannel <- deadlineExhaustedResult(msg, lastStatusCode, lastResponseBody):
+		case resultChannel <- deadlineExhaustedResult(msg, lastResp):
 		case <-ctx.Done():
 		}
 		return
@@ -400,9 +412,9 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 // deadlineExhaustedResult returns the appropriate result message when retries
 // are exhausted. If we have a last HTTP response, surface it (preserving the
 // actual status/body). Otherwise emit a non-HTTP deadline-exceeded error.
-func deadlineExhaustedResult(msg pipeline.EmbelishedRequestMessage, lastStatusCode int, lastResponseBody []byte) asyncapi.ResultMessage {
-	if lastStatusCode > 0 {
-		return asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, lastStatusCode, lastResponseBody)
+func deadlineExhaustedResult(msg pipeline.EmbelishedRequestMessage, lastResp asyncapi.InferenceResponse) asyncapi.ResultMessage {
+	if lastResp.StatusCode > 0 {
+		return asyncapi.NewHTTPResult(msg.PublicRequest, msg.InternalRouting, lastResp.StatusCode, lastResp.Body)
 	}
 	return asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting)
 }

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -63,7 +63,7 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 		Created:  time.Now().Unix(),
 		Deadline: time.Now().Add(-10 * time.Second).Unix(),
 	}, "", map[string]string{})
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 0, nil)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, asyncapi.InferenceResponse{})
 	if len(retryChannel) > 0 {
 		t.Errorf("Message that its deadline passed should not be retried. Got a message in the retry channel")
 		return
@@ -99,7 +99,7 @@ func TestRetryMessage_retry(t *testing.T) {
 		Created:  time.Now().Unix(),
 		Deadline: time.Now().Add(10 * time.Second).Unix(),
 	}, "", map[string]string{})
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 0, nil)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, asyncapi.InferenceResponse{})
 	if len(resultChannel) > 0 {
 		t.Errorf("Should not have any messages in the result channel")
 		return
@@ -448,7 +448,7 @@ func TestRetryMessage_deadlineExact(t *testing.T) {
 		Created:  now,
 		Deadline: now, // same second → no time left to retry
 	}, "", nil)
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 0, nil)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, asyncapi.InferenceResponse{})
 	if len(retryChannel) > 0 {
 		t.Errorf("secondsToDeadline==0 should not produce a retry")
 	}
@@ -509,7 +509,7 @@ func TestRetryMessage_retryAfterHonored(t *testing.T) {
 
 	// Server says wait 30s; expBackoff for retry 1 would be ~[1,2) seconds,
 	// so the Retry-After value should win.
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, 0, nil)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, asyncapi.InferenceResponse{})
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
@@ -530,7 +530,7 @@ func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
 
 	// Server says wait 1s, but expBackoff at retry 5 is much larger.
 	// expBackoff should win.
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 1*time.Second, 0, nil)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 1*time.Second, asyncapi.InferenceResponse{})
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
@@ -550,7 +550,7 @@ func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
 	}, "", nil)
 
 	// Server says wait 30s, but deadline is only 5s away → deadline exceeded.
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, 0, nil)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, asyncapi.InferenceResponse{})
 	if len(retryChannel) > 0 {
 		t.Errorf("should not retry when Retry-After exceeds deadline")
 	}
@@ -575,7 +575,7 @@ func TestRetryMessage_deadlineExhaustedPreservesHTTPResponse(t *testing.T) {
 	}, "", nil)
 
 	lastBody := []byte(`{"error":"too many requests"}`)
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 429, lastBody)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, asyncapi.InferenceResponse{StatusCode: 429, Body: lastBody})
 	if len(retryChannel) > 0 {
 		t.Errorf("should not retry past deadline")
 	}
@@ -679,7 +679,7 @@ func TestRetryMessage_cancelledCtxDoesNotBlock(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		retryMessage(ctx, msg, retryChannel, resultChannel, 0, 0, nil)
+		retryMessage(ctx, msg, retryChannel, resultChannel, 0, asyncapi.InferenceResponse{})
 		close(done)
 	}()
 
@@ -1857,6 +1857,130 @@ func TestWorker_DrainWithCancelledRequestCtx(t *testing.T) {
 	}
 }
 
+type blockingPoolGate struct {
+	unblock chan struct{}
+}
+
+func (g *blockingPoolGate) Budget(ctx context.Context) float64 {
+	return 1.0
+}
+
+func (g *blockingPoolGate) Apply(ctx context.Context, _ *asyncapi.InternalRequest, _ *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
+	select {
+	case <-ctx.Done():
+		return pipeline.Verdict{}, ctx.Err()
+	case <-g.unblock:
+		return pipeline.Continue(), nil
+	}
+}
+
+type waitingPoolGate struct{}
+
+func (g *waitingPoolGate) Budget(ctx context.Context) float64 {
+	return 1.0
+}
+
+func (g *waitingPoolGate) Apply(ctx context.Context, _ *asyncapi.InternalRequest, _ *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
+	return pipeline.Wait(), nil
+}
+
+func TestWorker_PoolGateShutdownReenqueues(t *testing.T) {
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	gate := &blockingPoolGate{unblock: make(chan struct{})}
+
+	done := make(chan struct{})
+	go func() {
+		WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+		close(done)
+	}()
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       "gate-shutdown-test",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(30 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	// Let the worker block in poolGate.Apply, then cancel (simulating shutdown).
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker did not exit after shutdown cancel")
+	}
+
+	if len(resultChannel) > 0 {
+		t.Errorf("expected no result (should re-enqueue on shutdown), got a result")
+	}
+	if len(retryChannel) != 1 {
+		t.Fatalf("expected message to be re-enqueued, retry channel len = %d", len(retryChannel))
+	}
+	retryMsg := <-retryChannel
+	if retryMsg.PublicRequest.ReqID() != "gate-shutdown-test" {
+		t.Errorf("re-enqueued wrong message: got ID %q", retryMsg.PublicRequest.ReqID())
+	}
+}
+
+func TestWorker_PoolGateActionWaitShutdownReenqueues(t *testing.T) {
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	gate := &waitingPoolGate{}
+
+	done := make(chan struct{})
+	go func() {
+		WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+		close(done)
+	}()
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       "gate-wait-shutdown-test",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(30 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	// Let the worker enter the ActionWait polling loop, then cancel (simulating shutdown).
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker did not exit after ActionWait shutdown cancel")
+	}
+
+	if len(resultChannel) > 0 {
+		t.Errorf("expected no result (should re-enqueue on shutdown), got a result")
+	}
+	if len(retryChannel) != 1 {
+		t.Fatalf("expected message to be re-enqueued, retry channel len = %d", len(retryChannel))
+	}
+	retryMsg := <-retryChannel
+	if retryMsg.PublicRequest.ReqID() != "gate-wait-shutdown-test" {
+		t.Errorf("re-enqueued wrong message: got ID %q", retryMsg.PublicRequest.ReqID())
+	}
+}
+
 type raceMockPoolGate struct {
 	releaseCalled *int32
 }
@@ -1934,8 +2058,14 @@ func TestWorker_QueueGateAndPoolGateRace(t *testing.T) {
 	}()
 	wg.Wait()
 
-	// Wait for worker goroutine poolReleases to finish executing
-	time.Sleep(50 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&queueReleaseCalled) < 1 || atomic.LoadInt32(&poolReleaseCalled) < 1 {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for releases: queue=%d pool=%d",
+				atomic.LoadInt32(&queueReleaseCalled), atomic.LoadInt32(&poolReleaseCalled))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	if atomic.LoadInt32(&queueReleaseCalled) != 1 {
 		t.Errorf("expected queue release to be called exactly once, got %d", queueReleaseCalled)

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -63,7 +63,7 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 		Created:  time.Now().Unix(),
 		Deadline: time.Now().Add(-10 * time.Second).Unix(),
 	}, "", map[string]string{})
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 0, nil)
 	if len(retryChannel) > 0 {
 		t.Errorf("Message that its deadline passed should not be retried. Got a message in the retry channel")
 		return
@@ -74,6 +74,15 @@ func TestRetryMessage_deadlinePassed(t *testing.T) {
 
 	}
 	result := <-resultChannel
+	if result.StatusCode != 0 {
+		t.Errorf("Expected StatusCode 0 for deadline exceeded, got %d", result.StatusCode)
+	}
+	if result.ErrorCode != asyncapi.ErrCodeDeadlineExceeded {
+		t.Errorf("Expected ErrorCode %q, got %q", asyncapi.ErrCodeDeadlineExceeded, result.ErrorCode)
+	}
+	if result.ErrorMessage != "deadline exceeded" {
+		t.Errorf("Expected ErrorMessage 'deadline exceeded', got %q", result.ErrorMessage)
+	}
 	var resultMap map[string]any
 	json.Unmarshal([]byte(result.Payload), &resultMap) // nolint:errcheck
 	if resultMap["error"] != "deadline exceeded" {
@@ -90,7 +99,7 @@ func TestRetryMessage_retry(t *testing.T) {
 		Created:  time.Now().Unix(),
 		Deadline: time.Now().Add(10 * time.Second).Unix(),
 	}, "", map[string]string{})
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 0, nil)
 	if len(resultChannel) > 0 {
 		t.Errorf("Should not have any messages in the result channel")
 		return
@@ -190,8 +199,51 @@ func TestSuccessfulRequest(t *testing.T) {
 		if r.ID != msgId {
 			t.Errorf("Expected result message id to be %s, got %s", msgId, r.ID)
 		}
+		if r.StatusCode != http.StatusOK {
+			t.Errorf("Expected StatusCode %d, got %d", http.StatusOK, r.StatusCode)
+		}
 	}
 
+}
+
+func TestSuccessfulRequest_PreservesActualStatusCode(t *testing.T) {
+	msgId := "201-created"
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"id":"new-resource"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       msgId,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	select {
+	case <-retryChannel:
+		t.Errorf("should not retry a 2xx response")
+	case r := <-resultChannel:
+		if r.ID != msgId {
+			t.Errorf("Expected result ID %s, got %s", msgId, r.ID)
+		}
+		if r.StatusCode != http.StatusCreated {
+			t.Errorf("Expected StatusCode %d (201 Created), got %d", http.StatusCreated, r.StatusCode)
+		}
+		if r.Payload != `{"id":"new-resource"}` {
+			t.Errorf("Expected body preserved, got %q", r.Payload)
+		}
+	}
 }
 
 func TestFatalError_NoRetry(t *testing.T) {
@@ -223,6 +275,15 @@ func TestFatalError_NoRetry(t *testing.T) {
 	case r := <-resultChannel:
 		if r.ID != msgId {
 			t.Errorf("Expected result message id to be %s, got %s", msgId, r.ID)
+		}
+		if r.StatusCode != 0 {
+			t.Errorf("Expected StatusCode 0 for non-HTTP error, got %d", r.StatusCode)
+		}
+		if r.ErrorCode != asyncapi.ErrCodeInferenceError {
+			t.Errorf("Expected ErrorCode %q, got %q", asyncapi.ErrCodeInferenceError, r.ErrorCode)
+		}
+		if r.ErrorMessage == "" {
+			t.Errorf("Expected non-empty ErrorMessage for non-HTTP error")
 		}
 		var resultMap map[string]any
 		err := json.Unmarshal([]byte(r.Payload), &resultMap)
@@ -387,7 +448,7 @@ func TestRetryMessage_deadlineExact(t *testing.T) {
 		Created:  now,
 		Deadline: now, // same second → no time left to retry
 	}, "", nil)
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 0, nil)
 	if len(retryChannel) > 0 {
 		t.Errorf("secondsToDeadline==0 should not produce a retry")
 	}
@@ -448,7 +509,7 @@ func TestRetryMessage_retryAfterHonored(t *testing.T) {
 
 	// Server says wait 30s; expBackoff for retry 1 would be ~[1,2) seconds,
 	// so the Retry-After value should win.
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, 0, nil)
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
@@ -469,7 +530,7 @@ func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
 
 	// Server says wait 1s, but expBackoff at retry 5 is much larger.
 	// expBackoff should win.
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 1*time.Second)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 1*time.Second, 0, nil)
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
@@ -489,7 +550,7 @@ func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
 	}, "", nil)
 
 	// Server says wait 30s, but deadline is only 5s away → deadline exceeded.
-	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, 0, nil)
 	if len(retryChannel) > 0 {
 		t.Errorf("should not retry when Retry-After exceeds deadline")
 	}
@@ -501,6 +562,35 @@ func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
 	json.Unmarshal([]byte(result.Payload), &resultMap) // nolint:errcheck
 	if resultMap["error"] != "deadline exceeded" {
 		t.Errorf("expected 'deadline exceeded', got: %s", resultMap["error"])
+	}
+}
+
+func TestRetryMessage_deadlineExhaustedPreservesHTTPResponse(t *testing.T) {
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	msg := newEmb(asyncapi.RequestMessage{
+		ID:       "retry-exhausted-http",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(-1 * time.Second).Unix(),
+	}, "", nil)
+
+	lastBody := []byte(`{"error":"too many requests"}`)
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 0, 429, lastBody)
+	if len(retryChannel) > 0 {
+		t.Errorf("should not retry past deadline")
+	}
+	if len(resultChannel) != 1 {
+		t.Fatalf("expected one result, got %d", len(resultChannel))
+	}
+	result := <-resultChannel
+	if result.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", result.StatusCode)
+	}
+	if result.Payload != string(lastBody) {
+		t.Errorf("Payload = %q, want %q", result.Payload, string(lastBody))
+	}
+	if result.ErrorCode != "" {
+		t.Errorf("ErrorCode should be empty for HTTP error result, got %q", result.ErrorCode)
 	}
 }
 
@@ -589,7 +679,7 @@ func TestRetryMessage_cancelledCtxDoesNotBlock(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		retryMessage(ctx, msg, retryChannel, resultChannel, 0)
+		retryMessage(ctx, msg, retryChannel, resultChannel, 0, 0, nil)
 		close(done)
 	}()
 
@@ -676,9 +766,14 @@ func TestClientError_NoRetry(t *testing.T) {
 		if r.ID != msgId {
 			t.Errorf("Expected result message id to be %s, got %s", msgId, r.ID)
 		}
-		expectedPayload := `{"error":"Failed to send request to inference: INVALID_REQ: client error: status code 400"}`
-		if r.Payload != expectedPayload {
-			t.Errorf("Expected payload to be %s, got %s", expectedPayload, r.Payload)
+		if r.StatusCode != http.StatusBadRequest {
+			t.Errorf("Expected StatusCode 400, got %d", r.StatusCode)
+		}
+		if r.Payload != errorBody {
+			t.Errorf("Expected payload to be response body %q, got %q", errorBody, r.Payload)
+		}
+		if r.ErrorCode != "" {
+			t.Errorf("Expected empty ErrorCode for HTTP error, got %q", r.ErrorCode)
 		}
 	case <-time.After(time.Second):
 		t.Errorf("Timeout waiting for result")

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -527,10 +527,7 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 			if verdict.Result != nil {
 				resultMsg = *verdict.Result
 			} else {
-				resultMsg = api.ResultMessage{
-					ID:      body.ID,
-					Payload: `{"status": "dropped"}`,
-				}
+				resultMsg = api.NewGateDroppedResult(&body, ir.InternalRouting)
 			}
 			resultMsg.Routing = ir.InternalRouting
 			r.resultChannel <- resultMsg

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -526,10 +526,10 @@ func (r *PubSubMQFlow) processMessages(ctx context.Context, receive receiveFunc,
 			var resultMsg api.ResultMessage
 			if verdict.Result != nil {
 				resultMsg = *verdict.Result
+				resultMsg.Routing = ir.InternalRouting
 			} else {
 				resultMsg = api.NewGateDroppedResult(&body, ir.InternalRouting)
 			}
-			resultMsg.Routing = ir.InternalRouting
 			r.resultChannel <- resultMsg
 
 			// Wait for the result worker to finish publishing and signal true

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -130,6 +130,54 @@ func TestMarshalResultMessage_Fallback(t *testing.T) {
 	}
 }
 
+func TestMarshalResultMessage_StructuredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  api.ResultMessage
+	}{
+		{
+			name: "HTTP success preserves status_code",
+			msg:  api.ResultMessage{ID: "http-ok", StatusCode: 200, Payload: `{"result":"ok"}`},
+		},
+		{
+			name: "HTTP error preserves status_code and body",
+			msg:  api.ResultMessage{ID: "http-err", StatusCode: 429, Payload: `{"error":"rate limited"}`},
+		},
+		{
+			name: "non-HTTP error preserves error_code and error_message",
+			msg:  api.ResultMessage{ID: "non-http", Payload: `{"error":"deadline exceeded"}`, ErrorCode: api.ErrCodeDeadlineExceeded, ErrorMessage: "deadline exceeded"},
+		},
+		{
+			name: "gate drop preserves error_code",
+			msg:  api.ResultMessage{ID: "dropped", Payload: `{"error":"Pool gating dropped request"}`, ErrorCode: api.ErrCodeGateDropped, ErrorMessage: "Pool gating dropped request"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serialized := marshalResultMessage(tt.msg)
+			var got api.ResultMessage
+			if err := json.Unmarshal([]byte(serialized), &got); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+			if got.ID != tt.msg.ID {
+				t.Errorf("ID = %q, want %q", got.ID, tt.msg.ID)
+			}
+			if got.StatusCode != tt.msg.StatusCode {
+				t.Errorf("StatusCode = %d, want %d", got.StatusCode, tt.msg.StatusCode)
+			}
+			if got.Payload != tt.msg.Payload {
+				t.Errorf("Payload = %q, want %q", got.Payload, tt.msg.Payload)
+			}
+			if got.ErrorCode != tt.msg.ErrorCode {
+				t.Errorf("ErrorCode = %q, want %q", got.ErrorCode, tt.msg.ErrorCode)
+			}
+			if got.ErrorMessage != tt.msg.ErrorMessage {
+				t.Errorf("ErrorMessage = %q, want %q", got.ErrorMessage, tt.msg.ErrorMessage)
+			}
+		})
+	}
+}
+
 func TestPubsubResultWorker_ContextCancellation(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -483,10 +483,7 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			if verdict.Result != nil {
 				r.resultChannel <- *verdict.Result
 			} else {
-				r.resultChannel <- api.ResultMessage{
-					ID:      rview.ReqID(),
-					Payload: `{"status": "dropped"}`,
-				}
+				r.resultChannel <- api.NewGateDroppedResult(rview, ir.InternalRouting)
 			}
 			continue
 		}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -481,7 +481,9 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		if verdict.Action == pipeline.ActionDrop {
 			metrics.RecordGateDecision(metrics.ReasonDropped, queueID, queueName, poolName)
 			if verdict.Result != nil {
-				r.resultChannel <- *verdict.Result
+				resultMsg := *verdict.Result
+				resultMsg.Routing = ir.InternalRouting
+				r.resultChannel <- resultMsg
 			} else {
 				r.resultChannel <- api.NewGateDroppedResult(rview, ir.InternalRouting)
 			}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -453,6 +453,62 @@ func TestSortedSetFlow_ResultFIFO(t *testing.T) {
 	}
 }
 
+func TestSortedSetFlow_ResultStructuredFields(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "structured-result-queue"
+	flow := &RedisSortedSetFlow{
+		defaultResultQueueName: queue,
+		rdb:                    rdb,
+		resultChannel:          make(chan api.ResultMessage, 4),
+		pollInterval:           50 * time.Millisecond,
+		batchSize:              10,
+		gate:                   noopGate(),
+	}
+
+	messages := []api.ResultMessage{
+		{ID: "success", StatusCode: 201, Payload: `{"id":"new"}`},
+		{ID: "http-err", StatusCode: 502, Payload: `{"error":"bad gateway"}`},
+		{ID: "deadline", Payload: `{"error":"deadline exceeded"}`, ErrorCode: api.ErrCodeDeadlineExceeded, ErrorMessage: "deadline exceeded"},
+		{ID: "gate-drop", Payload: `{"error":"Pool gating dropped request"}`, ErrorCode: api.ErrCodeGateDropped, ErrorMessage: "Pool gating dropped request"},
+	}
+	for _, m := range messages {
+		flow.resultChannel <- m
+	}
+
+	go flow.resultWorker(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	for _, want := range messages {
+		raw, err := rdb.RPop(ctx, queue).Result()
+		if err != nil {
+			t.Fatalf("RPop error for %s: %v", want.ID, err)
+		}
+		var got api.ResultMessage
+		if err := json.Unmarshal([]byte(raw), &got); err != nil {
+			t.Fatalf("Unmarshal error for %s: %v", want.ID, err)
+		}
+		if got.ID != want.ID {
+			t.Errorf("ID = %q, want %q", got.ID, want.ID)
+		}
+		if got.StatusCode != want.StatusCode {
+			t.Errorf("[%s] StatusCode = %d, want %d", want.ID, got.StatusCode, want.StatusCode)
+		}
+		if got.Payload != want.Payload {
+			t.Errorf("[%s] Payload = %q, want %q", want.ID, got.Payload, want.Payload)
+		}
+		if got.ErrorCode != want.ErrorCode {
+			t.Errorf("[%s] ErrorCode = %q, want %q", want.ID, got.ErrorCode, want.ErrorCode)
+		}
+		if got.ErrorMessage != want.ErrorMessage {
+			t.Errorf("[%s] ErrorMessage = %q, want %q", want.ID, got.ErrorMessage, want.ErrorMessage)
+		}
+	}
+}
+
 func TestSortedSetFlow_ResultBatch(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -480,7 +480,19 @@ func TestSortedSetFlow_ResultStructuredFields(t *testing.T) {
 	}
 
 	go flow.resultWorker(ctx)
-	time.Sleep(200 * time.Millisecond)
+
+	timeout := time.After(2 * time.Second)
+	for {
+		n, err := rdb.LLen(ctx, queue).Result()
+		if err == nil && n >= int64(len(messages)) {
+			break
+		}
+		select {
+		case <-timeout:
+			t.Fatalf("timeout waiting for %d results to be pushed", len(messages))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
 
 	for _, want := range messages {
 		raw, err := rdb.RPop(ctx, queue).Result()

--- a/release-notes.d/unreleased/300.md
+++ b/release-notes.d/unreleased/300.md
@@ -1,0 +1,24 @@
+---
+pr: 300
+url: https://github.com/llm-d-incubation/llm-d-async/pull/300
+author: j-mok-dev
+date: 2026-07-09
+---
+**Breaking:** `ResultMessage` now carries structured result fields so consumers can
+distinguish HTTP successes, HTTP errors, and non-HTTP failures — added `StatusCode`
+(int, non-zero means an HTTP response was received), `ErrorCode` (string, e.g.
+`DEADLINE_EXCEEDED`, `GATE_DROPPED`, `GATE_ERROR`, `INFERENCE_ERROR`,
+`INVALID_REQUEST`), and `ErrorMessage` (string).
+
+Wire-format changes to be aware of:
+- HTTP-error `Payload` now contains the raw upstream response body instead of a
+  wrapped error string.
+- Gate-drop `Payload` changed from `{"status":"dropped"}` to
+  `{"error":"Pool gating dropped request"}` and is now unified across all
+  transports via `NewGateDroppedResult`. Detect gate drops via
+  `ErrorCode == "GATE_DROPPED"` rather than parsing the payload body.
+- Gate-drop results now include `Metadata` (from `req.ReqMetadata()`), which the
+  previous inline construction omitted.
+- `InferenceClient.SendRequest` now returns `(*InferenceResponse, error)`, where
+  `InferenceResponse` has `StatusCode int` and `Body []byte` fields (previously
+  `([]byte, int, error)`).


### PR DESCRIPTION
## Why is this PR needed?

`ResultMessage` previously carried only `ID` and `Payload`, making it impossible
for consumers (e.g. batch-gateway) to distinguish HTTP successes from HTTP errors
or non-HTTP failures. The OpenAI Batch API contract requires routing HTTP responses
(any status) to the output file and non-HTTP failures to the error file — this
distinction was not expressible in the old wire format.

## What does this PR do?

Adds structured fields to `ResultMessage` so consumers can branch on result type:

- **`StatusCode`** (int): actual HTTP status from upstream; non-zero means "HTTP
  response was received." Zero means non-HTTP failure.
- **`ErrorCode`** (string): machine-readable result-level code for non-HTTP failures
  (`DEADLINE_EXCEEDED`, `GATE_DROPPED`, `GATE_ERROR`, `INFERENCE_ERROR`, `INVALID_REQUEST`).
- **`ErrorMessage`** (string): human-readable description.

Supporting changes:

`InferenceClient.SendRequest` now returns `*InferenceResponse` (struct with
   `StatusCode` and `Body`) so the worker propagates the real HTTP status
   (not hard-coded 200) for success paths.
- On retry exhaustion, the last HTTP status/body is preserved via
  `deadlineExhaustedResult` rather than being collapsed into `DEADLINE_EXCEEDED`.
- Shared constructors (`NewErrorResult`, `NewHTTPResult`, `NewGateDroppedResult`,
  `NewDeadlineExceededResult`) in the `api` package ensure all transports
  (asyncworker, pubsub, redis sorted set) produce identical wire format.

**Breaking changes:**
- `InferenceClient.SendRequest` signature changed from `([]byte, int, error)` to
  `(*InferenceResponse, error)` where `InferenceResponse` is a new struct with
  `StatusCode int` and `Body []byte` fields.
- HTTP error `Payload` now contains the raw upstream response body instead of a
  wrapped error string (e.g. `{"error":"INVALID_REQ: client error: status code 400"}`
  → actual response body from upstream).
- Gate-drop `Payload` changed from `{"status":"dropped"}` to
  `{"error":"Pool gating dropped request"}` (unified via `NewGateDroppedResult`
  across all transports). Consumers should use `ErrorCode == "GATE_DROPPED"` for
  detection rather than parsing the payload body.
- Gate-drop results now include `Metadata` (from `req.ReqMetadata()`), which the
  previous inline construction omitted.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Manual testing performed

New test coverage:
- `TestSuccessfulRequest_PreservesActualStatusCode` — verifies non-200 success status propagation
- `TestRetryMessage_deadlineExhaustedPreservesHTTPResponse` — verifies last HTTP response survives retry exhaustion
- `TestSendRequest_bodyReadFailurePreservesStatusCode` — verifies partial HTTP response preserves status
- `TestMarshalResultMessage_StructuredFields` — verifies JSON round-trip of all new fields
- `TestSortedSetFlow_ResultStructuredFields` — end-to-end Redis publish/consume of structured fields

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make test-e2e`)

## Related Issues

Closes #298