### PR TITLE
feat: raise default worker concurrency from 8 to 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ make deploy-ap-on-k8s
      ```
 
 ## Command line parameters
-- `concurrency`: The number of concurrent workers (per pool if unspecified), default is 8.
+- `concurrency`: The number of concurrent workers (per pool if unspecified), default is 64. The processor is I/O-bound (each worker holds one in-flight request for its full duration), so by Little's Law in-flight concurrency caps throughput — tune this to your backend's latency/throughput target (see the [Async Processor Operations Guide](https://github.com/llm-d/llm-d/blob/main/docs/operations/async-processor.md)).
 - `request-merge-policy-config`: Path to the JSON configuration file containing the request merge policy specification (`type` and `parameters`). If not specified, defaults to the `random-robin` policy.
 - `message-queue-impl`: Implementation of the queueing system. Options are <u>gcp-pubsub</u> for GCP PubSub, <u>gcp-pubsub-gated</u> for GCP PubSub with per-topic gating, <u>redis-sortedset</u> for Redis Sorted Set (persisted and sorted), and <u>redis-pubsub</u> for ephemeral Redis-based implementation.
 - `pool-config-file`: Path to the JSON configuration file containing the worker pool definitions. If omitted, a single `"default"` worker pool is created with concurrency determined by the global `concurrency` flag.

--- a/charts/async-processor/templates/ap-deployments.yaml
+++ b/charts/async-processor/templates/ap-deployments.yaml
@@ -120,7 +120,7 @@ spec:
           {{- if .Values.ap.requestMergePolicyConfig }}
           - --request-merge-policy-config=/etc/async-processor/config/request-merge-policy.json
           {{- end }}
-          - --concurrency={{ .Values.ap.concurrency | default 8 }}
+          - --concurrency={{ .Values.ap.concurrency | default 64 }}
           - --drain-timeout={{ .Values.ap.drainTimeout | default "2m" }}
           - --health-port={{ .Values.ap.health.port | default 8081 }}
           - --metrics-endpoint-auth={{ .Values.ap.metrics.secure }}

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -25,7 +25,11 @@ ap:
     # image stays in sync with the chart). Set explicitly to pin a different tag.
     tag: ""
   imagePullPolicy: Always
-  concurrency: 8
+  # Global worker concurrency (in-flight requests per pool). The processor is
+  # I/O-bound, so by Little's Law this caps throughput; the default of 8 left
+  # real inference pools mostly idle. Tune to your backend's latency/throughput
+  # target — see the Async Processor Operations Guide.
+  concurrency: 64
   drainTimeout: "2m"
   prometheusURL: ""
   prometheusCacheTTL: ""

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -80,7 +80,7 @@ func NewOptions() *Options {
 				MetricsEndpointAuth: true,
 			},
 			Worker: WorkerConfig{
-				Concurrency:    8,
+				Concurrency:    64,
 				RequestTimeout: 5 * time.Minute,
 				DrainTimeout:   2 * time.Minute,
 			},

--- a/release-notes.d/unreleased/306.md
+++ b/release-notes.d/unreleased/306.md
@@ -1,0 +1,7 @@
+---
+pr: 306
+url: https://github.com/llm-d-incubation/llm-d-async/pull/306
+author: shimib
+date: 2026-07-10
+---
+The default worker `concurrency` is now **64** (was 8). The processor is I/O-bound, so by Little's Law in-flight concurrency caps throughput; the old default of 8 left real inference pools mostly idle. Tune `concurrency` to your backend's latency/throughput target (see the Async Processor Operations Guide).


### PR DESCRIPTION
## What does this PR do?

Raises the default worker `concurrency` from **8** to **64**, kept in sync across the flag default, the chart value, and the deployment-template fallback. Fixes #261.

## Why

The processor is I/O-bound — each worker holds one in-flight request for its full duration — so by Little's Law in-flight concurrency caps throughput. The old default of 8 left real inference pools mostly idle: the issue's measured sweep (Llama-3.1-8B, single H100) delivered ~4 req/s and <1% KV at 8, vs ~36 req/s at 128 near the knee.

Per the issue's open question, this uses **64** (the recommended middle ground): 8× the old default and enough to do meaningful work, while leaving headroom for smaller/shared backends and staying well clear of where a lone gateway/EPP replica destabilized (~256). Operators saturating a dedicated GPU can still raise it.

## Changes (in sync)

- `pkg/server/options.go` — flag default (`Concurrency: 64`). *(The issue referenced `cmd/main.go:66`; the flag moved to `pkg/server/options.go` in the server refactor.)*
- `charts/async-processor/values.yaml` — `concurrency: 64` + a tuning comment.
- `charts/async-processor/templates/ap-deployments.yaml` — `| default 64` fallback.
- `README.md` — flag doc updated to 64 with a Little's-Law tuning note pointing at the Async Processor Operations Guide.

## How was this tested?

- [x] `go build ./...`
- [x] `helm template` renders `--concurrency=64`; `helm lint` clean.
- [x] No test or manifest pinned `--concurrency=8`.

## Release note

```release-note
The default worker `concurrency` is now 64 (was 8). The old default left inference pools mostly idle; tune `concurrency` to your backend's latency/throughput target.
```