### PR TITLE
ci(release): publish image with github.token (drop GHCR_TOKEN PAT)

### DIFF
--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -12,13 +12,13 @@ on:
       prerelease:
         required: true
         type: string
-    secrets:
-      GHCR_TOKEN:
-        required: true
 
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -30,7 +30,7 @@ jobs:
           tag: ${{ inputs.tag }}
           image-name: ${{ inputs.image-name }}
           registry: ghcr.io/llm-d
-          github-token: ${{ secrets.GHCR_TOKEN }}
+          github-token: ${{ github.token }}
           prerelease: ${{ inputs.prerelease }}
 
       - name: Run Trivy scan on Async Processor image

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -13,6 +13,9 @@ on:
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -49,7 +52,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push multi-arch image
         run: |


### PR DESCRIPTION
## What does this PR do?

Switches the release **image** publish from the `GHCR_TOKEN` PAT to the built-in `${{ github.token }}` (with an explicit `permissions: packages: write`), matching the `llm-d` org convention used by `llm-d-go-template`, `llm-d-router`, and `llm-d-batch-gateway`. Also drops the now-unused `GHCR_TOKEN` secret input from the reusable `ci-build-images.yaml`.

## Why

After the org migration, the v0.7.4 image published correctly to `ghcr.io/llm-d/llm-d-async` but came out **private and not linked to the repo** — because it was pushed with a **classic PAT** (`GHCR_TOKEN`). The default `GITHUB_TOKEN` instead **auto-links the package to the repo and inherits repo visibility**, which is exactly why our *chart* (already published with `GITHUB_TOKEN`) came out public + linked. This aligns the image with that behavior, so future releases need no manual public/link step.

Token audit that motivated this (image publish auth):
- `llm-d-go-template`, `llm-d-router`, `llm-d-batch-gateway` → `github.token` + `packages: write` ✅
- `llm-d-async` (this repo, image) and `llm-d-inference-sim` → `GHCR_TOKEN` PAT ⚠️ (this PR fixes async)

## Follow-ups (not in this PR)
- The `GHCR_TOKEN` **repo secret** can be deleted once this merges (no longer referenced).
- The **already-published v0.7.4 image** still needs a one-time **set-public + link-to-repo** in the org package settings; releases after this merge will be linked/public automatically.
- `llm-d-inference-sim` is the other repo still on `GHCR_TOKEN` — worth a matching PR (separate team).

## How was this tested?
- YAML validated; `GHCR_TOKEN` no longer referenced in any workflow.
- Change mirrors the working `llm-d-router` `ci-build-images.yaml` / `ci-release.yaml` exactly.

## Release note
```release-note
NONE
```
