### PR TITLE
docs: fix stale llm-d paths in the e2e deploy guide

### DIFF
--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -14,9 +14,13 @@ export LLM_D_REPO=/path/to/llm-d        # local checkout of github.com/llm-d/llm
 export ASYNC_REPO=/path/to/llm-d-async   # this repo
 export NAMESPACE=llm-d-async              # choose your namespace
 export GAIE_VERSION=v1.5.0
+export ROUTER_CHART_VERSION=v0.9.0
 export GATEWAY_API_VERSION=v1.5.1
 export GUIDE_NAME=optimized-baseline
 ```
+
+`GAIE_VERSION` and `ROUTER_CHART_VERSION` track upstream; `${LLM_D_REPO}/guides/env.sh`
+is the source of truth for the versions the llm-d guides are tested against.
 
 ## Step 1: Install CRDs
 
@@ -43,7 +47,7 @@ export PATH="$PWD/istio-${ISTIO_VERSION}/bin:$PATH"
 istioctl install -y --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
 ```
 
-Reference: [llm-d istio gateway guide](https://github.com/llm-d/llm-d/blob/main/guides/prereq/gateways/istio.md)
+Reference: [llm-d istio gateway guide](https://github.com/llm-d/llm-d/blob/main/docs/infrastructure/gateway/istio.md)
 
 ## Step 4: Deploy Gateway
 
@@ -57,22 +61,30 @@ kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Programmed")].status
 
 ```bash
 helm install ${GUIDE_NAME} \
-    oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
-    -f ${LLM_D_REPO}/guides/recipes/scheduler/base.values.yaml \
-    -f ${LLM_D_REPO}/guides/${GUIDE_NAME}/scheduler/${GUIDE_NAME}.values.yaml \
+    oci://ghcr.io/llm-d/charts/llm-d-router-gateway \
+    -f ${LLM_D_REPO}/guides/recipes/router/base.values.yaml \
+    -f ${LLM_D_REPO}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f ${LLM_D_REPO}/guides/recipes/router/features/monitoring.values.yaml \
     --set provider.name=istio \
-    --set experimentalHttpRoute.enabled=true \
-    --set experimentalHttpRoute.inferenceGatewayName=llm-d-inference-gateway \
-    --set inferenceExtension.monitoring.prometheus.enabled=true \
-    -n ${NAMESPACE} --version ${GAIE_VERSION}
+    --set httpRoute.create=true \
+    --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
-`monitoring.prometheus.enabled=true` creates:
-- A `ServiceMonitor` for EPP metrics (`optimized-baseline-epp-monitor`)
-- A metrics reader `Secret` with a bearer token (`inference-gateway-sa-metrics-reader-secret`)
-- Proper RBAC (ClusterRoleBinding to `system:auth-delegator` for the EPP ServiceAccount)
+This creates the EPP `Deployment` and `Service`, an `InferencePool` named
+`optimized-baseline` (selecting pods labeled `llm-d.ai/guide: optimized-baseline`,
+which is what Step 6 applies), an `HTTPRoute` attached to the gateway, and — from
+`monitoring.values.yaml` — a `ServiceMonitor` named `optimized-baseline-epp-monitor`
+scraping EPP `/metrics` every 10s. The chart also creates a dedicated `ClusterRole`
+and `ClusterRoleBinding` for the EPP ServiceAccount granting `tokenreviews`,
+`subjectaccessreviews`, and `nonResourceURLs: /metrics`.
 
-Reference: [llm-d monitoring docs](https://github.com/llm-d/llm-d/blob/main/docs/monitoring/README.md)
+The recipe leaves metrics authentication off (`auth.enabled: false`), so the
+ServiceMonitor scrapes without a bearer token and no metrics-reader `Secret` is
+created. If you enable auth, Prometheus needs a token with the `/metrics`
+permission granted by that ClusterRole.
+
+Reference: [llm-d observability setup](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/setup.md)
 
 ## Step 6: Deploy vLLM model server (Qwen/Qwen3-0.6B)
 
@@ -107,10 +119,13 @@ kubectl wait --for=condition=Ready pod -l llm-d.ai/role=decode -n ${NAMESPACE} -
 
 ```bash
 cd ${LLM_D_REPO}
-./docs/monitoring/scripts/install-prometheus-grafana.sh
+./guides/recipes/observability/install-prometheus-grafana.sh
 ```
 
-Reference: [Prometheus/Grafana quickstart](https://github.com/llm-d/llm-d/blob/main/docs/monitoring/prometheus-grafana-stack.md)
+This installs the kube-prometheus-stack into the `llm-d-monitoring` namespace,
+watching all namespaces.
+
+Reference: [llm-d observability setup](https://github.com/llm-d/llm-d/blob/main/docs/operations/observability/setup.md)
 
 Verify EPP metrics are flowing into Prometheus:
 

--- a/release-notes.d/unreleased/373.md
+++ b/release-notes.d/unreleased/373.md
@@ -1,0 +1,14 @@
+---
+pr: 373
+url: https://github.com/llm-d/llm-d-async/pull/373
+author: shimib
+date: 2026-07-29
+---
+
+Fixed the end-to-end deploy guide (`docs/guides/e2e-deploy.md`), which referenced
+llm-d paths and chart flags that no longer exist. Step 5 now installs the
+`llm-d-router-gateway` chart instead of the retired GAIE `inferencepool` chart
+(`httpRoute.*` instead of `experimentalHttpRoute.*`, monitoring via the router
+recipe's `monitoring.values.yaml`, pinned to a new `ROUTER_CHART_VERSION`), the
+Istio and observability references point at their current locations, and the
+description of what the install creates now matches the rendered chart.


### PR DESCRIPTION
Fixes #354

`docs/guides/e2e-deploy.md` referenced llm-d paths that no longer exist, and step 5 used chart flags belonging to the retired GAIE `inferencepool` chart, so the guide could not be followed end to end.

## What changed

**Step 3** — `guides/prereq/gateways/istio.md` → `docs/infrastructure/gateway/istio.md`.

**Step 5** — the GAIE `inferencepool` chart is retired. Replaced with the llm-d router chart:

```bash
helm install ${GUIDE_NAME} \
    oci://ghcr.io/llm-d/charts/llm-d-router-gateway \
    -f ${LLM_D_REPO}/guides/recipes/router/base.values.yaml \
    -f ${LLM_D_REPO}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
    -f ${LLM_D_REPO}/guides/recipes/router/features/monitoring.values.yaml \
    --set provider.name=istio \
    --set httpRoute.create=true \
    --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \
    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
```

`experimentalHttpRoute.*` → `httpRoute.*`, and `inferenceExtension.monitoring.prometheus.enabled` does not exist on the router chart — monitoring comes from `recipes/router/features/monitoring.values.yaml`.

**Step 5 bullet list** — corrected against what the chart actually renders:

| Old claim | Reality |
| --- | --- |
| ServiceMonitor `optimized-baseline-epp-monitor` | still correct (10s interval) |
| metrics reader `Secret` with a bearer token | not created — the recipe sets `auth.enabled: false` |
| ClusterRoleBinding to `system:auth-delegator` | a *dedicated* ClusterRole/ClusterRoleBinding granting `tokenreviews`, `subjectaccessreviews`, `nonResourceURLs: /metrics` |

**Step 7** — `./docs/monitoring/scripts/install-prometheus-grafana.sh` → `./guides/recipes/observability/install-prometheus-grafana.sh`; `docs/monitoring/` docs → `docs/operations/observability/setup.md`.

**Env block** — added `ROUTER_CHART_VERSION=v0.9.0`. The router chart is versioned independently of GAIE, so the old `--version ${GAIE_VERSION}` was wrong. Added a pointer to `${LLM_D_REPO}/guides/env.sh` as the upstream source of truth for these versions.

## Verification

Every llm-d path the guide now references was checked to exist on llm-d `main` (including the ones left untouched: `guides/recipes/gateway/istio`, `guides/optimized-baseline/modelserver`).

The new step 5 command was rendered with `helm template` against the three values files from llm-d `main`. It renders cleanly and produces the EPP Deployment/Service/ServiceAccount, the dedicated ClusterRole + ClusterRoleBinding, Roles/RoleBindings, an Istio DestinationRule, the HTTPRoute, `InferencePool/optimized-baseline` (selector `llm-d.ai/guide: optimized-baseline`, which matches the model server labels this guide applies in step 6), `ServiceMonitor/optimized-baseline-epp-monitor`, and zero Secrets — which is what the corrected bullet list now says.

The InferencePool name is unchanged, so the `inference_pool_ready_pods{name="optimized-baseline"} = 1` check in step 7 and the gate's PromQL later in the guide still hold.

Docs-only change; no code touched.
