### PR TITLE
fix(chart): apply inference_pool at scrape time when pods lack the label

### DIFF
--- a/charts/llm-d-async/templates/modelserver-podmonitor.yaml
+++ b/charts/llm-d-async/templates/modelserver-podmonitor.yaml
@@ -23,4 +23,14 @@ spec:
         # This relabeling carries it from the pod label into scraped metrics.
         - sourceLabels: [__meta_kubernetes_pod_label_inference_pool]
           targetLabel: inference_pool
+        {{- with .Values.ap.modelServerMonitor.inferencePool }}
+        # The llm-d guide overlays label decode pods with llm-d.ai/* only, so the
+        # rule above yields an empty label and the gate queries match nothing.
+        # Write the configured pool name in that case. A pod label, where one
+        # exists, is left untouched.
+        - sourceLabels: [inference_pool]
+          regex: ^$
+          targetLabel: inference_pool
+          replacement: {{ . | quote }}
+        {{- end }}
 {{- end }}

--- a/charts/llm-d-async/tests/observability_test.yaml
+++ b/charts/llm-d-async/tests/observability_test.yaml
@@ -214,3 +214,46 @@ tests:
       - equal:
           path: spec.namespaceSelector.any
           value: true
+
+  - it: should only copy the inference_pool pod label by default
+    templates:
+      - templates/modelserver-podmonitor.yaml
+    set:
+      ap.modelServerMonitor.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.podMetricsEndpoints[0].relabelings
+          count: 1
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[0].sourceLabels
+          value:
+            - __meta_kubernetes_pod_label_inference_pool
+
+  - it: should fall back to the configured inference pool when pods are unlabelled
+    templates:
+      - templates/modelserver-podmonitor.yaml
+    set:
+      ap.modelServerMonitor.enabled: true
+      ap.modelServerMonitor.inferencePool: optimized-baseline
+    asserts:
+      - lengthEqual:
+          path: spec.podMetricsEndpoints[0].relabelings
+          count: 2
+      # The pod-label copy still runs first, so a labelled pod keeps its own value.
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[0].sourceLabels
+          value:
+            - __meta_kubernetes_pod_label_inference_pool
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[1].sourceLabels
+          value:
+            - inference_pool
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[1].regex
+          value: ^$
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[1].targetLabel
+          value: inference_pool
+      - equal:
+          path: spec.podMetricsEndpoints[0].relabelings[1].replacement
+          value: optimized-baseline

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -218,6 +218,12 @@ ap:
   # the llm-d guides, which deploy the model server to llm-d-optimized-baseline
   # and llm-d-async to llm-d-async -- the monitor matches zero pods and scrapes
   # nothing, with no error reported. Set namespaceSelector in that case.
+  #
+  # The inference_pool pod label is likewise absent from the llm-d guide overlays,
+  # which label decode pods with llm-d.ai/* only. Scraping those pods leaves the
+  # metrics unlabelled, so the gate's PromQL matches nothing, reads NaN, and never
+  # opens. Set inferencePool unless your own overlay adds the pod label, as
+  # docs/guides/e2e-deploy/modelserver/kustomization.yaml does.
   modelServerMonitor:
     enabled: false
     selector:
@@ -235,3 +241,10 @@ ap:
     #   namespaceSelector:
     #     any: true
     namespaceSelector: {}
+    # Pool name written into the inference_pool metric label for pods that do not
+    # carry an inference_pool pod label. Must match the gate_params.pool of the
+    # subscriber whose gate consumes these metrics (redis.queuesConfig or
+    # gcpPubSub.topicsConfig). Pods that do carry the label keep their own value,
+    # so a single monitor can span pools that set it and pools that do not.
+    # Empty disables the fallback and preserves pod-label-only behavior.
+    inferencePool: ""

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -91,6 +91,12 @@ Pod labels serve two purposes:
 - `inference_pool: optimized-baseline` — carried into vLLM metrics via PodMonitor relabeling
   (required for the dispatch budget gate's PromQL queries)
 
+> **Using the upstream llm-d overlays instead?** They label decode pods with `llm-d.ai/*` only
+> and do not set `inference_pool`, so the relabeling produces nothing and the gate's PromQL
+> matches an empty vector, reads `NaN`, and never opens. Either add the label to your overlay as
+> the kustomization above does, or set `ap.modelServerMonitor.inferencePool` to the same value as
+> `gate_params.pool` and the chart will apply it at scrape time.
+
 Wait for the model to load:
 
 ```bash


### PR DESCRIPTION
## What

Adds `ap.modelServerMonitor.inferencePool`. When set, the model server PodMonitor writes the `inference_pool` metric label at scrape time for pods that don't carry an `inference_pool` pod label.

## Why

The chart's relabeling copies `__meta_kubernetes_pod_label_inference_pool` into `inference_pool`, and the gate PromQL then filters `vllm:num_requests_running{inference_pool="<pool>"}` (`promql_metric_source_factory.go:95,103`).

But the upstream overlay labels decode pods with `llm-d.ai/model`, `llm-d.ai/guide`, `llm-d.ai/accelerator-variant` and `llm-d.ai/accelerator-vendor` only — no `inference_pool`. Neither does `guides/recipes/modelserver/components/monitoring/decode-podmonitor.yaml`. The only manifest in either repo that sets the label is llm-d-async's own example overlay, `docs/guides/e2e-deploy/modelserver/kustomization.yaml`.

So installing the model server from the llm-d guide and the gate from this chart yields an empty vector, `invalid metric value: NaN`, and a gate that never opens. Both components are individually correct; the contract between them was undocumented and unenforced.

## Change

A second relabeling, rendered only when `inferencePool` is set:

```yaml
relabelings:
  - sourceLabels: [__meta_kubernetes_pod_label_inference_pool]
    targetLabel: inference_pool
  - sourceLabels: [inference_pool]      # empty when the pod has no label
    regex: ^$
    targetLabel: inference_pool
    replacement: "optimized-baseline"
```

The pod-label copy runs first and wins wherever a label exists — the fallback only fires on the empty result, so one monitor stays usable across pools that set the label and pools that don't. `inferencePool` defaults to `""`, so **rendered output is unchanged for existing installs**.

### Why an explicit field rather than deriving it

The issue suggested deriving the label from `gate_params.pool`. That turns out not to be well-defined: `gate_params.pool` lives inside per-subscriber entries of `redis.queuesConfig` / `gcpPubSub.topicsConfig` (`values.yaml:129`, `:169`), and several subscribers may each name a different pool, so there's no single value in the chart to read. Hence an explicit field, documented as needing to match `gate_params.pool`.

Documented in the `values.yaml` comment and in `docs/guides/e2e-deploy.md`, which now flags the upstream-overlay case explicitly.

## Testing

Two helm-unittest cases: default renders exactly one relabeling, and setting `inferencePool` renders the fallback with the right `regex` / `targetLabel` / `replacement`. Verified locally with `helm lint` and by parsing `helm template` output for both cases; the unit tests run in CI.

Fixes #356
