### PR TITLE
add generation-aware request cancellation with pre-dispatch drop checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# Local replace directives (./api, ./pipeline) must exist before go mod download.
+# Local replace directives (./api, ./pipeline, ./producer) must exist before go mod download.
 COPY api/ api/
 COPY pipeline/ pipeline/
+COPY producer/ producer/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,9 @@
 package api
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+)
 
 // Request is the public interface for submitting requests to the async queue.
 // It exposes only the caller-visible fields. Concrete types like RequestMessage,
@@ -81,11 +84,27 @@ type ResultMessage struct {
 // These are result-level codes describing why a request could not be completed.
 const (
 	ErrCodeDeadlineExceeded = "DEADLINE_EXCEEDED"
+	ErrCodeCancelled        = "CANCELLED"
 	ErrCodeGateDropped      = "GATE_DROPPED"
 	ErrCodeGateError        = "GATE_ERROR"
 	ErrCodeInferenceError   = "INFERENCE_ERROR"
 	ErrCodeInvalidRequest   = "INVALID_REQUEST"
 )
+
+// CancellationChecker reports whether a specific request generation has been cancelled.
+type CancellationChecker interface {
+	IsCancelled(ctx context.Context, requestID, requestToken string) (bool, error)
+}
+
+// RequestCancellationKey returns the Redis key used for per-request cancellation markers.
+func RequestCancellationKey(requestID string) string {
+	return "request-cancel:" + requestID
+}
+
+// RequestActiveTokenKey returns the Redis key tracking the currently active request generation.
+func RequestActiveTokenKey(requestID string) string {
+	return "request-active:" + requestID
+}
 
 // NewErrorResult builds a non-HTTP error ResultMessage.
 // errorCode must be one of the ErrCode* constants; errMsg is a human-readable description.
@@ -127,4 +146,9 @@ func NewGateDroppedResult(req Request, routing InternalRouting) ResultMessage {
 // NewDeadlineExceededResult builds a ResultMessage for deadline expiry.
 func NewDeadlineExceededResult(req Request, routing InternalRouting) ResultMessage {
 	return NewErrorResult(req, routing, ErrCodeDeadlineExceeded, "deadline exceeded")
+}
+
+// NewCancelledResult builds a ResultMessage for a cancelled request.
+func NewCancelledResult(req Request, routing InternalRouting) ResultMessage {
+	return NewErrorResult(req, routing, ErrCodeCancelled, "cancelled")
 }

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -34,6 +34,7 @@ const (
 type InternalRouting struct {
 	RetryCount             int    `json:"retry_count,omitempty"`
 	QueueID                string `json:"queue_id,omitempty"`
+	RequestToken           string `json:"request_token,omitempty"`
 	RequestQueueName       string `json:"request_queue_name,omitempty"`
 	ResultQueueName        string `json:"result_queue_name,omitempty"`
 	TransportCorrelationID string `json:"transport_correlation_id,omitempty"`

--- a/api/internal_api_test.go
+++ b/api/internal_api_test.go
@@ -262,6 +262,9 @@ func assertRouting(t *testing.T, got, want InternalRouting) {
 	if got.RequestQueueName != want.RequestQueueName {
 		t.Errorf("RequestQueueName = %q, want %q", got.RequestQueueName, want.RequestQueueName)
 	}
+	if got.RequestToken != want.RequestToken {
+		t.Errorf("RequestToken = %q, want %q", got.RequestToken, want.RequestToken)
+	}
 	if got.ResultQueueName != want.ResultQueueName {
 		t.Errorf("ResultQueueName = %q, want %q", got.ResultQueueName, want.ResultQueueName)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,13 @@ go 1.25.8
 
 require github.com/llm-d-incubation/llm-d-async/api v0.7.2
 
+require github.com/llm-d-incubation/llm-d-async/producer v0.7.2
+
 require github.com/llm-d-incubation/llm-d-async/pipeline v0.7.2
 
 replace github.com/llm-d-incubation/llm-d-async/api => ./api
+
+replace github.com/llm-d-incubation/llm-d-async/producer => ./producer
 
 replace github.com/llm-d-incubation/llm-d-async/pipeline => ./pipeline
 

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -47,6 +47,12 @@ type BacklogReporter interface {
 	QueueBacklog(ctx context.Context) ([]QueueBacklogStat, error)
 }
 
+// CancellationCheckerProvider is an optional capability for flows that can
+// surface per-request cancellation state to workers.
+type CancellationCheckerProvider interface {
+	CancellationChecker() api.CancellationChecker
+}
+
 type RequestChannel struct {
 	Channel            chan *api.InternalRequest
 	IGWBaseURL         string

--- a/pkg/asyncworker/cancellation.go
+++ b/pkg/asyncworker/cancellation.go
@@ -1,0 +1,25 @@
+package asyncworker
+
+import (
+	"context"
+
+	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
+)
+
+type cancellationCheckerKey struct{}
+
+// WithCancellationChecker attaches a request cancellation checker to the worker context.
+func WithCancellationChecker(ctx context.Context, checker asyncapi.CancellationChecker) context.Context {
+	if checker == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, cancellationCheckerKey{}, checker)
+}
+
+func cancellationCheckerFromContext(ctx context.Context) asyncapi.CancellationChecker {
+	if ctx == nil {
+		return nil
+	}
+	checker, _ := ctx.Value(cancellationCheckerKey{}).(asyncapi.CancellationChecker)
+	return checker
+}

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -89,7 +89,9 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 					metrics.RecordAsyncReq(queueID, queueName, msg.WorkerPoolID)
 				}
 
-				if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+				var nextCancellationCheck time.Time
+
+				if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg, &nextCancellationCheck) {
 					return
 				}
 
@@ -115,13 +117,9 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 
 					var verdict pipeline.Verdict
 					var err error
-					nextCancellationCheck := time.Now().Add(cancellationCheckPollInterval)
 					for {
-						if time.Now().After(nextCancellationCheck) {
-							if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
-								return
-							}
-							nextCancellationCheck = time.Now().Add(cancellationCheckPollInterval)
+						if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg, &nextCancellationCheck) {
+							return
 						}
 
 						verdict, err = poolGate.Apply(gateCtx, msg.InternalRequest, &poolReleases)
@@ -201,7 +199,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 					}
 				}
 
-				if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+				if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg, &nextCancellationCheck) {
 					return
 				}
 
@@ -259,7 +257,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						sendHeaders = headersWithContentType(msg.HttpHeaders, contentType)
 					}
 
-					if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+					if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg, &nextCancellationCheck) {
 						return
 					}
 
@@ -470,8 +468,13 @@ func emitCancelledResultIfNeeded(
 	retryChannel chan pipeline.RetryMessage,
 	resultChannel chan asyncapi.ResultMessage,
 	msg pipeline.EmbelishedRequestMessage,
+	nextCheck *time.Time,
 ) bool {
 	if msg.PublicRequest == nil {
+		return false
+	}
+	now := time.Now()
+	if nextCheck != nil && !nextCheck.IsZero() && now.Before(*nextCheck) {
 		return false
 	}
 	checker := cancellationCheckerFromContext(ctx)
@@ -479,6 +482,9 @@ func emitCancelledResultIfNeeded(
 		return false
 	}
 	cancelled, err := checker.IsCancelled(ctx, msg.PublicRequest.ReqID(), msg.RequestToken)
+	if nextCheck != nil {
+		*nextCheck = now.Add(cancellationCheckPollInterval)
+	}
 	if err != nil {
 		logger.Error(err, "Failed to check request cancellation", "id", msg.PublicRequest.ReqID())
 		select {

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/go-logr/logr"
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	uotel "github.com/llm-d-incubation/llm-d-async/internal/otel"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
@@ -26,6 +27,10 @@ import (
 const (
 	baseDelaySeconds = 2
 	maxDelaySeconds  = 60
+
+	gateWaitPollInterval              = 50 * time.Millisecond
+	cancellationCheckPollInterval     = 1 * time.Second
+	cancellationCheckRetryAfterSecond = 1.0
 )
 
 func Worker(consumeCtx, requestCtx context.Context, characteristics pipeline.Characteristics, client asyncapi.InferenceClient, requestChannel chan pipeline.EmbelishedRequestMessage,
@@ -84,6 +89,10 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 					metrics.RecordAsyncReq(queueID, queueName, msg.WorkerPoolID)
 				}
 
+				if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+					return
+				}
+
 				payloadBytes := validateAndMarshal(requestCtx, resultChannel, msg, transforms)
 				if payloadBytes == nil {
 					return
@@ -106,7 +115,15 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 
 					var verdict pipeline.Verdict
 					var err error
+					nextCancellationCheck := time.Now().Add(cancellationCheckPollInterval)
 					for {
+						if time.Now().After(nextCancellationCheck) {
+							if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+								return
+							}
+							nextCancellationCheck = time.Now().Add(cancellationCheckPollInterval)
+						}
+
 						verdict, err = poolGate.Apply(gateCtx, msg.InternalRequest, &poolReleases)
 						if err != nil {
 							if errors.Is(err, context.DeadlineExceeded) || gateCtx.Err() != nil {
@@ -177,11 +194,15 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 								case <-requestCtx.Done():
 								}
 								return
-							case <-time.After(50 * time.Millisecond):
+							case <-time.After(gateWaitPollInterval):
 								// poll again
 							}
 						}
 					}
+				}
+
+				if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+					return
 				}
 
 				metrics.IncInflight(queueID, queueName, msg.WorkerPoolID)
@@ -236,6 +257,10 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 					} else if handled {
 						sendPayload = body
 						sendHeaders = headersWithContentType(msg.HttpHeaders, contentType)
+					}
+
+					if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg) {
+						return
 					}
 
 					logger.V(logutil.DEBUG).Info("Sending inference request", "url", msg.RequestURL)
@@ -437,6 +462,42 @@ func inferenceErrorCategory(err error) string {
 		return string(inferenceErr.Category())
 	}
 	return string(asyncapi.ErrCategoryUnknown)
+}
+
+func emitCancelledResultIfNeeded(
+	ctx context.Context,
+	logger logr.Logger,
+	retryChannel chan pipeline.RetryMessage,
+	resultChannel chan asyncapi.ResultMessage,
+	msg pipeline.EmbelishedRequestMessage,
+) bool {
+	if msg.PublicRequest == nil {
+		return false
+	}
+	checker := cancellationCheckerFromContext(ctx)
+	if checker == nil {
+		return false
+	}
+	cancelled, err := checker.IsCancelled(ctx, msg.PublicRequest.ReqID(), msg.RequestToken)
+	if err != nil {
+		logger.Error(err, "Failed to check request cancellation", "id", msg.PublicRequest.ReqID())
+		select {
+		case retryChannel <- pipeline.RetryMessage{
+			EmbelishedRequestMessage: msg,
+			BackoffDurationSeconds:   cancellationCheckRetryAfterSecond,
+		}:
+		case <-ctx.Done():
+		}
+		return true
+	}
+	if !cancelled {
+		return false
+	}
+	select {
+	case resultChannel <- asyncapi.NewCancelledResult(msg.PublicRequest, msg.InternalRouting):
+	case <-ctx.Done():
+	}
+	return true
 }
 
 // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -16,7 +16,9 @@ import (
 	asyncapi "github.com/llm-d-incubation/llm-d-async/api"
 	uotel "github.com/llm-d-incubation/llm-d-async/internal/otel"
 	"github.com/llm-d-incubation/llm-d-async/pipeline"
+	"github.com/llm-d-incubation/llm-d-async/pkg/asyncworker/transform"
 	"github.com/llm-d-incubation/llm-d-async/pkg/metrics"
+	"github.com/llm-d-incubation/llm-d-async/pkg/plugins"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
@@ -243,6 +245,213 @@ func TestSuccessfulRequest_PreservesActualStatusCode(t *testing.T) {
 		if r.Payload != `{"id":"new-resource"}` {
 			t.Errorf("Expected body preserved, got %q", r.Payload)
 		}
+	}
+}
+
+type stubCancellationChecker struct {
+	mu        sync.RWMutex
+	cancelled map[string]bool
+	err       error
+	checks    int
+}
+
+func (s *stubCancellationChecker) IsCancelled(ctx context.Context, requestID, requestToken string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.checks++
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.cancelled[requestID+"|"+requestToken], nil
+}
+
+func (s *stubCancellationChecker) setCancelled(requestID, requestToken string, cancelled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancelled == nil {
+		s.cancelled = make(map[string]bool)
+	}
+	s.cancelled[requestID+"|"+requestToken] = cancelled
+}
+
+func (s *stubCancellationChecker) checkCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.checks
+}
+
+type blockingTransform struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (t *blockingTransform) TypedName() plugins.TypedName {
+	return plugins.TypedName{Name: "blocking", Type: "test"}
+}
+
+func (t *blockingTransform) Validate(payload []byte, metadata map[string]string, reqDeadline int64) error {
+	return nil
+}
+
+func (t *blockingTransform) Transform(payload []byte, metadata map[string]string) ([]byte, string, bool, error) {
+	t.once.Do(func() {
+		if t.started != nil {
+			close(t.started)
+		}
+	})
+	if t.release != nil {
+		<-t.release
+	}
+	return nil, "", false, nil
+}
+
+func TestWorker_CancelledRequestSkipsInference(t *testing.T) {
+	msgID := "cancelled-before-send"
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       nil,
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	requestToken := "token-cancelled-before-send"
+	ctx := WithCancellationChecker(context.Background(), &stubCancellationChecker{
+		cancelled: map[string]bool{msgID + "|" + requestToken: true},
+	})
+
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: requestToken}, asyncapi.RequestMessage{
+		ID:       msgID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	select {
+	case <-retryChannel:
+		t.Fatal("cancelled request should not be retried")
+	case r := <-resultChannel:
+		if r.ID != msgID {
+			t.Errorf("Expected result message id %s, got %s", msgID, r.ID)
+		}
+		if r.ErrorCode != asyncapi.ErrCodeCancelled {
+			t.Errorf("Expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, r.ErrorCode)
+		}
+		if r.ErrorMessage != "cancelled" {
+			t.Errorf("Expected ErrorMessage 'cancelled', got %q", r.ErrorMessage)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for cancelled result")
+	}
+
+	if called.Load() != 0 {
+		t.Fatalf("expected inference client to be skipped, got %d calls", called.Load())
+	}
+}
+
+func TestWorker_CancellationCheckErrorRequeuesRequest(t *testing.T) {
+	msgID := "cancel-check-error"
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       nil,
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	requestToken := "token-cancel-check-error"
+	ctx := WithCancellationChecker(context.Background(), &stubCancellationChecker{
+		err: fmt.Errorf("redis unavailable"),
+	})
+
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: requestToken}, asyncapi.RequestMessage{
+		ID:       msgID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	select {
+	case retryMsg := <-retryChannel:
+		if retryMsg.PublicRequest.ReqID() != msgID {
+			t.Fatalf("expected retry for %q, got %q", msgID, retryMsg.PublicRequest.ReqID())
+		}
+		if retryMsg.BackoffDurationSeconds != cancellationCheckRetryAfterSecond {
+			t.Fatalf("expected backoff %f, got %f", cancellationCheckRetryAfterSecond, retryMsg.BackoffDurationSeconds)
+		}
+	case result := <-resultChannel:
+		t.Fatalf("expected requeue on cancellation check failure, got result %+v", result)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for re-enqueued request")
+	}
+
+	if called.Load() != 0 {
+		t.Fatalf("expected inference client to be skipped, got %d calls", called.Load())
+	}
+}
+
+func TestWorker_PoolGateActionWaitThrottlesCancellationChecks(t *testing.T) {
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	checker := &stubCancellationChecker{cancelled: map[string]bool{}}
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+	ctx := WithCancellationChecker(requestCtx, checker)
+	gate := &notifyingWaitGate{applied: make(chan struct{})}
+
+	go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: "token-gate-wait-throttled"}, asyncapi.RequestMessage{
+		ID:       "gate-wait-throttled",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(30 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-gate.applied:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never entered ActionWait")
+	}
+
+	time.Sleep(220 * time.Millisecond)
+	cancelRequest()
+
+	select {
+	case <-retryChannel:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected request to be re-enqueued after shutdown")
+	}
+
+	if got := checker.checkCount(); got > 2 {
+		t.Fatalf("expected throttled cancellation checks during ActionWait, got %d", got)
+	}
+	if called.Load() != 0 {
+		t.Fatalf("expected inference client to be skipped, got %d calls", called.Load())
 	}
 }
 
@@ -1884,6 +2093,48 @@ func (g *waitingPoolGate) Apply(ctx context.Context, _ *asyncapi.InternalRequest
 	return pipeline.Wait(), nil
 }
 
+type notifyingWaitGate struct {
+	applied  chan struct{}
+	notified atomic.Bool
+}
+
+func (g *notifyingWaitGate) Budget(ctx context.Context) float64 {
+	return 1.0
+}
+
+func (g *notifyingWaitGate) Apply(ctx context.Context, _ *asyncapi.InternalRequest, _ *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
+	if g.applied != nil && !g.notified.Swap(true) {
+		close(g.applied)
+	}
+	return pipeline.Wait(), nil
+}
+
+type signalContinueGate struct {
+	applied chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (g *signalContinueGate) Budget(ctx context.Context) float64 {
+	return 1.0
+}
+
+func (g *signalContinueGate) Apply(ctx context.Context, _ *asyncapi.InternalRequest, _ *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
+	g.once.Do(func() {
+		if g.applied != nil {
+			close(g.applied)
+		}
+	})
+	if g.release != nil {
+		select {
+		case <-g.release:
+		case <-ctx.Done():
+			return pipeline.Verdict{}, ctx.Err()
+		}
+	}
+	return pipeline.Continue(), nil
+}
+
 func TestWorker_PoolGateShutdownReenqueues(t *testing.T) {
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
@@ -1978,6 +2229,176 @@ func TestWorker_PoolGateActionWaitShutdownReenqueues(t *testing.T) {
 	retryMsg := <-retryChannel
 	if retryMsg.PublicRequest.ReqID() != "gate-wait-shutdown-test" {
 		t.Errorf("re-enqueued wrong message: got ID %q", retryMsg.PublicRequest.ReqID())
+	}
+}
+
+func TestWorker_PoolGateActionWaitHonorsCancellation(t *testing.T) {
+	msgID := "gate-wait-cancelled"
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	checker := &stubCancellationChecker{cancelled: map[string]bool{}}
+	ctx := WithCancellationChecker(context.Background(), checker)
+	gate := &notifyingWaitGate{applied: make(chan struct{})}
+	requestToken := "token-gate-wait-cancelled"
+
+	go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: requestToken}, asyncapi.RequestMessage{
+		ID:       msgID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(30 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-gate.applied:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never entered ActionWait")
+	}
+
+	checker.setCancelled(msgID, requestToken, true)
+
+	select {
+	case <-retryChannel:
+		t.Fatal("cancelled request should not be retried")
+	case result := <-resultChannel:
+		if result.ID != msgID {
+			t.Fatalf("Expected result ID %q, got %q", msgID, result.ID)
+		}
+		if result.ErrorCode != asyncapi.ErrCodeCancelled {
+			t.Fatalf("Expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, result.ErrorCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cancelled result")
+	}
+
+	if called.Load() != 0 {
+		t.Fatalf("expected no inference call after cancellation during ActionWait, got %d", called.Load())
+	}
+}
+
+func TestWorker_RechecksCancellationAfterGateContinue(t *testing.T) {
+	msgID := "gate-continue-cancelled"
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	checker := &stubCancellationChecker{cancelled: map[string]bool{}}
+	ctx := WithCancellationChecker(context.Background(), checker)
+	gate := &signalContinueGate{
+		applied: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	requestToken := "token-gate-continue-cancelled"
+
+	go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: requestToken}, asyncapi.RequestMessage{
+		ID:       msgID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(30 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-gate.applied:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never reached pool gate")
+	}
+
+	checker.setCancelled(msgID, requestToken, true)
+	close(gate.release)
+
+	select {
+	case <-retryChannel:
+		t.Fatal("cancelled request should not be retried")
+	case result := <-resultChannel:
+		if result.ID != msgID {
+			t.Fatalf("expected result ID %q, got %q", msgID, result.ID)
+		}
+		if result.ErrorCode != asyncapi.ErrCodeCancelled {
+			t.Fatalf("expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, result.ErrorCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cancelled result after gate continue")
+	}
+
+	if called.Load() != 0 {
+		t.Fatalf("expected no inference call after cancellation post-gate, got %d", called.Load())
+	}
+}
+
+func TestWorker_RechecksCancellationImmediatelyBeforeSend(t *testing.T) {
+	msgID := "pre-send-cancelled"
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+	checker := &stubCancellationChecker{cancelled: map[string]bool{}}
+	ctx := WithCancellationChecker(context.Background(), checker)
+	requestToken := "token-pre-send-cancelled"
+	xform := &blockingTransform{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, transform.NewChain([]transform.RequestTransform{xform}))
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: requestToken}, asyncapi.RequestMessage{
+		ID:       msgID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(30 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", nil)
+
+	select {
+	case <-xform.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never entered transform phase")
+	}
+
+	checker.setCancelled(msgID, requestToken, true)
+	close(xform.release)
+
+	select {
+	case <-retryChannel:
+		t.Fatal("cancelled request should not be retried")
+	case result := <-resultChannel:
+		if result.ID != msgID {
+			t.Fatalf("expected result ID %q, got %q", msgID, result.ID)
+		}
+		if result.ErrorCode != asyncapi.ErrCodeCancelled {
+			t.Fatalf("expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, result.ErrorCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cancelled result before send")
+	}
+
+	if called.Load() != 0 {
+		t.Fatalf("expected no inference call after cancellation during transform, got %d", called.Load())
 	}
 }
 

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -405,6 +405,53 @@ func TestWorker_CancellationCheckErrorRequeuesRequest(t *testing.T) {
 	}
 }
 
+func TestWorker_FastPathChecksCancellationOnce(t *testing.T) {
+	msgID := "fast-path-cancel-check"
+	var called atomic.Int32
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		called.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"ok":true}`))),
+			Header:     make(http.Header),
+		}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	requestToken := "token-fast-path-cancel-check"
+	checker := &stubCancellationChecker{cancelled: map[string]bool{}}
+	ctx := WithCancellationChecker(context.Background(), checker)
+
+	go Worker(ctx, ctx, pipeline.Characteristics{HasExternalBackoff: false}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
+
+	requestChannel <- newEmbR(asyncapi.InternalRouting{RequestToken: requestToken}, asyncapi.RequestMessage{
+		ID:       msgID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(100 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "test", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	select {
+	case <-retryChannel:
+		t.Fatal("request should not be retried")
+	case result := <-resultChannel:
+		if result.ID != msgID {
+			t.Fatalf("expected result ID %q, got %q", msgID, result.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for successful result")
+	}
+
+	if got := checker.checkCount(); got != 1 {
+		t.Fatalf("expected exactly 1 cancellation check on fast path, got %d", got)
+	}
+	if called.Load() != 1 {
+		t.Fatalf("expected exactly 1 inference call, got %d", called.Load())
+	}
+}
+
 func TestWorker_PoolGateActionWaitThrottlesCancellationChecks(t *testing.T) {
 	var called atomic.Int32
 	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
@@ -447,7 +494,7 @@ func TestWorker_PoolGateActionWaitThrottlesCancellationChecks(t *testing.T) {
 		t.Fatal("expected request to be re-enqueued after shutdown")
 	}
 
-	if got := checker.checkCount(); got > 2 {
+	if got := checker.checkCount(); got > 1 {
 		t.Fatalf("expected throttled cancellation checks during ActionWait, got %d", got)
 	}
 	if called.Load() != 0 {
@@ -2266,6 +2313,7 @@ func TestWorker_PoolGateActionWaitHonorsCancellation(t *testing.T) {
 	}
 
 	checker.setCancelled(msgID, requestToken, true)
+	time.Sleep(cancellationCheckPollInterval + 100*time.Millisecond)
 
 	select {
 	case <-retryChannel:
@@ -2277,7 +2325,7 @@ func TestWorker_PoolGateActionWaitHonorsCancellation(t *testing.T) {
 		if result.ErrorCode != asyncapi.ErrCodeCancelled {
 			t.Fatalf("Expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, result.ErrorCode)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for cancelled result")
 	}
 
@@ -2323,6 +2371,7 @@ func TestWorker_RechecksCancellationAfterGateContinue(t *testing.T) {
 	}
 
 	checker.setCancelled(msgID, requestToken, true)
+	time.Sleep(cancellationCheckPollInterval + 100*time.Millisecond)
 	close(gate.release)
 
 	select {
@@ -2335,7 +2384,7 @@ func TestWorker_RechecksCancellationAfterGateContinue(t *testing.T) {
 		if result.ErrorCode != asyncapi.ErrCodeCancelled {
 			t.Fatalf("expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, result.ErrorCode)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for cancelled result after gate continue")
 	}
 
@@ -2381,6 +2430,7 @@ func TestWorker_RechecksCancellationImmediatelyBeforeSend(t *testing.T) {
 	}
 
 	checker.setCancelled(msgID, requestToken, true)
+	time.Sleep(cancellationCheckPollInterval + 100*time.Millisecond)
 	close(xform.release)
 
 	select {
@@ -2393,7 +2443,7 @@ func TestWorker_RechecksCancellationImmediatelyBeforeSend(t *testing.T) {
 		if result.ErrorCode != asyncapi.ErrCodeCancelled {
 			t.Fatalf("expected ErrorCode %q, got %q", asyncapi.ErrCodeCancelled, result.ErrorCode)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for cancelled result before send")
 	}
 

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -54,12 +54,28 @@ type requestChannelData struct {
 }
 
 var (
-	_ pipeline.Flow          = (*RedisSortedSetFlow)(nil)
-	_ pipeline.HealthChecker = (*RedisSortedSetFlow)(nil)
+	_ pipeline.Flow                        = (*RedisSortedSetFlow)(nil)
+	_ pipeline.HealthChecker               = (*RedisSortedSetFlow)(nil)
+	_ pipeline.CancellationCheckerProvider = (*RedisSortedSetFlow)(nil)
 )
+
+var cleanupRequestStateScript = redis.NewScript(`
+local token = ARGV[1]
+if token == "" then
+  return 0
+end
+if redis.call("GET", KEYS[1]) == token then
+  redis.call("DEL", KEYS[1])
+end
+if redis.call("GET", KEYS[2]) == token then
+  redis.call("DEL", KEYS[2])
+end
+return 1
+`)
 
 type RedisSortedSetFlow struct {
 	rdb                     *redis.Client
+	cancellationChecker     api.CancellationChecker
 	requestChannels         []requestChannelData
 	retryChannel            chan pipeline.RetryMessage
 	resultChannel           chan api.ResultMessage
@@ -77,6 +93,24 @@ type RedisSortedSetFlow struct {
 	drainCancel             context.CancelFunc
 	drainWg                 sync.WaitGroup
 	enableTracing           bool
+}
+
+type redisCancellationChecker struct {
+	rdb *redis.Client
+}
+
+func (c *redisCancellationChecker) IsCancelled(ctx context.Context, requestID, requestToken string) (bool, error) {
+	if requestID == "" || requestToken == "" {
+		return false, nil
+	}
+	token, err := c.rdb.Get(ctx, api.RequestCancellationKey(requestID)).Result()
+	if err == redis.Nil {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return token == requestToken, nil
 }
 
 // SortedSetOption is a functional option for configuring RedisSortedSetFlow
@@ -341,6 +375,13 @@ func (r *RedisSortedSetFlow) ResultChannel() chan api.ResultMessage {
 	return r.resultChannel
 }
 
+func (r *RedisSortedSetFlow) CancellationChecker() api.CancellationChecker {
+	if r.cancellationChecker != nil {
+		return r.cancellationChecker
+	}
+	return &redisCancellationChecker{rdb: r.rdb}
+}
+
 func (r *RedisSortedSetFlow) HealthCheck(ctx context.Context) error {
 	return r.rdb.Ping(ctx).Err()
 }
@@ -411,6 +452,9 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		}
 		if deadline < currentTime {
 			logger.V(logutil.DEFAULT).Info("Deadline expired", "id", rview.ReqID())
+			if err := r.cleanupRequestStateByIDAndToken(ctx, rview.ReqID(), ir.RequestToken); err != nil {
+				logger.V(logutil.DEFAULT).Error(err, "Failed to cleanup expired request state", "id", rview.ReqID())
+			}
 			continue
 		}
 
@@ -427,6 +471,20 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			for k, v := range cfg.Labels {
 				ir.Labels[k] = v
 			}
+		}
+
+		cancelled, err := r.CancellationChecker().IsCancelled(ctx, rview.ReqID(), ir.RequestToken)
+		if err != nil {
+			// Best-effort at dequeue time only. The worker path performs the
+			// authoritative pre-dispatch cancellation check and fails closed.
+			logger.V(logutil.DEFAULT).Error(err, "Failed to check request cancellation", "id", rview.ReqID())
+		} else if cancelled {
+			select {
+			case r.resultChannel <- api.NewCancelledResult(rview, ir.InternalRouting):
+			case <-ctx.Done():
+				return
+			}
+			continue
 		}
 
 		// Apply gate
@@ -637,8 +695,30 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 		_, err := pipe.Exec(ctx)
 		return err
 	}); err == nil {
+		for _, result := range batch {
+			if err := r.cleanupRequestState(ctx, result); err != nil {
+				logger.V(logutil.DEFAULT).Error(err, "Failed to cleanup request state after result flush", "id", result.ID)
+			}
+		}
 		logger.V(logutil.DEBUG).Info("Pushed result batch", "batchSize", len(batch))
 	}
+}
+
+func (r *RedisSortedSetFlow) cleanupRequestState(ctx context.Context, result api.ResultMessage) error {
+	return r.cleanupRequestStateByIDAndToken(ctx, result.ID, result.Routing.RequestToken)
+}
+
+func (r *RedisSortedSetFlow) cleanupRequestStateByIDAndToken(ctx context.Context, requestID, requestToken string) error {
+	if requestID == "" || requestToken == "" {
+		return nil
+	}
+	_, err := cleanupRequestStateScript.Run(
+		ctx,
+		r.rdb,
+		[]string{api.RequestActiveTokenKey(requestID), api.RequestCancellationKey(requestID)},
+		requestToken,
+	).Result()
+	return err
 }
 
 func (r *RedisSortedSetFlow) marshalResult(msg api.ResultMessage) string {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -22,6 +22,20 @@ func noopGate() pipeline.Gate {
 	return pipeline.ConstOpenGate()
 }
 
+type stubFlowCancellationChecker struct {
+	cancelled bool
+	err       error
+	onCheck   func()
+}
+
+func (s *stubFlowCancellationChecker) IsCancelled(ctx context.Context, requestID, requestToken string) (bool, error) {
+	if s.onCheck != nil {
+		s.onCheck()
+		s.onCheck = nil
+	}
+	return s.cancelled, s.err
+}
+
 // Test helper to create test flow and Redis
 func setupTest(t *testing.T) (*miniredis.Miniredis, *redis.Client, context.Context, context.CancelFunc) {
 	s := miniredis.RunT(t)
@@ -254,6 +268,140 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	}
 }
 
+func TestSortedSetFlow_ExpiredMessagesCleanupRequestState(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "expired-cleanup-queue"
+	token := "expired-token"
+	requestID := "expired-cleanup"
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+			queueName: queue,
+		}},
+		pollInterval: 50 * time.Millisecond,
+		batchSize:    10,
+		gate:         noopGate(),
+	}
+
+	ir := api.NewInternalRequest(api.InternalRouting{RequestToken: token}, &api.RequestMessage{
+		ID:       requestID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Unix() - 100,
+	})
+	msgBytes, _ := json.Marshal(ir)
+	rdb.Set(ctx, api.RequestActiveTokenKey(requestID), token, time.Hour)
+	rdb.Set(ctx, api.RequestCancellationKey(requestID), token, time.Hour)
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix() - 100), Member: string(msgBytes)})
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+
+	time.Sleep(300 * time.Millisecond)
+
+	if count, _ := rdb.ZCard(ctx, queue).Result(); count != 0 {
+		t.Fatalf("Expected expired message to be removed from queue, got count=%d", count)
+	}
+	if exists, _ := rdb.Exists(ctx, api.RequestActiveTokenKey(requestID)).Result(); exists != 0 {
+		t.Fatalf("expected expired request active token for %q to be cleaned up", requestID)
+	}
+	if exists, _ := rdb.Exists(ctx, api.RequestCancellationKey(requestID)).Result(); exists != 0 {
+		t.Fatalf("expected expired request cancellation marker for %q to be cleaned up", requestID)
+	}
+}
+
+func TestSortedSetFlow_CancelledMessageProducesCancelledResult(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "cancelled-queue"
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
+			queueName: queue,
+		}},
+		resultChannel: make(chan api.ResultMessage, 1),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
+	}
+
+	requestToken := "cancel-token"
+	ir := api.NewInternalRequest(api.InternalRouting{RequestToken: requestToken}, &api.RequestMessage{
+		ID: "cancelled-msg", Created: time.Now().Unix(), Deadline: 9999999999,
+	})
+	msgBytes, _ := json.Marshal(ir)
+	rdb.Set(ctx, api.RequestCancellationKey(ir.PublicRequest.ReqID()), requestToken, time.Hour)
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+
+	select {
+	case result := <-flow.resultChannel:
+		if result.ID != ir.PublicRequest.ReqID() {
+			t.Fatalf("Expected cancelled result for %q, got %q", ir.PublicRequest.ReqID(), result.ID)
+		}
+		if result.ErrorCode != api.ErrCodeCancelled {
+			t.Fatalf("Expected ErrorCode %q, got %q", api.ErrCodeCancelled, result.ErrorCode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for cancelled result")
+	}
+
+	select {
+	case msg := <-flow.requestChannels[0].channel.Channel:
+		t.Fatalf("Cancelled message should not reach worker channel: %s", msg.PublicRequest.ReqID())
+	default:
+	}
+}
+
+func TestSortedSetFlow_CancellationCheckErrorLeavesMessageDispatchable(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "cancel-check-error-queue"
+	flow := &RedisSortedSetFlow{
+		rdb: rdb,
+		requestChannels: []requestChannelData{{
+			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
+			queueName: queue,
+		}},
+		resultChannel:       make(chan api.ResultMessage, 1),
+		pollInterval:        50 * time.Millisecond,
+		batchSize:           10,
+		gate:                noopGate(),
+		cancellationChecker: &stubFlowCancellationChecker{err: fmt.Errorf("redis unavailable")},
+	}
+
+	requestToken := "cancel-check-error-token"
+	ir := api.NewInternalRequest(api.InternalRouting{RequestToken: requestToken}, &api.RequestMessage{
+		ID: "cancel-check-error-msg", Created: time.Now().Unix(), Deadline: 9999999999,
+	})
+	msgBytes, _ := json.Marshal(ir)
+	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
+
+	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+
+	select {
+	case msg := <-flow.requestChannels[0].channel.Channel:
+		if msg.PublicRequest.ReqID() != ir.PublicRequest.ReqID() {
+			t.Fatalf("expected message %q to remain dispatchable, got %q", ir.PublicRequest.ReqID(), msg.PublicRequest.ReqID())
+		}
+	case result := <-flow.resultChannel:
+		t.Fatalf("message should not emit a result on cancellation check error: %+v", result)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message to reach worker channel")
+	}
+}
+
 func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()
@@ -447,6 +595,98 @@ func TestSortedSetFlow_ResultStructuredFields(t *testing.T) {
 		if got.ErrorMessage != want.ErrorMessage {
 			t.Errorf("[%s] ErrorMessage = %q, want %q", want.ID, got.ErrorMessage, want.ErrorMessage)
 		}
+	}
+}
+
+func TestSortedSetFlow_ResultBatchClearsCancellationMarkers(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "cancel-cleanup-result-queue"
+	cancelledID := "cancel-cleanup"
+	requestToken := "cleanup-token"
+	rdb.Set(ctx, api.RequestActiveTokenKey(cancelledID), requestToken, time.Hour)
+	rdb.Set(ctx, api.RequestCancellationKey(cancelledID), requestToken, time.Hour)
+
+	flow := &RedisSortedSetFlow{
+		defaultResultQueueName: queue,
+		rdb:                    rdb,
+		resultChannel:          make(chan api.ResultMessage, 1),
+		pollInterval:           50 * time.Millisecond,
+		batchSize:              10,
+		gate:                   noopGate(),
+	}
+
+	go flow.resultWorker(ctx)
+	flow.resultChannel <- api.NewCancelledResult(&api.RequestMessage{ID: cancelledID}, api.InternalRouting{RequestToken: requestToken})
+
+	timeout := time.After(2 * time.Second)
+	for {
+		n, err := rdb.LLen(ctx, queue).Result()
+		if err == nil && n == 1 {
+			break
+		}
+		select {
+		case <-timeout:
+			t.Fatal("timeout waiting for cancelled result to be pushed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if exists, _ := rdb.Exists(ctx, api.RequestCancellationKey(cancelledID)).Result(); exists != 0 {
+		t.Fatalf("expected cancellation marker for %q to be cleared after result flush", cancelledID)
+	}
+	if exists, _ := rdb.Exists(ctx, api.RequestActiveTokenKey(cancelledID)).Result(); exists != 0 {
+		t.Fatalf("expected active token for %q to be cleared after result flush", cancelledID)
+	}
+}
+
+func TestSortedSetFlow_OldResultDoesNotClearNewGenerationCancellation(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	queue := "cancel-generation-result-queue"
+	requestID := "reused-request-id"
+	oldToken := "old-token"
+	newToken := "new-token"
+
+	rdb.Set(ctx, api.RequestActiveTokenKey(requestID), newToken, time.Hour)
+	rdb.Set(ctx, api.RequestCancellationKey(requestID), newToken, time.Hour)
+
+	flow := &RedisSortedSetFlow{
+		defaultResultQueueName: queue,
+		rdb:                    rdb,
+		resultChannel:          make(chan api.ResultMessage, 1),
+		pollInterval:           50 * time.Millisecond,
+		batchSize:              10,
+		gate:                   noopGate(),
+	}
+
+	go flow.resultWorker(ctx)
+	flow.resultChannel <- api.NewCancelledResult(&api.RequestMessage{ID: requestID}, api.InternalRouting{RequestToken: oldToken})
+
+	timeout := time.After(2 * time.Second)
+	for {
+		n, err := rdb.LLen(ctx, queue).Result()
+		if err == nil && n == 1 {
+			break
+		}
+		select {
+		case <-timeout:
+			t.Fatal("timeout waiting for old-generation result to be pushed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if got, _ := rdb.Get(ctx, api.RequestCancellationKey(requestID)).Result(); got != newToken {
+		t.Fatalf("expected new generation cancellation marker %q to remain, got %q", newToken, got)
+	}
+	if got, _ := rdb.Get(ctx, api.RequestActiveTokenKey(requestID)).Result(); got != newToken {
+		t.Fatalf("expected new generation active token %q to remain, got %q", newToken, got)
 	}
 }
 

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -128,6 +128,9 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 
 	drainCtx, drainCancel := context.WithCancel(baseCtx)
 	defer drainCancel()
+	if provider, ok := flow.(pipeline.CancellationCheckerProvider); ok {
+		drainCtx = asyncworker.WithCancellationChecker(drainCtx, provider.CancellationChecker())
+	}
 
 	dispatch := policy.MergeRequestChannels(flow.RequestChannels(), poolsMap)
 

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -13,6 +13,14 @@ type Producer interface {
 	// Returns error if submission fails.
 	SubmitRequest(ctx context.Context, req api.Request) error
 
+	// CancelRequests marks previously submitted requests as cancelled.
+	// Implementations guarantee best-effort cancellation before dispatch
+	// (during dequeue and worker pre-dispatch checks), but do not guarantee
+	// aborting requests that are already in flight to the inference backend
+	// or forcing already-dispatched requests to return a CANCELLED result.
+	// Cancellation is idempotent: unknown or already-completed request IDs are a no-op.
+	CancelRequests(ctx context.Context, requestIDs []string) error
+
 	// GetResult retrieves a result from the result queue.
 	// Blocks until a result is available or context is cancelled.
 	// Use context.WithTimeout for timeout-based retrieval.

--- a/producer/redis_sortedset_producer.go
+++ b/producer/redis_sortedset_producer.go
@@ -2,6 +2,8 @@ package producer
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +23,17 @@ type RedisSortedSetProducer struct {
 	requestQueueName string
 	resultQueueName  string
 }
+
+const cancellationMarkerTTL = 7 * 24 * time.Hour
+
+var markRequestCancelledScript = redis.NewScript(`
+local active = redis.call("GET", KEYS[1])
+if not active then
+  return 0
+end
+redis.call("SET", KEYS[2], active, "EX", ARGV[1])
+return 1
+`)
 
 // ProducerOption is a functional option for NewRedisSortedSetProducer.
 type ProducerOption func(*RedisSortedSetProducer) error
@@ -171,10 +184,6 @@ func (p *RedisSortedSetProducer) SubmitRequest(ctx context.Context, req api.Requ
 		return errors.New("deadline is required and must be a positive Unix timestamp")
 	}
 
-	if deadline <= time.Now().Unix() {
-		return errors.New("deadline has already expired")
-	}
-
 	// Apply producer-level defaults for queue routing if not set by caller
 	if ir.ResultQueueName == "" {
 		ir.ResultQueueName = p.resultQueueName
@@ -183,23 +192,68 @@ func (p *RedisSortedSetProducer) SubmitRequest(ctx context.Context, req api.Requ
 	if ir.RequestQueueName == "" {
 		ir.RequestQueueName = p.requestQueueName
 	}
+	token, err := newRequestToken()
+	if err != nil {
+		return fmt.Errorf("failed to create request token: %w", err)
+	}
+	ir.RequestToken = token
 
 	msgBytes, err := json.Marshal(ir)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Add to sorted set with deadline as score
+	// Clear any stale cancellation marker for this request ID before enqueue.
+	// This prevents a previously cancelled/completed request ID from poisoning
+	// a later submission that legitimately reuses the same ID.
 	targetQueue := ir.RequestQueueName
 	score := float64(deadline)
-	if err := p.client.ZAdd(ctx, targetQueue, redis.Z{
+	activeTTL := time.Until(time.Unix(deadline, 0))
+	if activeTTL <= 0 {
+		return errors.New("deadline has already expired")
+	}
+	pipe := p.client.TxPipeline()
+	pipe.Del(ctx, api.RequestCancellationKey(r.ReqID()))
+	pipe.Set(ctx, api.RequestActiveTokenKey(r.ReqID()), ir.RequestToken, activeTTL)
+	pipe.ZAdd(ctx, targetQueue, redis.Z{
 		Score:  score,
 		Member: string(msgBytes),
-	}).Err(); err != nil {
+	})
+	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("failed to add request to queue: %w", err)
 	}
 
 	return nil
+}
+
+// CancelRequests marks request IDs as cancelled so dequeue/dispatch paths can drop them.
+func (p *RedisSortedSetProducer) CancelRequests(ctx context.Context, requestIDs []string) error {
+	if len(requestIDs) == 0 {
+		return nil
+	}
+
+	for _, requestID := range requestIDs {
+		if requestID == "" {
+			continue
+		}
+		if _, err := markRequestCancelledScript.Run(
+			ctx,
+			p.client,
+			[]string{api.RequestActiveTokenKey(requestID), api.RequestCancellationKey(requestID)},
+			int(cancellationMarkerTTL/time.Second),
+		).Result(); err != nil {
+			return fmt.Errorf("failed to mark request %q as cancelled: %w", requestID, err)
+		}
+	}
+	return nil
+}
+
+func newRequestToken() (string, error) {
+	token := make([]byte, 16)
+	if _, err := rand.Read(token); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(token), nil
 }
 
 // GetResult retrieves a result from the Redis list, blocking until one is available.

--- a/producer/redis_sortedset_producer_test.go
+++ b/producer/redis_sortedset_producer_test.go
@@ -221,6 +221,53 @@ func TestSubmitRequest_Validation(t *testing.T) {
 	}
 }
 
+func TestCancelRequests(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx := context.Background()
+	mr.Set(api.RequestActiveTokenKey("req-1"), "token-1")
+	mr.Set(api.RequestActiveTokenKey("req-2"), "token-2")
+	err := producer.CancelRequests(ctx, []string{"req-1", "", "req-2"})
+	require.NoError(t, err)
+
+	got1, err := mr.Get(api.RequestCancellationKey("req-1"))
+	require.NoError(t, err)
+	assert.Equal(t, "token-1", got1)
+	got2, err := mr.Get(api.RequestCancellationKey("req-2"))
+	require.NoError(t, err)
+	assert.Equal(t, "token-2", got2)
+	assert.False(t, mr.Exists(api.RequestCancellationKey("")))
+}
+
+func TestCancelRequests_UnknownRequestIDIsNoOp(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx := context.Background()
+	err := producer.CancelRequests(ctx, []string{"unknown-request"})
+	require.NoError(t, err)
+
+	assert.False(t, mr.Exists(api.RequestActiveTokenKey("unknown-request")))
+	assert.False(t, mr.Exists(api.RequestCancellationKey("unknown-request")))
+}
+
+func TestSubmitRequest_ClearsStaleCancellationMarker(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+
+	ctx := context.Background()
+	requestID := "reused-id"
+	mr.Set(api.RequestCancellationKey(requestID), "1")
+
+	err := producer.SubmitRequest(ctx, &api.RequestMessage{
+		ID:       requestID,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(1 * time.Hour).Unix(),
+		Payload:  map[string]any{"model": "test"},
+	})
+	require.NoError(t, err)
+	assert.False(t, mr.Exists(api.RequestCancellationKey(requestID)))
+	assert.True(t, mr.Exists(api.RequestActiveTokenKey(requestID)))
+}
+
 func TestGetResult(t *testing.T) {
 	producer, mr := setupTestProducer(t)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/llm-d-incubation/llm-d-async/api"
+	producerpkg "github.com/llm-d-incubation/llm-d-async/producer"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -391,5 +393,46 @@ var _ = ginkgo.Describe("Redis Dispatch Gate E2E", func() {
 		gomega.Eventually(func() int64 {
 			return getResultCount(ctx, rdb, redisGateResultQueue)
 		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 3))
+	})
+
+	ginkgo.It("returns a cancelled result after producer-side cancellation", func() {
+		setDispatchGateBudget(ctx, rdb, "0.0")
+
+		producer, err := producerpkg.NewRedisSortedSetProducer(producerpkg.RedisSortedSetConfig{
+			RedisURL:         "redis://localhost:" + redisPort,
+			RequestQueueName: redisGateRequestQueue,
+			ResultQueueName:  redisGateResultQueue,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(producer.Close()).To(gomega.Succeed())
+		})
+
+		requestID := "producer-cancel-e2e"
+		gomega.Expect(producer.SubmitRequest(ctx, &api.RequestMessage{
+			ID:       requestID,
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(5 * time.Minute).Unix(),
+			Payload:  map[string]any{"model": "test-model", "prompt": "cancel me"},
+		})).To(gomega.Succeed())
+
+		gomega.Eventually(func() int64 {
+			return rdb.ZCard(ctx, redisGateRequestQueue).Val()
+		}, 10*time.Second, 500*time.Millisecond).Should(gomega.Equal(int64(1)))
+
+		gomega.Expect(producer.CancelRequests(ctx, []string{requestID})).To(gomega.Succeed())
+
+		setDispatchGateBudget(ctx, rdb, "1.0")
+
+		resultCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		result, err := producer.GetResult(resultCtx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(result).NotTo(gomega.BeNil())
+		gomega.Expect(result.ID).To(gomega.Equal(requestID))
+		gomega.Expect(result.ErrorCode).To(gomega.Equal(api.ErrCodeCancelled))
+		gomega.Expect(result.ErrorMessage).To(gomega.Equal("cancelled"))
+		gomega.Expect(result.StatusCode).To(gomega.Equal(0))
 	})
 })


### PR DESCRIPTION
## What does this PR do?
This PR adds request cancellation support for the Redis sorted-set async flow and makes cancellation generation-aware so reused request IDs do not inherit stale cancel state.
It:
- adds `CancelRequests()` to the producer and stores an active request token per submission
- writes cancellation markers against the active generation only, then checks them in both dequeue and worker pre-dispatch paths
- emits `CANCELLED` results when a request is dropped before dispatch
- cleans up active/cancel markers safely by token so older results cannot clear newer generations
- adds producer-to-result e2e coverage for the cancel path
## Why is this change needed?
Previously, there was no producer-side API to cancel pending async requests, so requests could still be dispatched after a batch/job had been cancelled.
This change is needed to:
- stop requests before dispatch when cancellation arrives in time
- avoid stale cancellation poisoning when the same request ID is reused
- preserve correctness across races between old results, new submissions, and cancellation markers
Cancellation is best-effort up to dequeue/pre-dispatch. It does not guarantee aborting already in-flight inference requests.
## How was this tested?
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed
Verified with:
- `make test-all`
- `go test ./...` in `api`
- `go test ./...` in `pipeline`
- `go test ./...` in `producer`
- `make test-e2e`
## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)
## Related Issues
Fixes #299