### PR TITLE
test(producer): fix flaky TestMultipleTenantsIsolation

### DIFF
--- a/producer/redis_sortedset_producer_test.go
+++ b/producer/redis_sortedset_producer_test.go
@@ -379,8 +379,15 @@ func TestMultipleTenantsIsolation(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(members[0]), &ir1))
 	require.NoError(t, json.Unmarshal([]byte(members[1]), &ir2))
 
-	assert.Equal(t, alphaResultQueue, ir1.ResultQueueName)
-	assert.Equal(t, betaResultQueue, ir2.ResultQueueName)
+	// Both requests share one queue with equal deadline scores, so the ZMembers
+	// order is not deterministic. Assert routing keyed by request ID rather than
+	// by member position (which previously made this test flaky).
+	routing := map[string]string{
+		ir1.PublicRequest.ReqID(): ir1.ResultQueueName,
+		ir2.PublicRequest.ReqID(): ir2.ResultQueueName,
+	}
+	assert.Equal(t, alphaResultQueue, routing["alpha-request"])
+	assert.Equal(t, betaResultQueue, routing["beta-request"])
 
 	// Simulate worker routing results to correct tenant queues
 	result1 := api.ResultMessage{


### PR DESCRIPTION
## Problem

`producer.TestMultipleTenantsIsolation` fails intermittently (~50% of runs; reliably under `go test -count=20`). Both tenant requests are `ZADD`'d to `shared-request-queue` with **equal deadline scores** (`now+1h`), so `miniredis`'s `ZMembers` returns them in a non-deterministic order. The test decoded the members **positionally** (`members[0]==alpha`, `members[1]==beta`), so the pair swaps and the assertion flips.

This flake fails `make test` / the pre-commit CI for **any** PR, not just ones touching producer.

## Fix

Assert result-queue routing **keyed by request ID** rather than member position — order-independent, and it still verifies the real invariant (each tenant's request carries its own result queue).

## Testing

- `go test -run TestMultipleTenantsIsolation -count=20` → passes 20/20 (was ~50%).
- Full `make test` green.

```release-note
NONE
```