### PR TITLE
Refactor CI container image and chart to use main and v0 tags

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -83,6 +83,7 @@ jobs:
         if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'main'
         env:
           VERSION: ${{ steps.tag.outputs.helm_version }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -35,13 +35,19 @@ jobs:
           COMMIT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
           echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF##refs/tags/}"
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF##refs/tags/}"
           elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            TAG="main"
           else
-            echo "tag=dev" >> "$GITHUB_OUTPUT"
+            TAG="dev"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            echo "helm_version=v0" >> "$GITHUB_OUTPUT"
+          else
+            echo "helm_version=${TAG}" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
 
@@ -74,9 +80,9 @@ jobs:
           # helm is usually pre-installed on ubuntu-latest
 
       - name: Publish Helm chart
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') || github.ref_name == 'main'
         env:
-          VERSION: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.helm_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,7 @@ publish-helm-chart:
 	  echo "VERSION is required (e.g. VERSION=v1.0.0 make publish-helm-chart)"; exit 1; \
 	fi
 	@export VERSION="$(VERSION)"; \
+	export IMAGE_TAG="$(IMAGE_TAG)"; \
 	export GITHUB_TOKEN="$(GITHUB_TOKEN)"; \
 	export GITHUB_ACTOR="$(GITHUB_ACTOR)"; \
 	./scripts/publish-helm-chart.sh

--- a/scripts/publish-helm-chart.sh
+++ b/scripts/publish-helm-chart.sh
@@ -17,9 +17,9 @@
 set -euo pipefail
 
 VERSION="${VERSION:?VERSION is required (e.g. v1.0.0)}"
-CHART_VERSION="${VERSION#v}"
+IMAGE_TAG="${IMAGE_TAG:-${VERSION}}"
 export VERSION
-export CHART_VERSION
+export IMAGE_TAG
 
 HELM_OCI_REGISTRY='oci://ghcr.io/llm-d/charts'
 
@@ -36,19 +36,16 @@ command -v helm >/dev/null 2>&1 || {
   exit 1
 }
 
-yq -i '.ap.image.tag = strenv(VERSION)' charts/llm-d-async/values.yaml
-# Chart version must be bare SemVer (OCI/Helm requirement), so it uses the
-# v-stripped CHART_VERSION. appVersion keeps the leading "v" to match the
-# published image tag (images are tagged with the git tag verbatim, e.g.
-# v0.7.1). This makes the recommended empty `ap.image.tag` default — which
-# falls back to .Chart.AppVersion — resolve to a tag that actually exists.
-yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(VERSION)' charts/llm-d-async/Chart.yaml
+yq -i '.ap.image.tag = strenv(IMAGE_TAG)' charts/llm-d-async/values.yaml
+# Chart version matches VERSION directly, preserving leading "v" if present (following the llm-d-router pattern).
+# appVersion matches the image tag (IMAGE_TAG) so that any fallback to .Chart.AppVersion resolves to a container image tag that actually exists.
+yq -i '.version = strenv(VERSION) | .appVersion = strenv(IMAGE_TAG)' charts/llm-d-async/Chart.yaml
 
 helm package charts/llm-d-async -d release/
 
-(cd release && sha256sum "llm-d-async-${CHART_VERSION}.tgz" >> SHA256SUMS && cat SHA256SUMS)
+(cd release && sha256sum "llm-d-async-${VERSION}.tgz" >> SHA256SUMS && cat SHA256SUMS)
 
 printf '%s' "${GITHUB_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
-helm push "release/llm-d-async-${CHART_VERSION}.tgz" "${HELM_OCI_REGISTRY}"
+helm push "release/llm-d-async-${VERSION}.tgz" "${HELM_OCI_REGISTRY}"
 
-echo "Helm chart published: ${HELM_OCI_REGISTRY}/llm-d-async:${CHART_VERSION}"
+echo "Helm chart published: ${HELM_OCI_REGISTRY}/llm-d-async:${VERSION}"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

 Refactor container image + helm chart tagging on main branch
 refactor the ci-release workflow to do the following:
    - use "main" tag for images built off main branch to follow llm-d-router
      precedent.
    - use "v0" for helm charts built off main branch to follow llm-d-router
      precedent.
    - prefix versions with v similar to llm-d-router versions.


## Why is this change needed?

Fixes: #315

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
NONE
```
