### PR TITLE
fix(chart): allow modelServerMonitor to scrape across namespaces

### DIFF
--- a/charts/llm-d-async/templates/modelserver-podmonitor.yaml
+++ b/charts/llm-d-async/templates/modelserver-podmonitor.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       {{- toYaml .Values.ap.modelServerMonitor.selector | nindent 6 }}
+  {{- with .Values.ap.modelServerMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   podMetricsEndpoints:
     - port: {{ .Values.ap.modelServerMonitor.port }}
       path: {{ .Values.ap.modelServerMonitor.path }}

--- a/charts/llm-d-async/tests/observability_test.yaml
+++ b/charts/llm-d-async/tests/observability_test.yaml
@@ -179,3 +179,38 @@ tests:
       - equal:
           path: spec.podMetricsEndpoints[0].path
           value: /metrics
+
+  - it: should not set a ModelServer PodMonitor namespaceSelector by default
+    templates:
+      - templates/modelserver-podmonitor.yaml
+    set:
+      ap.modelServerMonitor.enabled: true
+    asserts:
+      - notExists:
+          path: spec.namespaceSelector
+
+  - it: should scope the ModelServer PodMonitor to the given namespaces
+    templates:
+      - templates/modelserver-podmonitor.yaml
+    set:
+      ap.modelServerMonitor.enabled: true
+      ap.modelServerMonitor.namespaceSelector:
+        matchNames:
+          - llm-d-optimized-baseline
+    asserts:
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - llm-d-optimized-baseline
+
+  - it: should let the ModelServer PodMonitor search all namespaces
+    templates:
+      - templates/modelserver-podmonitor.yaml
+    set:
+      ap.modelServerMonitor.enabled: true
+      ap.modelServerMonitor.namespaceSelector:
+        any: true
+    asserts:
+      - equal:
+          path: spec.namespaceSelector.any
+          value: true

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -212,6 +212,12 @@ ap:
   # the inference_pool pod label into scraped metrics.
   # Required when using prometheus-budget or prometheus-saturation gates
   # without llm-d's flow control plugin enabled.
+  #
+  # The selector below matches model server pods in the release namespace only.
+  # If the model server runs in a different namespace than llm-d-async -- as in
+  # the llm-d guides, which deploy the model server to llm-d-optimized-baseline
+  # and llm-d-async to llm-d-async -- the monitor matches zero pods and scrapes
+  # nothing, with no error reported. Set namespaceSelector in that case.
   modelServerMonitor:
     enabled: false
     selector:
@@ -219,3 +225,13 @@ ap:
     port: modelserver
     path: /metrics
     interval: 15s
+    # Namespaces to search for model server pods. Empty means the release
+    # namespace only (prometheus-operator's default). Either list namespaces
+    # explicitly or search all of them:
+    #   namespaceSelector:
+    #     matchNames:
+    #       - llm-d-optimized-baseline
+    # or:
+    #   namespaceSelector:
+    #     any: true
+    namespaceSelector: {}

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -160,7 +160,10 @@ The values file (`docs/guides/e2e-deploy/llm-d-async-values.yaml`) configures:
 >   baseline: "0.05"
 > ```
 - `modelServerMonitor.enabled: true` — creates a PodMonitor that relabels the `inference_pool`
-  pod label into vLLM metrics (required for the dispatch budget gate fallback)
+  pod label into vLLM metrics (required for the dispatch budget gate fallback). This guide puts
+  the model server and llm-d-async in the same namespace; if yours are split, also set
+  `modelServerMonitor.namespaceSelector.matchNames` to the model server's namespace, or the
+  monitor matches no pods and scrapes nothing without reporting an error
 - `podMonitor.enabled: true` — creates a PodMonitor that scrapes the llm-d-async's own
   Prometheus metrics (retry rate, success rate, latency, etc.)
 - `prometheusRule.enabled: true` — installs alert rules for high retry rate, deadline exceeded


### PR DESCRIPTION
## What

Adds an optional `ap.modelServerMonitor.namespaceSelector` to the model server `PodMonitor`, so it can scrape vLLM pods that live in a different namespace than llm-d-async.

## Why

The rendered `PodMonitor` had a `selector` but no `namespaceSelector`, so prometheus-operator restricts it to the release namespace. The llm-d guides deploy the model server into `llm-d-optimized-baseline` and llm-d-async into `llm-d-async` — the exact layout in which the monitor matches zero pods.

Nothing surfaces an error when that happens:

- vLLM metrics never get the `inference_pool` label.
- `prometheus-budget` / `prometheus-saturation` lose their vLLM fallback source (`pkg/async/inference/flowcontrol/promql_metric_source_factory.go:88`).
- With EPP flow-control metrics also absent, the gate falls back to `0` and stays shut.

So the failure mode is a permanently closed dispatch gate with a clean-looking install.

## Change

`namespaceSelector` renders only when set (`{{- with ... }}`), defaulting to `{}`. An absent `namespaceSelector` is already prometheus-operator's "release namespace only" behavior, so **existing installs render byte-identical output** and there's no migration.

Both forms are supported:

```yaml
ap:
  modelServerMonitor:
    namespaceSelector:
      matchNames:
        - llm-d-optimized-baseline
    # or:
    # namespaceSelector:
    #   any: true
```

Also documents the same-namespace assumption in the `values.yaml` comment and in `docs/guides/e2e-deploy.md` — that guide installs both components into a single namespace, which is why this never showed up in our own e2e path.

## Testing

Three helm-unittest cases added to `charts/llm-d-async/tests/observability_test.yaml`: no `namespaceSelector` by default, `matchNames` scoping, and `any: true`. Verified locally with `helm lint` and `helm template` across all three cases; the unit tests themselves run in CI.

Fixes #355
