### PR TITLE
feat(metrics): expose gate metric value + threshold gauges (#217)

### DIFF
--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -229,7 +229,8 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 		if f.cacheTTL > 0 {
 			ms = NewCachedMetricSource(source, f.cacheTTL)
 		}
-		return NewSaturationDispatchGate(ms, threshold, fallback), nil
+		return NewSaturationDispatchGate(ms, threshold, fallback).
+			WithPoolLabel(paramString(params, "pool", "")), nil
 
 	case "prometheus-budget":
 		if f.prometheusURL == "" {
@@ -275,7 +276,7 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 			cachedSource(primary, f.cacheTTL),
 			cachedSource(secondary, f.cacheTTL),
 		)
-		return NewBudgetDispatchGate(ms, baseline, fallback), nil
+		return NewBudgetDispatchGate(ms, baseline, fallback).WithPoolLabel(pool), nil
 
 	case "prometheus-query":
 		if f.prometheusURL == "" {
@@ -297,7 +298,10 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewMetricDispatchGate(cachedSource(source, f.cacheTTL), 0.0, fallback), nil
+		// Optional 'pool' param labels the async_gate_metric_value gauge; set it to
+		// match the inference pool referenced in the query.
+		return NewMetricDispatchGate(cachedSource(source, f.cacheTTL), 0.0, fallback).
+			WithPoolLabel(paramString(params, "pool", "")), nil
 
 	case "endpoint-scrape":
 		url := paramString(params, "url", "")

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -38,6 +39,14 @@ type MetricDispatchGate struct {
 	source    MetricSource
 	threshold float64
 	fallback  float64
+	poolLabel string
+}
+
+// WithPoolLabel sets the pool name used to label the async_gate_metric_value and
+// async_gate_metric_threshold gauges this gate records on each evaluation.
+func (g *MetricDispatchGate) WithPoolLabel(pool string) *MetricDispatchGate {
+	g.poolLabel = pool
+	return g
 }
 
 // NewMetricDispatchGate creates a MetricDispatchGate with the given source, threshold,
@@ -90,6 +99,10 @@ func (g *MetricDispatchGate) Budget(ctx context.Context) float64 {
 		logger.Error(fmt.Errorf("invalid metric value: %v", value), "using fallback value", "fallback", g.fallback)
 		return g.fallback
 	}
+
+	// Expose the raw value and threshold so operators can see why the gate is
+	// open/closed (it closes when value <= threshold).
+	metrics.SetGateMetricValue(value, g.threshold, g.poolLabel)
 
 	if value <= g.threshold {
 		return 0.0

--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/llm-d/llm-d-async/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,6 +114,25 @@ func TestBudgetDispatchGate(t *testing.T) {
 			require.InDelta(t, tt.expected, gate.Budget(context.Background()), 1e-9)
 		})
 	}
+}
+
+// TestMetricDispatchGate_RecordsGateMetricValue verifies that a metric gate
+// records the raw value it read and the threshold it compared against, labeled by
+// pool (issue #217, "Saturation Metric Value").
+func TestMetricDispatchGate_RecordsGateMetricValue(t *testing.T) {
+	const pool = "test-pool-217"
+	metrics.GateMetricValue.DeleteLabelValues(pool)
+	metrics.GateMetricThreshold.DeleteLabelValues(pool)
+
+	// Saturation gate: source returns D = 1 - saturation; the gate's threshold is
+	// 1 - satThreshold. With saturation 0.3 -> D=0.7, satThreshold 0.8 -> thr=0.2.
+	source := &mockMetricSource{samples: []Sample{{Value: 0.7}}}
+	gate := NewSaturationDispatchGate(source, 0.8, 0.0).WithPoolLabel(pool)
+
+	_ = gate.Budget(context.Background())
+
+	require.InDelta(t, 0.7, testutil.ToFloat64(metrics.GateMetricValue.WithLabelValues(pool)), 1e-9)
+	require.InDelta(t, 0.2, testutil.ToFloat64(metrics.GateMetricThreshold.WithLabelValues(pool)), 1e-9)
 }
 
 // switchableMetricSource allows changing what Query returns between calls.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -103,6 +103,14 @@ var (
 		Subsystem: SchedulerSubsystem, Name: "async_gate_decisions_total",
 		Help: "Count of gate decisions that prevented a message from being dispatched, by reason (gate_closed, quota_exhausted, dropped, error).",
 	}, []string{LabelQueueID, LabelQueueName, LabelPoolName, LabelReason})
+	GateMetricValue = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_gate_metric_value",
+		Help: "Raw metric value last read by a metric-based dispatch gate (prometheus-saturation/-budget/-query), i.e. the value compared against async_gate_metric_threshold to decide the gate. The gate closes when value <= threshold. For the saturation gate the value is 1 - saturation.",
+	}, []string{LabelPoolName})
+	GateMetricThreshold = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_gate_metric_threshold",
+		Help: "Threshold a metric-based dispatch gate compares async_gate_metric_value against; the gate closes when value <= this threshold.",
+	}, []string{LabelPoolName})
 )
 
 // Gate decision reason label values for async_gate_decisions_total.
@@ -193,12 +201,21 @@ func RecordGateDecision(reason, queueID, queueName, poolName string) {
 	GateDecisions.WithLabelValues(queueID, queueName, poolName, reason).Inc()
 }
 
+// SetGateMetricValue records the raw metric value a metric-based dispatch gate
+// last read and the threshold it is compared against, for the given pool. Helps
+// answer "why is the gate closed?" (value <= threshold).
+func SetGateMetricValue(value, threshold float64, poolName string) {
+	GateMetricValue.WithLabelValues(poolName).Set(value)
+	GateMetricThreshold.WithLabelValues(poolName).Set(threshold)
+}
+
 // GetCollectors returns all custom collectors for the async processor.
 func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Collector {
 	collectors := []prometheus.Collector{
 		Retries, AsyncReqs, ExceededDeadlineReqs, FailedReqs, SuccessfulReqs, SheddedRequests,
 		QueueDepth, InflightRequests, BrokerBacklog, InferenceLatencyTime, QueueResidenceTime,
 		DispatchBudget, PoolWorkerLimit, GateDecisions,
+		GateMetricValue, GateMetricThreshold,
 	}
 	if supportsMessageLatency {
 		collectors = append(collectors, MessageLatencyTime)

--- a/release-notes.d/unreleased/339.md
+++ b/release-notes.d/unreleased/339.md
@@ -1,0 +1,7 @@
+---
+pr: 339
+url: https://github.com/llm-d/llm-d-async/pull/339
+author: shimib
+date: 2026-07-21
+---
+Added two Prometheus gauges (labeled by `pool_name`) that expose the raw value a metric-based dispatch gate reads and the threshold it compares against, so you can see why a gate is open or closed: `async_gate_metric_value` (for the saturation gate, `1 - saturation`) and `async_gate_metric_threshold`. Recorded by the `prometheus-saturation`, `prometheus-budget`, and `prometheus-query` gates.


### PR DESCRIPTION
## What / why

Implements the **"Saturation Metric Value (Gauge)"** item of #217. Metric-based dispatch gates (`prometheus-saturation`, `prometheus-budget`, `prometheus-query`) query a value and close when it drops to/below a threshold, but that raw value wasn't observable — so operators couldn't see *why* a gate was closed. This is the diagnostics gap behind the recent gate reliability/correctness work (#311/#334, #335/#336).

## Changes

- New gauges (labeled by `pool_name`, mirroring `async_pool_worker_limit`):
  - **`async_gate_metric_value`** — the raw value the gate last read (for the saturation gate, `1 − saturation`).
  - **`async_gate_metric_threshold`** — the threshold it's compared against; the gate closes when `value <= threshold`.
- `MetricDispatchGate` **self-records** both in `Budget()`, so the value is captured regardless of wrapping (`wait-on-refuse` / `composite` / `tier-priority-admission`) — no flow/worker plumbing.
- Pool label from the gate's `pool` param (already required for saturation/budget; added as an optional label-only param for `prometheus-query`).

## Testing

- New unit test `TestMetricDispatchGate_RecordsGateMetricValue` asserts both gauges are set after `Budget()`.
- `make test` green.

Advances #217 (does not close it — Deadline Proximity and Token Throughput remain).