### PR TITLE
Add E2E reddis sorted set queue clearing benchmark

### DIFF
--- a/test/e2e/e2e_benchmark_test.go
+++ b/test/e2e/e2e_benchmark_test.go
@@ -1,0 +1,257 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"github.com/llm-d/llm-d-async/api"
+)
+
+var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Ordered, func() {
+	var ctx context.Context
+
+	ginkgo.BeforeAll(func() {
+		redeployEPPWithFlowControl()
+
+		// Patch the simulator to simulate realistic TTFT & ITL
+		// TTFT: 10ms, ITL: 1ms, Max concurrency: 32.
+		// Also increase max waiting queue length so EPP doesn't reject requests.
+		ginkgo.By("Patching llm-sim to simulate realistic latencies")
+		patchSimArgs([]string{
+			"--model", "test-model",
+			"--port", "8000",
+			"--time-to-first-token", "10ms",
+			"--inter-token-latency", "1ms",
+			"--max-num-seqs", "32",
+			"--max-waiting-queue-length", "2000",
+			"--max-model-len", "4096",
+			"--v", "4",
+		})
+	})
+
+	ginkgo.AfterAll(func() {
+		// Restore the default simulator setup (which uses fake metrics and responds instantly)
+		ginkgo.By("Restoring default llm-sim configuration")
+		patchSimArgs([]string{
+			"--model", "test-model",
+			"--port", "8000",
+			"--fake-metrics", `{"kv-cache-usage": 0, "waiting-requests": 0, "running-requests": 0}`,
+		})
+	})
+
+	ginkgo.BeforeEach(func() {
+		ctx = context.Background()
+
+		// Clean the benchmark queues
+		rdb.Del(ctx, benchmarkRequestQueue)         //nolint:errcheck
+		rdb.Del(ctx, benchmarkResultQueue)          //nolint:errcheck
+		rdb.Del(ctx, benchmarkPoolGateRequestQueue) //nolint:errcheck
+		rdb.Del(ctx, benchmarkPoolGateResultQueue)  //nolint:errcheck
+	})
+
+	ginkgo.It("measure clearing time and saturation under load with queue-level gate", func() {
+		// Build a prompt containing 1000 tokens by repeating a word 1000 times
+		prompt := strings.Repeat("word ", 1000)
+
+		numRequests := 5000
+		ginkgo.By(fmt.Sprintf("Bulk enqueuing %d inference requests (1000 input tokens, 500 output tokens)", numRequests))
+
+		msgs := make([]api.RequestMessage, numRequests)
+		now := time.Now().Unix()
+		for i := 0; i < numRequests; i++ {
+			msgs[i] = api.RequestMessage{
+				ID:       fmt.Sprintf("bench-msg-%d", i),
+				Created:  now,
+				Deadline: now + 600, // 10 minutes deadline
+				Payload: map[string]any{
+					"model":      "test-model",
+					"prompt":     prompt,
+					"max_tokens": 500,
+				},
+			}
+		}
+
+		// Enqueue all messages atomically via pipeline
+		enqueueMessages(ctx, rdb, benchmarkRequestQueue, msgs...)
+
+		ginkgo.By("Starting performance monitoring loop")
+		var saturationMetrics []float64
+		monitorCtx, monitorCancel := context.WithCancel(ctx)
+		var monitorWg sync.WaitGroup
+		monitorWg.Add(1)
+
+		// Start a goroutine to poll Prometheus for saturation metrics during the benchmark run
+		go func() {
+			defer monitorWg.Done()
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-monitorCtx.Done():
+					return
+				case <-ticker.C:
+					// Send probe requests to drive flow control admission logic in EPP
+					sendProbeRequest(envoyURL)
+					satVal := queryProm(promURL, `inference_extension_flow_control_pool_saturation{inference_pool="e2e-pool"}`)
+					if !math.IsNaN(satVal) {
+						saturationMetrics = append(saturationMetrics, satVal)
+					}
+				}
+			}
+		}()
+
+		startTime := time.Now()
+
+		ginkgo.By("Waiting for all messages to be processed")
+		// Wait for the result queue length to match the enqueued requests count
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, benchmarkResultQueue)
+		}, 10*time.Minute, 5*time.Second).Should(gomega.Equal(int64(numRequests)))
+
+		elapsedTime := time.Since(startTime)
+		monitorCancel()
+		monitorWg.Wait()
+
+		// Calculate average saturation
+		var avgSaturation float64
+		if len(saturationMetrics) > 0 {
+			var sum float64
+			for _, v := range saturationMetrics {
+				sum += v
+			}
+			avgSaturation = sum / float64(len(saturationMetrics))
+		}
+
+		ginkgo.GinkgoWriter.Printf("\n================ BENCHMARK RESULTS ================\n")
+		ginkgo.GinkgoWriter.Printf("Total Requests: %d\n", numRequests)
+		ginkgo.GinkgoWriter.Printf("Total Queue Clearing Time: %s\n", elapsedTime)
+		ginkgo.GinkgoWriter.Printf("Average Saturation Level: %.4f\n", avgSaturation)
+		ginkgo.GinkgoWriter.Printf("Saturation Metric Points Collected: %v\n", saturationMetrics)
+		ginkgo.GinkgoWriter.Printf("===================================================\n\n")
+
+		// Verify basic correctness: result queue contains all processed messages
+		gomega.Expect(getResultCount(ctx, rdb, benchmarkResultQueue)).To(gomega.Equal(int64(numRequests)))
+	})
+
+	ginkgo.It("measure clearing time and saturation under load with pool-level gate", func() {
+		// Build a prompt containing 1000 tokens by repeating a word 1000 times
+		prompt := strings.Repeat("word ", 1000)
+
+		numRequests := 5000
+		ginkgo.By(fmt.Sprintf("Bulk enqueuing %d inference requests (1000 input tokens, 500 output tokens) to pool gate queue", numRequests))
+
+		msgs := make([]api.RequestMessage, numRequests)
+		now := time.Now().Unix()
+		for i := 0; i < numRequests; i++ {
+			msgs[i] = api.RequestMessage{
+				ID:       fmt.Sprintf("bench-pool-msg-%d", i),
+				Created:  now,
+				Deadline: now + 600, // 10 minutes deadline
+				Payload: map[string]any{
+					"model":      "test-model",
+					"prompt":     prompt,
+					"max_tokens": 500,
+				},
+			}
+		}
+
+		// Enqueue all messages atomically via pipeline
+		enqueueMessages(ctx, rdb, benchmarkPoolGateRequestQueue, msgs...)
+
+		ginkgo.By("Starting performance monitoring loop for worker pool gate")
+		var saturationMetrics []float64
+		monitorCtx, monitorCancel := context.WithCancel(ctx)
+		var monitorWg sync.WaitGroup
+		monitorWg.Add(1)
+
+		// Start a goroutine to poll Prometheus for saturation metrics during the benchmark run
+		go func() {
+			defer monitorWg.Done()
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-monitorCtx.Done():
+					return
+				case <-ticker.C:
+					// Send probe requests to drive flow control admission logic in EPP
+					sendProbeRequest(envoyURL)
+					satVal := queryProm(promURL, `inference_extension_flow_control_pool_saturation{inference_pool="e2e-pool"}`)
+					if !math.IsNaN(satVal) {
+						saturationMetrics = append(saturationMetrics, satVal)
+					}
+				}
+			}
+		}()
+
+		startTime := time.Now()
+
+		ginkgo.By("Waiting for all messages to be processed by worker pool gate")
+		// Wait for the result queue length to match the enqueued requests count
+		gomega.Eventually(func() int64 {
+			return getResultCount(ctx, rdb, benchmarkPoolGateResultQueue)
+		}, 10*time.Minute, 5*time.Second).Should(gomega.Equal(int64(numRequests)))
+
+		elapsedTime := time.Since(startTime)
+		monitorCancel()
+		monitorWg.Wait()
+
+		// Calculate average saturation
+		var avgSaturation float64
+		if len(saturationMetrics) > 0 {
+			var sum float64
+			for _, v := range saturationMetrics {
+				sum += v
+			}
+			avgSaturation = sum / float64(len(saturationMetrics))
+		}
+
+		ginkgo.GinkgoWriter.Printf("\n================ WORKER POOL GATE BENCHMARK RESULTS ================\n")
+		ginkgo.GinkgoWriter.Printf("Total Requests: %d\n", numRequests)
+		ginkgo.GinkgoWriter.Printf("Total Queue Clearing Time: %s\n", elapsedTime)
+		ginkgo.GinkgoWriter.Printf("Average Saturation Level: %.4f\n", avgSaturation)
+		ginkgo.GinkgoWriter.Printf("Saturation Metric Points Collected: %v\n", saturationMetrics)
+		ginkgo.GinkgoWriter.Printf("====================================================================\n\n")
+
+		// Verify basic correctness: result queue contains all processed messages
+		gomega.Expect(getResultCount(ctx, rdb, benchmarkPoolGateResultQueue)).To(gomega.Equal(int64(numRequests)))
+	})
+})
+
+func patchSimArgs(args []string) {
+	// Construct the patch JSON
+	// Since json.Marshal on string slices can be tricky inside a raw patch, we build it carefully.
+	// E.g. {"spec":{"template":{"spec":{"containers":[{"name":"sim","args":["--model","test-model",...]}]}}}}
+	var argsQuoted []string
+	for _, arg := range args {
+		// Escape quotes in args (specifically for the fake-metrics JSON string)
+		escaped := strings.ReplaceAll(arg, `"`, `\"`)
+		argsQuoted = append(argsQuoted, fmt.Sprintf(`"%s"`, escaped))
+	}
+	patchStr := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":"sim","args":[%s]}]}}}}`, strings.Join(argsQuoted, ","))
+
+	cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+		"-n", nsName, "patch", "deployment", "llm-sim",
+		"--patch", patchStr)
+	session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Eventually(session).WithTimeout(30 * time.Second).Should(gexec.Exit(0))
+
+	// Wait for the rollout to complete
+	cmd = exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+		"-n", nsName, "rollout", "status", "deployment/llm-sim", "--timeout=120s")
+	session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Eventually(session).WithTimeout(120 * time.Second).Should(gexec.Exit(0))
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -58,7 +58,7 @@ var (
 	containerRuntime = detectContainerRuntime()
 	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d/async-processor:e2e-test", ginkgo.GinkgoLogr)
 	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
-	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.9.1", ginkgo.GinkgoLogr)
+	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
 	gaieRoot         = os.Getenv("GAIE_ROOT")
 	simRoot          = os.Getenv("SIM_ROOT")
 
@@ -151,6 +151,19 @@ func pullIfMissing(image string) {
 
 func setupK8sCluster() {
 	kindKubeconfig = filepath.Join(os.TempDir(), "kind-kubeconfig-"+kindClusterName)
+
+	// Check if cluster already exists
+	checkCmd := exec.Command("kind", "get", "clusters")
+	output, err := checkCmd.Output()
+	if err == nil && strings.Contains(string(output), kindClusterName) {
+		ginkgo.By("Kind cluster " + kindClusterName + " already exists, rebuilding and loading async-processor image")
+		command := exec.Command(containerRuntime, "build", "-t", apImage, projectRoot())
+		session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
+		kindLoadImage(apImage)
+		return
+	}
 
 	if containerRuntime == "podman" {
 		ginkgo.By("Setting KIND_EXPERIMENTAL_PROVIDER=podman")
@@ -335,6 +348,8 @@ func applyManifests() {
 		{"multitenant", helmValuesDir + "/multitenant.yaml"},
 		{"tier-priority", helmValuesDir + "/tier-priority.yaml"},
 		{"mt-merge", helmValuesDir + "/mt-merge.yaml"},
+		{"benchmark", helmValuesDir + "/benchmark.yaml"},
+		{"benchmark-pool-gate", helmValuesDir + "/benchmark-pool-gate.yaml"},
 	} {
 		helmInstall(r.name, r.values, map[string]string{
 			"ap.image.repository": imageRepo,
@@ -394,7 +409,7 @@ func splitImage(image string) (string, string) {
 }
 
 func helmInstall(releaseName, valuesFile string, sets map[string]string) {
-	args := []string{"install", releaseName, chartPath,
+	args := []string{"upgrade", "--install", releaseName, chartPath,
 		"-f", valuesFile, "-n", nsName, "--wait", "--timeout=120s"}
 	for k, v := range sets {
 		args = append(args, "--set", k+"="+v)
@@ -565,6 +580,8 @@ func doRedeployEPPWithFlowControl() {
 		"multitenant-async-processor",
 		"tier-priority-async-processor",
 		"mt-merge-async-processor",
+		"benchmark-async-processor",
+		"benchmark-pool-gate-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "restart", "deployment/"+deploy)
@@ -585,6 +602,8 @@ func doRedeployEPPWithFlowControl() {
 		"multitenant-async-processor",
 		"tier-priority-async-processor",
 		"mt-merge-async-processor",
+		"benchmark-async-processor",
+		"benchmark-pool-gate-async-processor",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "status", "deployment/"+deploy, "--timeout=120s")

--- a/test/e2e/helm/benchmark-pool-gate.yaml
+++ b/test/e2e/helm/benchmark-pool-gate.yaml
@@ -1,0 +1,29 @@
+ap:
+  imagePullPolicy: Never
+  messageQueueImpl: "redis-sortedset"
+  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
+  prometheusCacheTTL: "0s"
+  workerPools:
+    - id: "benchmark-pool"
+      workers: 64
+      gate_type: "wait-on-refuse"
+      gate_params:
+        gate: '{"gate_type":"composite","gate_params":{"gates":[{"gate_type":"prometheus-saturation","gate_params":{"pool":"e2e-pool","threshold":"0.8"}},{"gate_type":"local-max-concurrency","gate_params":{"limit":50}}]}}'
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    enabled: true
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
+    resultQueueName: "benchmark-pool-gate-result-list"
+    pollIntervalMs: 50
+    batchSize: 64
+    queuesConfig:
+      - queue_name: "benchmark-pool-gate-request-sortedset"
+        worker_pool_id: "benchmark-pool"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/helm/benchmark.yaml
+++ b/test/e2e/helm/benchmark.yaml
@@ -1,0 +1,33 @@
+ap:
+  imagePullPolicy: Never
+  messageQueueImpl: "redis-sortedset"
+  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  concurrency: 64
+  prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
+  prometheusCacheTTL: "0s"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    enabled: true
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
+    resultQueueName: "benchmark-result-list"
+    pollIntervalMs: 50
+    batchSize: 64
+    queuesConfig:
+      - queue_name: "benchmark-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "composite"
+        gate_params:
+          gates:
+            - gate_type: "prometheus-saturation"
+              gate_params:
+                pool: "e2e-pool"
+                threshold: "0.8"
+            - gate_type: "local-max-concurrency"
+              gate_params:
+                limit: 40
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -38,6 +38,12 @@ const (
 	tierPriorityInteractiveQueue = "tier-priority-interactive"
 	tierPriorityAsyncQueue       = "tier-priority-async"
 	tierPriorityResultQueue      = "tier-priority-result-list"
+
+	benchmarkRequestQueue = "benchmark-request-sortedset"
+	benchmarkResultQueue  = "benchmark-result-list"
+
+	benchmarkPoolGateRequestQueue = "benchmark-pool-gate-request-sortedset"
+	benchmarkPoolGateResultQueue  = "benchmark-pool-gate-result-list"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}

--- a/test/e2e/yaml/epp-config-fc.yaml
+++ b/test/e2e/yaml/epp-config-fc.yaml
@@ -24,4 +24,4 @@ data:
       - pluginRef: queue-scorer
       - pluginRef: kv-cache-utilization-scorer
     flowControl:
-      maxRequests: "10"
+      maxRequests: "100"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

Adds benchmark that times how long it takes to clear a queue of requests that are identical in size.
Add benchmark for setup using queue gate and setup using pool gate.

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

These benchmark tests will fail if it takes longer than 70 seconds to clear the queue of requests. This is to detect regressions in the queue flow handling.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

Fixes: #309

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
NONE
```
