### PR TITLE
fix: refresh redis-quota concurrency TTL to prevent over-admission (#335)

### DIFF
--- a/pkg/redis/quota_gate.go
+++ b/pkg/redis/quota_gate.go
@@ -109,10 +109,11 @@ func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (ap
 		if current and tonumber(current) >= tonumber(ARGV[1]) then
 			return 0
 		end
-		local new_val = redis.call("INCR", KEYS[1])
-		if tonumber(new_val) == 1 then
-			redis.call("EXPIRE", KEYS[1], ARGV[2])
-		end
+		redis.call("INCR", KEYS[1])
+		-- Refresh the TTL on every acquire so the counter cannot expire while
+		-- requests are still in flight (#311 sibling). The key then expires only
+		-- after ARGV[2] seconds of total inactivity (crash-orphan cleanup).
+		redis.call("EXPIRE", KEYS[1], ARGV[2])
 		return 1
 	`
 	// TTL is window size, or a default 5m if window is 0
@@ -135,10 +136,14 @@ func (g *RedisQuotaGate) acquireConcurrency(ctx context.Context, key string) (ap
 		releaseScript := `
 			local current = redis.call("GET", KEYS[1])
 			if current and tonumber(current) > 0 then
-				redis.call("DECR", KEYS[1])
+				local remaining = redis.call("DECR", KEYS[1])
+				if remaining > 0 then
+					-- Keep the key alive while reservations remain in flight.
+					redis.call("EXPIRE", KEYS[1], ARGV[1])
+				end
 			end
 		`
-		err := g.rdb.Eval(context.Background(), releaseScript, []string{key}).Err()
+		err := g.rdb.Eval(context.Background(), releaseScript, []string{key}, ttl).Err()
 		if err != nil {
 			log.Log.Error(err, "Failed to release concurrency quota", "key", key)
 		}

--- a/pkg/redis/quota_gate_test.go
+++ b/pkg/redis/quota_gate_test.go
@@ -64,6 +64,62 @@ func TestRedisQuotaGate_Concurrency(t *testing.T) {
 	}
 }
 
+// TestRedisQuotaGate_Concurrency_TTLRefresh is a regression test for the #311
+// sibling over-admission bug: in concurrency mode the counter's TTL was set only
+// on the first acquire (new_val==1) and never refreshed, so under sustained load
+// the key expired mid-flight, the counter reset to 0, and further requests were
+// admitted beyond the limit. Every acquire must refresh the TTL so the counter
+// survives as long as there is activity (and only expires after `window` of
+// total inactivity, as crash-orphan cleanup).
+func TestRedisQuotaGate_Concurrency_TTLRefresh(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	defer func() { _ = rdb.Close() }()
+
+	gate := NewRedisQuotaGate(rdb, "userid", QuotaModeConcurrency, 2, 10*time.Second, "quota:")
+	ctx := context.Background()
+	attrs := map[string]string{"userid": "user1"}
+
+	// Acquire slot 1 (counter=1, TTL=10s); hold it.
+	var rel1 []pipeline.GateReleaseFunc
+	msg1 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req1", Metadata: attrs})
+	if v, err := gate.Apply(ctx, msg1, &rel1); err != nil || v.Action != pipeline.ActionContinue {
+		t.Fatalf("acquire 1: expected continue, got %v err %v", v, err)
+	}
+
+	// Advance below the TTL, then acquire slot 2 — this must refresh the TTL.
+	s.FastForward(9 * time.Second)
+	var rel2 []pipeline.GateReleaseFunc
+	msg2 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req2", Metadata: attrs})
+	if v, err := gate.Apply(ctx, msg2, &rel2); err != nil || v.Action != pipeline.ActionContinue {
+		t.Fatalf("acquire 2: expected continue, got %v err %v", v, err)
+	}
+
+	// Advance past the ORIGINAL first-acquire TTL (18s total > 10s) but within the
+	// refreshed TTL. Both slots are still held, so the counter must remain at the
+	// limit and a 3rd acquire must be refused. Before the fix the key would have
+	// expired at ~10s, resetting the counter and wrongly admitting this request.
+	s.FastForward(9 * time.Second)
+	var rel3 []pipeline.GateReleaseFunc
+	msg3 := api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{ID: "req3", Metadata: attrs})
+	v, err := gate.Apply(ctx, msg3, &rel3)
+	if err != nil {
+		t.Fatalf("acquire 3: unexpected error %v", err)
+	}
+	if v.Action != pipeline.ActionRefuse || msg3.GetClassification() != api.ClassificationOverflow {
+		t.Fatalf("acquire 3: counter reset mid-flight → over-admission (TTL not refreshed): got %v classification %v",
+			v, msg3.GetClassification())
+	}
+
+	for _, f := range rel1 {
+		f()
+	}
+	for _, f := range rel2 {
+		f()
+	}
+}
+
 func TestRedisQuotaGate_RateLimit(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()

--- a/release-notes.d/unreleased/336.md
+++ b/release-notes.d/unreleased/336.md
@@ -1,0 +1,7 @@
+---
+pr: 336
+url: https://github.com/llm-d/llm-d-async/pull/336
+author: shimib
+date: 2026-07-21
+---
+Fixed over-admission in concurrency-mode `redis-quota`: the in-flight counter's TTL was set only on the first acquire and never refreshed, so under sustained load the key expired mid-flight and the counter reset to 0, admitting requests beyond the configured limit. The TTL is now refreshed on every acquire/release, so it only expires after a full `window` of inactivity (crash-orphan cleanup).


### PR DESCRIPTION
## What / why

Fixes **#335** (sibling of #311/#334). In `RedisQuotaGate` concurrency mode (`pkg/redis/quota_gate.go`), the in-flight counter's `EXPIRE` was set **only on the first acquire** (`new_val == 1`) and never refreshed. The TTL = `window` (factory default **1m**; multitenant overlays don't set it), so under sustained per-tenant load the key **expires mid-flight**, the counter resets to 0, and further requests are **admitted beyond `limit`** — recurring every `window`, and for any request in flight longer than `window`.

This is the correctness residual after #334: that PR made the counter *accurate* (retries no longer leak `INCR`s), but an accurate-but-positive counter was still wiped by the TTL.

## Changes (`pkg/redis/quota_gate.go`, `acquireConcurrency`)

- **Refresh `EXPIRE` on every acquire** (drop the `new_val == 1` guard) — the counter can't expire while there's activity; the key now expires only after `window` of **total inactivity** (crash-orphan cleanup).
- **Refresh `EXPIRE` on release** while reservations remain in flight.
- Regression test `TestRedisQuotaGate_Concurrency_TTLRefresh` (TTL refresh across interleaved acquires via `miniredis` `FastForward`) — **fails on `main`, passes with the fix**.

Rate-limit mode is unchanged (its sorted set expires per-member correctly).

## Testing

- `go test ./pkg/redis/...` green (new + existing quota tests).
- Regression test verified to fail on `main` and pass with the fix.
- (The unrelated `producer.TestMultipleTenantsIsolation` flake is pre-existing and in a different, untouched module.)

Closes #335