### PR TITLE
fix: only render imagePullSecrets on ServiceAccount when set

### DIFF
--- a/charts/async-processor/templates/ap-serviceaccounts.yaml
+++ b/charts/async-processor/templates/ap-serviceaccounts.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "async-processor.labels" . | nindent 4 }}
+{{- if .Values.ap.imagePullSecret }}
 imagePullSecrets:
-  - name: {{ .Values.ap.imagePullSecret | default "" }}
+  - name: {{ .Values.ap.imagePullSecret }}
+{{- end }}


### PR DESCRIPTION
## What does this PR do?

Makes `imagePullSecrets` on the async-processor ServiceAccount conditional: only rendered when `ap.imagePullSecret` is actually set in values.

## Why is this change needed?

The current template unconditionally renders `imagePullSecrets: [{name: ""}]` when `ap.imagePullSecret` is not provided. An empty-name secret reference can cause Kubernetes warnings or errors during pod creation.

## How was this tested?

- [x] Manual testing performed
  - `helm template` with `ap.imagePullSecret` unset → ServiceAccount has no `imagePullSecrets` field
  - `helm template` with `ap.imagePullSecret: my-secret` → ServiceAccount has `imagePullSecrets: [{name: my-secret}]`

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Discovered during a full-chain audit of the [batch-gateway-operator](https://github.com/opendatahub-io/llm-d-batch-gateway-operator) CRD → helm values → chart template mapping.

## Release note

```release-note
NONE
```