### PR TITLE
feat: support Valkey as a drop-in replacement for Redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ undeploy-ap-on-k8s:
 #   AP_IMAGE         — async-processor image tag        (default: $(IMAGE_TAG_BASE)/async-processor:e2e-test)
 #   EPP_IMAGE        — EPP image tag                    (default: registry.k8s.io/.../epp:v1.5.0)
 #   SIM_IMAGE        — inference-sim image tag          (default: ghcr.io/llm-d/llm-d-inference-sim:v0.0.0-test)
+#   REDIS_IMAGE      — Redis/Valkey image for E2E MQ    (default: valkey/valkey:8-alpine)
 #   CONTAINER_TOOL   — container runtime                (default: docker)
 #   E2E_SKIP_CLEANUP — set "true" to keep the Kind cluster after tests
 #

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The architecture adheres to the following core principles:
   - [When to Use](#when-to-use)
   - [Design Principles](#design-principles)
   - [Table of Contents](#table-of-contents)
+  - [Backend Compatibility](#backend-compatibility)
   - [Deployment](#deployment)
   - [Command line parameters](#command-line-parameters)
   - [Dispatch Gates](#dispatch-gates)
@@ -56,6 +57,14 @@ The architecture adheres to the following core principles:
       - [GCP PubSub Command line parameters](#gcp-pubsub-command-line-parameters)
       - [Multiple Topics Configuration File Syntax](#multiple-topics-configuration-file-syntax)
   - [Development](#development)
+
+## Backend Compatibility
+
+The Async Processor uses the Redis wire protocol for its message queue implementations (`redis-sortedset`, `redis-pubsub`) and dispatch gates (`redis`, `redis-quota`). Redis-protocol-compatible backends such as [Valkey](https://valkey.io/) can be used with the existing Redis configuration surface.
+
+All `--redis.*` CLI flags, Helm values, and environment variables (e.g. `REDIS_URL`) work unchanged with Valkey — point them at your Valkey endpoint the same way you would with Redis.
+
+> **Note:** CLI flags and Helm values retain the `redis.*` prefix because it refers to the wire protocol, not a specific product.
 
 ## Deployment
 
@@ -601,7 +610,7 @@ A persisted implementation based on Redis SortedSets.
 ![Async Processor - Redis Sorted Set architecture](/docs/images/redis_sortedset_architecture.png "AP - Redis SortedSet")
 
 #### Redis Sorted Set Command line parameters
-- `redis.url`: Redis URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Can also be set via `REDIS_URL` env var.
+- `redis.url`: Redis/Valkey URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Supports Redis-protocol-compatible backends such as Valkey. Can also be set via `REDIS_URL` env var.
 - `redis.ss.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.ss.queues-config-file` flag.
 - `redis.ss.request-path-url`: Request path url (e.g.: "/v1/completions"). <br> Mutually exclusive with `redis.ss.queues-config-file` flag.")
 - `redis.ss.inference-objective`: InferenceObjective to use for requests (set as the HTTP header x-gateway-inference-objective if not empty).  <br> Mutually exclusive with `redis.ss.queues-config-file` flag.
@@ -629,7 +638,7 @@ An example implementation based on Redis channels is provided.
 
 #### Redis Channels Command line parameters
 
-- `redis.url`: Redis URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Can also be set via `REDIS_URL` env var.
+- `redis.url`: Redis/Valkey URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Supports Redis-protocol-compatible backends such as Valkey. Can also be set via `REDIS_URL` env var.
 - `redis.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.queues-config-file` flag.
 - `redis.request-path-url`: Request path url (e.g.: "/v1/completions"). <br> Mutually exclusive with `redis.queues-config-file` flag.")
 - `redis.inference-objective`: InferenceObjective to use for requests (set as the HTTP header x-gateway-inference-objective if not empty).  <br> Mutually exclusive with `redis.queues-config-file` flag.

--- a/charts/async-processor/values.yaml
+++ b/charts/async-processor/values.yaml
@@ -78,8 +78,8 @@ ap:
     # Sampling ratio (0.0 to 1.0), used when sampler is "*traceidratio".
     # 1.0 = 100% (dev), 0.1 = 10% (production).
     samplerArg: "1.0"
-    # Enable per-command Redis tracing spans. Can produce high span volume —
-    # leave disabled unless actively debugging Redis.
+    # Enable per-command Redis/Valkey tracing spans. Can produce high span volume —
+    # leave disabled unless actively debugging Redis/Valkey.
     redisTracing: false
   health:
     port: 8081
@@ -138,6 +138,8 @@ ap:
     keyKey: ""
   redis:
     enabled: false
+    # Compatible with any Redis-protocol server including Valkey.
+    # All redis.* fields work unchanged when pointed at a Valkey endpoint.
     # Option 1: provide the URL directly — chart creates the Secret automatically.
     # WARNING: Helm values are retrievable via `helm get values` and may expose credentials.
     # For production or credentialed URLs, prefer Option 2 (secretName/secretKey).

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -41,7 +41,10 @@ SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-"false"}
 AP_LOG_LEVEL=${AP_LOG_LEVEL:-"info"}
 VALUES_FILE=${VALUES_FILE:-"$AP_PROJECT/charts/async-processor/values.yaml"}
 
-# Redis Configuration
+# Redis / Valkey Configuration
+# REDIS_CHART selects the Helm chart for the message queue backend.
+# Use "bitnami/valkey" (default) or "bitnami/redis".
+REDIS_CHART=${REDIS_CHART:-"bitnami/valkey"}
 REDIS_RELEASE_NAME=${REDIS_RELEASE_NAME:-"redis"}
 
 
@@ -422,15 +425,22 @@ deploy_ap_controller() {
 }
 
 deploy_redis() {
-    log_info "Deploying Redis..."
+    log_info "Deploying message queue backend ($REDIS_CHART)..."
     helm repo add bitnami https://charts.bitnami.com/bitnami
     helm repo update
 
-    helm upgrade -i "$REDIS_RELEASE_NAME" bitnami/redis -n $REDIS_NS --set auth.enabled=false
+    helm upgrade -i "$REDIS_RELEASE_NAME" "$REDIS_CHART" -n $REDIS_NS --set auth.enabled=false
 
-    # Create a secret with the Redis URL in the AP namespace so the async-processor can connect
-    local redis_url="redis://${REDIS_RELEASE_NAME}-master.${REDIS_NS}.svc.cluster.local:6379"
-    log_info "Creating Redis URL secret in $AP_NS namespace"
+    # Derive service name: bitnami/redis uses -master, bitnami/valkey uses -primary.
+    local svc
+    case "$REDIS_CHART" in
+      */valkey) svc="${REDIS_RELEASE_NAME}-primary" ;;
+      *)        svc="${REDIS_RELEASE_NAME}-master"  ;;
+    esac
+
+    # Create a secret with the Redis-protocol URL in the AP namespace so the async-processor can connect
+    local redis_url="redis://${svc}.${REDIS_NS}.svc.cluster.local:6379"
+    log_info "Creating message queue URL secret in $AP_NS namespace"
     kubectl create secret generic redis-creds \
         --from-literal=url="$redis_url" \
         -n "$AP_NS" --dry-run=client -o yaml | kubectl apply -f -
@@ -728,12 +738,12 @@ undeploy_ap_controller() {
 }
 
 undeploy_redis() {
-    log_info "Uninstalling Redis (release: $REDIS_RELEASE_NAME)..."
+    log_info "Uninstalling message queue backend (release: $REDIS_RELEASE_NAME)..."
 
     helm uninstall "$REDIS_RELEASE_NAME" -n $REDIS_NS 2>/dev/null || \
-        log_warning "Redis not found or already uninstalled"
+        log_warning "Message queue backend not found or already uninstalled"
 
-    log_success "Redis uninstalled"
+    log_success "Message queue backend uninstalled"
 }
 
 cleanup() {
@@ -885,11 +895,11 @@ main() {
     # Create namespaces
     create_namespaces
 
-    # Deploy Redis
+    # Deploy message queue backend (Redis/Valkey)
     if [ "$DEPLOY_REDIS" = "true" ]; then
         deploy_redis
     else
-        log_info "Skipping Redis deployment (DEPLOY_REDIS=false)"
+        log_info "Skipping message queue deployment (DEPLOY_REDIS=false)"
     fi
 
 

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -115,11 +115,22 @@ kubectl run --rm -i prom-check --image=curlimages/curl --restart=Never -n ${NAME
 
 Expected: `inference_pool_ready_pods{name="optimized-baseline"} = 1`
 
-## Step 8: Install Redis
+## Step 8: Install Redis (or Valkey)
+
+[Valkey](https://valkey.io/) is a BSD-licensed, Redis-compatible alternative that works as a drop-in replacement. All `redis.*` flags and configurations work unchanged with Valkey.
+
+**Option A — Redis:**
 
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install redis bitnami/redis -n redis --create-namespace --set auth.enabled=false
+```
+
+**Option B — Valkey:**
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install redis bitnami/valkey -n redis --create-namespace --set auth.enabled=false
 ```
 
 ## Step 9: Deploy Async Processor with dispatch budget gate

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -59,6 +59,7 @@ var (
 	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d/async-processor:e2e-test", ginkgo.GinkgoLogr)
 	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
 	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
+	redisImage       = env.GetEnvString("REDIS_IMAGE", "valkey/valkey:8-alpine", ginkgo.GinkgoLogr)
 	gaieRoot         = os.Getenv("GAIE_ROOT")
 	simRoot          = os.Getenv("SIM_ROOT")
 
@@ -222,8 +223,8 @@ func setupK8sCluster() {
 	kindLoadImage(eppImage)
 	kindLoadImage(simImage)
 
-	pullIfMissing("redis:7-alpine")
-	kindLoadImage("redis:7-alpine")
+	pullIfMissing(redisImage)
+	kindLoadImage(redisImage)
 
 	pullIfMissing("docker.io/envoyproxy/envoy:distroless-v1.33.2")
 	kindLoadImage("docker.io/envoyproxy/envoy:distroless-v1.33.2")
@@ -259,7 +260,19 @@ func kindLoadImage(image string) {
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
 	} else {
-		command := exec.Command("kind", "load", "docker-image", image, "--name", kindClusterName)
+		// Pipe through ctr import WITHOUT --all-platforms. Kind's built-in
+		// "kind load docker-image" passes --all-platforms to ctr, which
+		// fails for multi-arch images when only one platform's layers are
+		// present locally (e.g. arm64-only pull on Apple Silicon).
+		//
+		// This applies to ALL images loaded into the cluster (not just the
+		// MQ image). It assumes a single-node Kind cluster with the default
+		// control-plane node name and overlayfs snapshotter.
+		node := kindClusterName + "-control-plane"
+		shell := fmt.Sprintf(
+			"docker save %s | docker exec -i %s ctr --namespace=k8s.io images import --digests --snapshotter=overlayfs -",
+			image, node)
+		command := exec.Command("bash", "-c", shell)
 		session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Eventually(session).WithTimeout(600 * time.Second).Should(gexec.Exit(0))
@@ -307,7 +320,7 @@ func applyManifests() {
 	}
 
 	ginkgo.By("Applying Redis manifest")
-	kubectlApplyFile(redisManifest, nil)
+	kubectlApplyFile(redisManifest, map[string]string{"${REDIS_IMAGE}": redisImage})
 
 	ginkgo.By("Applying sim manifest")
 	kubectlApplyFile(simManifest, nil)

--- a/test/e2e/yaml/redis.yaml
+++ b/test/e2e/yaml/redis.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: ${REDIS_IMAGE}
           ports:
             - containerPort: 6379
           readinessProbe:


### PR DESCRIPTION
## Why is this PR needed?

Redis changed its license to RSALv2/SSPL starting with version 7.4, which is incompatible with FOSS distribution requirements and blocks RHOAI adoption. Red Hat has already replaced Redis with Valkey across Fedora 41+ and RHEL 10. Valkey is a BSD-licensed Redis 7.2 fork under the Linux Foundation that is wire-protocol compatible.

## What does this PR do?

**Documentation:**
- Add a "Backend Compatibility" section to README documenting Valkey as a supported backend
- Add Valkey compatibility notes to Helm chart `values.yaml` comments
- Add Valkey install option to the e2e deployment guide (`docs/guides/e2e-deploy.md`)
- Update `deploy/install.sh` to support `REDIS_CHART` env var (defaults to `bitnami/valkey`, overridable to `bitnami/redis`)

**E2E validation:**
- Switch default E2E image from `redis:7-alpine` to `valkey/valkey:8-alpine`, configurable via `REDIS_IMAGE` env var
- Make `redis.yaml` manifest use `${REDIS_IMAGE}` substitution instead of a hardcoded image
- Fix `kindLoadImage` to use `ctr import` without `--all-platforms`, which fails for multi-arch images when only one platform's layers are present locally (pre-existing issue exposed by the image switch)

**Non-goals (intentional):**
- `redis.*` CLI flags, Helm values, and package names are **not renamed** — they refer to the wire protocol, not a specific product. Renaming would break all existing deployments.
- No migration to `valkey-io/valkey-go` client library — `go-redis` works for both.
- No removal of Redis support — existing Redis deployments continue to work.

## How was this tested?

- [x] `pre-commit run -a` passes (golangci-lint failure is pre-existing on main)
- [x] `go vet ./test/e2e/` passes
- [x] Full E2E suite (36/36 specs) passes with `valkey/valkey:8-alpine` as the message queue backend
- [x] All gate types verified against Valkey: `redis`, `redis-quota`, `prometheus-saturation`, `prometheus-budget`, `composite`

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #325