### PR TITLE
feat: add release-notes fragment mechanism

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,15 @@
 ## Related Issues
 
 <!-- Link to related issues: Fixes #123, Related to #456 -->
+
+## Release note
+
+<!--
+Summarize any user-facing change in one entry, or write `NONE` if there is none.
+For a user-facing change, ALSO add a fragment file
+`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
+Prefix breaking changes with `Breaking:` and note the deprecation window.
+-->
+```release-note
+NONE
+```

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,9 @@ repos:
         language: system
         pass_filenames: false
         files: \.go$
+      - id: release-notes-lint
+        name: release-note fragments
+        entry: ./hack/lint-release-notes.sh
+        language: system
+        pass_filenames: false
+        files: ^release-notes\.d/unreleased/.*\.md$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,35 @@ git push origin v0.8.0
 
 Go requires sub-module tags to carry the directory prefix — see [Managing module source](https://go.dev/doc/modules/managing-source) for details.
 
+## Release notes
+
+User-facing changes are recorded as **per-PR fragments** and assembled into
+[`RELEASE-NOTES.md`](RELEASE-NOTES.md) at each release. One fragment file per PR
+keeps this conflict-free.
+
+1. Fill the `release-note` block in the PR description (write `NONE` if there is
+   no user-facing impact).
+2. For a user-facing change, add a fragment at
+   `release-notes.d/unreleased/<PR-number>.md`:
+
+   ```markdown
+   ---
+   pr: 123
+   url: https://github.com/llm-d-incubation/llm-d-async/pull/123
+   author: your-handle
+   date: 2026-07-09
+   ---
+   Short description of the change. Prefix breaking changes with `Breaking:`.
+   ```
+
+3. `make release-notes-lint` validates fragment format (also enforced in CI via
+   pre-commit).
+
+At release time — as part of [Preparing a release](#preparing-a-release) — a
+maintainer runs `make release-notes VERSION=vX.Y.Z`, which moves the unreleased
+fragments into a new `RELEASE vX.Y.Z <date>` section at the top of
+`RELEASE-NOTES.md` and deletes them. Commit the result with the release.
+
 ## Go Conventions
 
 These conventions are enforced by linters where possible (see `.golangci.yml`) and by code review otherwise.
@@ -158,3 +187,4 @@ See [SECURITY.md](SECURITY.md) for our vulnerability disclosure process.
 * **No breaking changes**: Once an API/protocol is in GA release, it cannot be removed or behavior changed
 * **Versioning**: All protocols and APIs should be versionable with clear compatibility requirements
 * **Documentation**: All APIs must have documented specs describing expected behavior
+* **Deprecation policy (N+2)**: A feature deprecated in release N must keep working — with no user-facing or configuration change required — through releases N and N+1, emitting a clear warning, and may be removed no earlier than release N+2. Record the deprecation (and any breaking change) in the PR's [release note](#release-notes).

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,15 @@ check-dco: ## Check that all commits since main have a DCO Signed-off-by trailer
 	@scripts/check-dco.sh
 
 .PHONY: ci
-ci: fmt vet lint test ## Run all CI checks (fmt, vet, lint, test)
+ci: fmt vet lint release-notes-lint test ## Run all CI checks (fmt, vet, lint, test)
+
+.PHONY: release-notes-lint
+release-notes-lint: ## Validate release-note fragments in release-notes.d/unreleased.
+	./hack/lint-release-notes.sh
+
+.PHONY: release-notes
+release-notes: release-notes-lint ## Assemble fragments into RELEASE-NOTES.md (set VERSION=vX.Y.Z).
+	./hack/assemble-release-notes.sh $(VERSION)
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,11 @@
+# Release Notes
+
+User-facing changes for each release, newest first. Release sections are
+assembled from per-PR fragments in `release-notes.d/unreleased/` at each release
+tag by `make release-notes VERSION=vX.Y.Z`.
+
+Do not edit release sections by hand. To record a change, add a fragment via the
+PR template's `release-note` block — see
+[CONTRIBUTING.md → Release notes](CONTRIBUTING.md#release-notes).
+
+<!-- BEGIN RELEASES -->

--- a/hack/assemble-release-notes.sh
+++ b/hack/assemble-release-notes.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Assemble per-PR fragments from release-notes.d/unreleased/ into a new release
+# section at the top of RELEASE-NOTES.md, then remove the consumed fragments.
+#
+# Usage: hack/assemble-release-notes.sh <version> [date]
+#   version  release tag, e.g. v0.8.0 (required)
+#   date     release date YYYY-MM-DD (default: today, UTC)
+#
+# Typically invoked as `make release-notes VERSION=v0.8.0` while preparing a
+# release. The result is left staged in the working tree for you to review and
+# commit; this script performs no git operations.
+set -euo pipefail
+
+VERSION="${1:-}"
+RELEASE_DATE="${2:-$(date -u +%F)}"
+if [[ -z "$VERSION" ]]; then
+  echo "usage: $0 <version> [date]" >&2
+  exit 2
+fi
+
+DIR="release-notes.d/unreleased"
+NOTES="RELEASE-NOTES.md"
+MARKER="<!-- BEGIN RELEASES -->"
+
+# Reuse the linter so malformed fragments abort the release rather than
+# silently producing a broken section.
+hack/lint-release-notes.sh
+
+shopt -s nullglob
+fragments=("$DIR"/*.md)
+if [[ ${#fragments[@]} -eq 0 ]]; then
+  echo "No fragments in $DIR; nothing to assemble."
+  exit 0
+fi
+if [[ ! -f "$NOTES" ]] || ! grep -qF "$MARKER" "$NOTES"; then
+  echo "ERROR: $NOTES is missing or has no '$MARKER' marker" >&2
+  exit 1
+fi
+
+# Collect "<date>\t<pr>\t<url>\t<note>" rows, sorted by date then PR number.
+rows=""; section=""; new=""
+trap 'rm -f "$rows" "$section" "$new"' EXIT
+rows="$(mktemp)"
+for f in "${fragments[@]}"; do
+  pr="$(sed -n 's/^pr: *//p' "$f" | head -1)"
+  url="$(sed -n 's/^url: *//p' "$f" | head -1)"
+  date="$(sed -n 's/^date: *//p' "$f" | head -1)"
+  note="$(awk 'p {print; next} /^---$/ {if (++c == 2) p = 1}' "$f" \
+    | sed '/^[[:space:]]*$/d' | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+  printf '%s\t%s\t%s\t%s\n' "$date" "$pr" "$url" "$note" >> "$rows"
+done
+sort -k1,1 -k2,2n -o "$rows" "$rows"
+
+section="$(mktemp)"
+{
+  printf 'RELEASE %s %s\n' "$VERSION" "$RELEASE_DATE"
+  while IFS=$'\t' read -r date pr url note; do
+    printf '%s %s %s\n' "$date" "$url" "$note"
+  done < "$rows"
+  printf '\n'
+} > "$section"
+
+# Insert the new section immediately after the marker line.
+new="$(mktemp)"
+awk -v marker="$MARKER" -v sectionfile="$section" '
+  { print }
+  $0 == marker && !done {
+    print ""
+    while ((getline line < sectionfile) > 0) print line
+    done = 1
+  }
+' "$NOTES" > "$new"
+mv "$new" "$NOTES"
+
+git rm --quiet -- "${fragments[@]}" 2>/dev/null || rm -f "${fragments[@]}"
+
+echo "Assembled ${#fragments[@]} fragment(s) into $NOTES under 'RELEASE $VERSION $RELEASE_DATE'."
+echo "Review the changes and commit them as part of the release."

--- a/hack/lint-release-notes.sh
+++ b/hack/lint-release-notes.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Validate release-note fragments under release-notes.d/unreleased/.
+#
+# Each fragment must be YAML front matter with the keys pr, url, author, and
+# date, followed by a non-empty note body. Exits non-zero (listing every
+# problem) if any fragment is malformed. Run via `make release-notes-lint`.
+set -euo pipefail
+
+DIR="release-notes.d/unreleased"
+shopt -s nullglob
+fragments=("$DIR"/*.md)
+
+if [[ ${#fragments[@]} -eq 0 ]]; then
+  echo "No release-note fragments to validate."
+  exit 0
+fi
+
+rc=0
+for f in "${fragments[@]}"; do
+  # Front matter is the block between the first two '---' lines.
+  if [[ "$(sed -n '1p' "$f")" != "---" ]]; then
+    echo "ERROR: $f: must start with '---' front matter" >&2
+    rc=1
+    continue
+  fi
+  for key in pr url author date; do
+    if ! sed -n '2,/^---$/p' "$f" | grep -qE "^${key}: *[^ ]"; then
+      echo "ERROR: $f: missing or empty front-matter key '${key}'" >&2
+      rc=1
+    fi
+  done
+  # Body is everything after the second '---'; must be non-empty.
+  body="$(awk 'p {print; next} /^---$/ {if (++c == 2) p = 1}' "$f" | tr -d '[:space:]')"
+  if [[ -z "$body" ]]; then
+    echo "ERROR: $f: note body is empty" >&2
+    rc=1
+  fi
+done
+
+if [[ $rc -eq 0 ]]; then
+  echo "All ${#fragments[@]} release-note fragment(s) are well-formed."
+fi
+exit $rc


### PR DESCRIPTION
## What does this PR do?

Adds a per-PR **release-notes fragment** mechanism so user-facing and breaking changes have a durable, conflict-free home, mirroring the [`llm-d-router`](https://github.com/llm-d/llm-d-router) convention.

- `release-notes.d/unreleased/` fragments + a top-level `RELEASE-NOTES.md` (assembled newest-first).
- A `release-note` block in the PR template.
- `hack/assemble-release-notes.sh` (`make release-notes VERSION=vX.Y.Z`) — moves unreleased fragments into a new `RELEASE vX.Y.Z <date>` section and removes them.
- `hack/lint-release-notes.sh` (`make release-notes-lint`) — validates fragment front matter; wired into CI via `.pre-commit-config.yaml` and the `ci` target.
- `CONTRIBUTING.md`: a **Release notes** section and an **N+2 deprecation policy** (aligns with the umbrella [llm-d contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md)).

The existing `release-notes.d/unreleased/300.md` fragment (merged with #300) is left in place and will roll into the first assembled release section.

## Why is this change needed?

The repo had no durable place to record breaking changes — they lived only in PR descriptions (see the #300 discussion). Fixes #302.

## Scope note

This is the **self-contained** variant: fragments are authored per PR and assembled by a maintainer at release time. It intentionally does **not** port `llm-d-router`'s GitHub-App automation (auto-create fragment on merge / auto-assemble on tag), which requires org-level `RELEASE_NOTES_APP_*` secrets. That automation can be layered on later as a follow-up without changing this format.

## How was this tested?

- [x] `make release-notes-lint` passes on the current fragment.
- [x] `hack/assemble-release-notes.sh` verified end-to-end in a sandbox (produces the `RELEASE` section, flattens notes, removes fragments).
- [x] `bash -n` on both scripts; `.pre-commit-config.yaml` validates.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #302

## Release note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)