### PR TITLE
fix(release-notes): trim trailing blank line from assembled RELEASE-NOTES.md

### DIFF
--- a/hack/assemble-release-notes.sh
+++ b/hack/assemble-release-notes.sh
@@ -38,8 +38,8 @@ if [[ ! -f "$NOTES" ]] || ! grep -qF "$MARKER" "$NOTES"; then
 fi
 
 # Collect "<date>\t<pr>\t<url>\t<note>" rows, sorted by date then PR number.
-rows=""; section=""; new=""
-trap 'rm -f "$rows" "$section" "$new"' EXIT
+rows=""; section=""; new=""; trimmed=""
+trap 'rm -f "$rows" "$section" "$new" "$trimmed"' EXIT
 rows="$(mktemp)"
 for f in "${fragments[@]}"; do
   pr="$(sed -n 's/^pr: *//p' "$f" | head -1)"
@@ -71,6 +71,13 @@ awk -v marker="$MARKER" -v sectionfile="$section" '
   }
 ' "$NOTES" > "$new"
 mv "$new" "$NOTES"
+
+# Trim trailing blank lines so the file ends with exactly one newline. Each
+# assembled section ends with a blank separator; on the first release that blank
+# lands at EOF, which the end-of-file-fixer pre-commit hook rejects.
+trimmed="$(mktemp)"
+awk 'NF { last = NR } { line[NR] = $0 } END { for (i = 1; i <= last; i++) print line[i] }' "$NOTES" > "$trimmed"
+mv "$trimmed" "$NOTES"
 
 git rm --quiet -- "${fragments[@]}" 2>/dev/null || rm -f "${fragments[@]}"
 


### PR DESCRIPTION
## What does this PR do?

`hack/assemble-release-notes.sh` ends each assembled section with a blank separator line. On the **first** release (nothing after the `<!-- BEGIN RELEASES -->` marker), that blank lands at EOF, and the `end-of-file-fixer` pre-commit hook rejects the file — which is exactly what happened while preparing v0.8.0 in #348.

This adds a post-assembly trim so `RELEASE-NOTES.md` always ends with exactly one newline. Internal blank separators between release sections are preserved (the trim only removes trailing blanks).

## Testing

- Unit-tested the trim on three cases: trailing-blank file (trimmed), multi-section file with an internal blank separator (preserved, no-op), and an already-clean file (no-op).
- End-to-end sandbox run of the full script on a first-release scenario → output ends with a single trailing newline, no blank line.

## Release note

```release-note
NONE
```