### PR TITLE
test: fix typo-scan false positive (thr -> threshold) in a comment

### DIFF
--- a/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
+++ b/pkg/async/inference/flowcontrol/metric_dispatch_gate_test.go
@@ -125,7 +125,7 @@ func TestMetricDispatchGate_RecordsGateMetricValue(t *testing.T) {
 	metrics.GateMetricThreshold.DeleteLabelValues(pool)
 
 	// Saturation gate: source returns D = 1 - saturation; the gate's threshold is
-	// 1 - satThreshold. With saturation 0.3 -> D=0.7, satThreshold 0.8 -> thr=0.2.
+	// 1 - satThreshold. With saturation 0.3 -> D=0.7, satThreshold 0.8 -> threshold=0.2.
 	source := &mockMetricSource{samples: []Sample{{Value: 0.7}}}
 	gate := NewSaturationDispatchGate(source, 0.8, 0.0).WithPoolLabel(pool)
 


### PR DESCRIPTION
Fixes **#342** — the nightly typo scan flagged `thr` (my shorthand for *threshold*) in a comment in `metric_dispatch_gate_test.go` as a typo of `the`.

Spelled it out (`thr=0.2` → `threshold=0.2`) rather than adding `thr` to `.typos.toml`, since `thr` is only a one-off comment abbreviation and whitelisting it globally would risk masking a real `thr`/`the` typo elsewhere.

```release-note
NONE
```

Closes #342