### PR TITLE
feat: support imagePullSecrets array on ServiceAccount

### DIFF
--- a/charts/async-processor/templates/ap-serviceaccounts.yaml
+++ b/charts/async-processor/templates/ap-serviceaccounts.yaml
@@ -5,7 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "async-processor.labels" . | nindent 4 }}
-{{- if .Values.ap.imagePullSecret }}
+{{- if .Values.ap.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml .Values.ap.imagePullSecrets | nindent 2 }}
+{{- else if .Values.ap.imagePullSecret }}
 imagePullSecrets:
   - name: {{ .Values.ap.imagePullSecret }}
 {{- end }}

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -25,6 +25,13 @@ ap:
     # image stays in sync with the chart). Set explicitly to pin a different tag.
     tag: ""
   imagePullPolicy: Always
+  # imagePullSecrets is a list of references to secrets for pulling container
+  # images from private registries. Takes precedence over imagePullSecret.
+  # Example:
+  #   imagePullSecrets:
+  #     - name: registry-creds
+  #     - name: ghcr-token
+  imagePullSecrets: []
   # Global worker concurrency (in-flight requests per pool). The processor is
   # I/O-bound, so by Little's Law this caps throughput; the default of 8 left
   # real inference pools mostly idle. Tune to your backend's latency/throughput


### PR DESCRIPTION
## What does this PR do?

Add `ap.imagePullSecrets` (list) to the ServiceAccount template, alongside the existing `ap.imagePullSecret` (string). The list takes precedence when set.

## Why is this change needed?

The current chart only supports a single image pull secret. Kubernetes ServiceAccount supports multiple.

## How was this tested?

- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Follow-up to #313.

## Release note

```release-note
NONE
```