### PR TITLE
fix: suppress typos false-positives (typ, unmarshaling)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,10 @@ k8s = "k8s"
 KServe = "KServe"
 vLLM = "vLLM"
 IST = "IST"
+# Go convention: `typ` is a common identifier (since `type` is a keyword);
+# `unmarshaling` is the standard Go/American spelling (typos suggests British).
+typ = "typ"
+unmarshaling = "unmarshaling"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
The nightly typo scan (#293) flagged **26** items — all false positives:

- **`typ` (24×)** — a deliberate Go identifier (since `type` is a keyword), used as a local variable in `pkg/plugins/plugins_test.go` and `pkg/asyncworker/transform/transform_test.go`.
- **`unmarshaling` (2×)** — the standard Go/American spelling (`pipeline/worker_pool.go`, `pkg/redis/sortedset_impl.go`); typos-cli suggests the British `unmarshalling`.

No code should change. This adds both to `.typos.toml` `[default.extend-words]` so the nightly scan runs clean.

Closes #293