### PR TITLE
chore(release): retarget image and chart publish/pull to the llm-d org

### DIFF
--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -29,11 +29,11 @@ jobs:
           docker-file: Dockerfile
           tag: ${{ inputs.tag }}
           image-name: ${{ inputs.image-name }}
-          registry: ghcr.io/llm-d-incubation
+          registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}
           prerelease: ${{ inputs.prerelease }}
 
       - name: Run Trivy scan on Async Processor image
         uses: ./.github/actions/trivy-scan
         with:
-          image: ghcr.io/llm-d-incubation/${{ inputs.image-name }}:${{ inputs.tag }}
+          image: ghcr.io/llm-d/${{ inputs.image-name }}:${{ inputs.tag }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push multi-arch image
         run: |
-          IMAGE=ghcr.io/llm-d-incubation/${{ steps.version.outputs.project_name }}
+          IMAGE=ghcr.io/llm-d/${{ steps.version.outputs.project_name }}
           VERSION_TAG=${{ steps.tag.outputs.tag }}
           COMMIT_SHA=${{ steps.tag.outputs.commit_sha }}
           echo "Building $IMAGE with tags $VERSION_TAG and $COMMIT_SHA for linux/amd64,linux/arm64"
@@ -83,4 +83,4 @@ jobs:
       - name: Run Trivy scan
         uses: ./.github/actions/trivy-scan
         with:
-          image: ghcr.io/llm-d-incubation/${{ steps.version.outputs.project_name }}:${{ steps.tag.outputs.tag }}
+          image: ghcr.io/llm-d/${{ steps.version.outputs.project_name }}:${{ steps.tag.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export
 
 
 # Image URL to use all building/pushing image targets
-IMAGE_TAG_BASE ?= ghcr.io/llm-d-incubation
+IMAGE_TAG_BASE ?= ghcr.io/llm-d
 IMG_TAG ?= latest
 IMG ?= $(IMAGE_TAG_BASE)/async-processor:$(IMG_TAG)
 
@@ -401,7 +401,7 @@ set-version:
 	done
 
 ## Copied from https://github.com/llm-d-incubation/batch-gateway
-## publish-helm-chart: Patch chart for VERSION, package, append chart to SHA256SUMS, push to oci://ghcr.io/llm-d-incubation/charts (requires VERSION, yq, helm; GITHUB_TOKEN, GITHUB_ACTOR for push).
+## publish-helm-chart: Patch chart for VERSION, package, append chart to SHA256SUMS, push to oci://ghcr.io/llm-d/charts (requires VERSION, yq, helm; GITHUB_TOKEN, GITHUB_ACTOR for push).
 .PHONY: publish-helm-chart
 publish-helm-chart:
 	@if [ -z "$(VERSION)" ]; then \

--- a/charts/async-processor/tests/deployment_test.yaml
+++ b/charts/async-processor/tests/deployment_test.yaml
@@ -163,7 +163,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/llm-d-incubation/llm-d-async:0.7.0
+          value: ghcr.io/llm-d/llm-d-async:0.7.0
 
   - it: should honor an explicit image tag override
     set:
@@ -171,7 +171,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/llm-d-incubation/llm-d-async:v1.2.3
+          value: ghcr.io/llm-d/llm-d-async:v1.2.3
 
   - it: should render --pubsub.project-id when projectId is set
     set:

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -20,7 +20,7 @@ ap:
       cpu: 500m
       memory: 512Mi
   image:
-    repository: ghcr.io/llm-d-incubation/llm-d-async
+    repository: ghcr.io/llm-d/llm-d-async
     # Image tag. Leave empty to track the chart's appVersion (recommended so the
     # image stays in sync with the chart). Set explicitly to pin a different tag.
     tag: ""

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -31,7 +31,7 @@ REDIS_NS=${REDIS_NS:-"redis"}
 PROMETHEUS_SECRET_NS=${PROMETHEUS_SECRET_NS:-$MONITORING_NAMESPACE}
 
 # AP Configuration
-AP_IMAGE_REPO=${AP_IMAGE_REPO:-"ghcr.io/llm-d-incubation/async-processor"}
+AP_IMAGE_REPO=${AP_IMAGE_REPO:-"ghcr.io/llm-d/async-processor"}
 AP_IMAGE_TAG=${AP_IMAGE_TAG:-"latest"}
 AP_IMAGE_PULL_POLICY=${AP_IMAGE_PULL_POLICY:-"Never"}
 AP_RELEASE_NAME=${AP_RELEASE_NAME:-"async-processor"}

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -131,7 +131,7 @@ helm install async-processor ${ASYNC_REPO}/charts/async-processor/ \
 ```
 
 The values file (`docs/guides/e2e-deploy/async-processor-values.yaml`) configures:
-- Image: `ghcr.io/llm-d-incubation/llm-d-async:938cd44`
+- Image: `ghcr.io/llm-d/llm-d-async:938cd44`
 - Queue: Redis sorted-set with `redis.url` set directly (chart creates the Secret), configured via `queuesConfig`
 - Gate: `prometheus-budget` with pool=`optimized-baseline`, max_concurrency=100, baseline=0.05 (per-queue)
 - Prometheus URL pointing to the cluster's `llmd-kube-prometheus-stack-prometheus` service

--- a/docs/guides/e2e-deploy/async-processor-values.yaml
+++ b/docs/guides/e2e-deploy/async-processor-values.yaml
@@ -1,6 +1,6 @@
 ap:
   image:
-    repository: ghcr.io/llm-d-incubation/llm-d-async
+    repository: ghcr.io/llm-d/llm-d-async
     tag: "938cd44"
   imagePullPolicy: Always
   igwBaseURL: "http://llm-d-inference-gateway-istio:80"

--- a/scripts/publish-helm-chart.sh
+++ b/scripts/publish-helm-chart.sh
@@ -7,7 +7,7 @@
 #   GITHUB_TOKEN  Token for helm registry login to ghcr.io
 #   GITHUB_ACTOR  Username for registry login (e.g. github.actor in Actions)
 #
-# Chart is always pushed to oci://ghcr.io/llm-d-incubation/charts (not configurable).
+# Chart is always pushed to oci://ghcr.io/llm-d/charts (not configurable).
 #
 # Requires: helm, yq (mikefarah). Run after make package-release so release/ exists.
 
@@ -21,7 +21,7 @@ CHART_VERSION="${VERSION#v}"
 export VERSION
 export CHART_VERSION
 
-HELM_OCI_REGISTRY='oci://ghcr.io/llm-d-incubation/charts'
+HELM_OCI_REGISTRY='oci://ghcr.io/llm-d/charts'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -56,7 +56,7 @@ var (
 	jaegerPort     string = env.GetEnvString("E2E_INTEGRATION_JAEGER_PORT", "30494", ginkgo.GinkgoLogr)
 
 	containerRuntime = detectContainerRuntime()
-	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d-incubation/async-processor:e2e-test", ginkgo.GinkgoLogr)
+	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d/async-processor:e2e-test", ginkgo.GinkgoLogr)
 	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
 	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.9.1", ginkgo.GinkgoLogr)
 	gaieRoot         = os.Getenv("GAIE_ROOT")


### PR DESCRIPTION
## What does this PR do?

Retargets image and Helm-chart **publishing and pulling** from `ghcr.io/llm-d-incubation` to `ghcr.io/llm-d`, following the repo's transfer into the `llm-d` org. GitHub redirects the git repo on transfer, but **GHCR packages do not follow a repo transfer**, so every publish/pull path had to move explicitly.

## Changes

**Publish (release):**
- `.github/workflows/ci-release.yaml` — build/push the release image and trivy-scan it under `ghcr.io/llm-d`.
- `.github/workflows/ci-build-images.yaml` — reusable build workflow registry/image.
- `scripts/publish-helm-chart.sh` — push the chart to `oci://ghcr.io/llm-d/charts`.

**Pull (consumers):**
- `charts/async-processor/values.yaml` — default image repository → `ghcr.io/llm-d/llm-d-async` (this is the one end users hit on `helm install`), plus the chart unit-test expectations.
- `deploy/install.sh`, the e2e default image (`test/e2e/e2e_suite_test.go`), and `docs/guides/e2e-deploy*`.

**Local/dev:** `Makefile` `IMAGE_TAG_BASE`.

## Out of scope (intentional)

- **Go module paths** (`github.com/llm-d-incubation/llm-d-async/...` in `go.mod`s and imports) are left unchanged. They are self-consistent and resolve via GitHub's repo redirect, so builds and `go get` keep working; renaming the module path is a separate breaking change for downstream consumers (e.g. the batch-gateway operator) and warrants its own PR.

## ⚠️ Ops prerequisite (not code)

Merging this is necessary but not sufficient — a release will only publish once an `llm-d` org admin ensures the release workflow's `GHCR_TOKEN` has `write:packages` on the `llm-d` org and the `llm-d-async` image + `charts/async-processor` packages can be created there. Existing `ghcr.io/llm-d-incubation/*` packages keep working via their old path until deleted, so pinned consumers aren't broken immediately.

## How was this tested?

- `helm template` → default image renders `ghcr.io/llm-d/llm-d-async:0.7.0`
- `helm lint` clean; `helm unittest` **49/49 pass**
- `go vet -tags e2e ./test/e2e/` ok

## Release note

```release-note
Image and Helm chart are now published to and pulled from ghcr.io/llm-d (was ghcr.io/llm-d-incubation).
```
