### PR TITLE
refactor: consistent config flags for transport implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The JSON document is transport-specific. Its `queues`/`topics` entries use the s
 }
 ```
 
-The `url` field honors the `REDIS_URL` environment variable as an override for the Redis transports. Per-queue/topic dispatch gates are configured with the `gate_type`/`gate_params` fields (see [Dispatch Gates](#dispatch-gates)).
+For the Redis transports, `REDIS_URL` is used as a fallback default for the `url` field: an explicit `url` in the transport config takes precedence, and `REDIS_URL` fills it in only when `url` is empty. Per-queue/topic dispatch gates are configured with the `gate_type`/`gate_params` fields (see [Dispatch Gates](#dispatch-gates)).
 
 > **Deprecated:** The per-backend flags — `--message-queue-impl`, `--redis.url`, `--redis.*`, `--redis.ss.*`, `--pubsub.*`, `--redis-tracing`, and `--request-merge-policy-config` — still work for backwards compatibility but are deprecated. When used, the processor logs a warning and translates them into the transport config above. `--transport`/`--transport-config` take precedence when both are set. Prefer the new flags.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The architecture adheres to the following core principles:
   - [Backend Compatibility](#backend-compatibility)
   - [Deployment](#deployment)
   - [Command line parameters](#command-line-parameters)
+  - [Transport Configuration](#transport-configuration)
   - [Dispatch Gates](#dispatch-gates)
     - [Per-Queue Dispatch Gates](#per-queue-dispatch-gates)
   - [Request Messages and Consumption](#request-messages-and-consumption)
@@ -62,9 +63,9 @@ The architecture adheres to the following core principles:
 
 The Async Processor uses the Redis wire protocol for its message queue implementations (`redis-sortedset`, `redis-pubsub`) and dispatch gates (`redis`, `redis-quota`). Redis-protocol-compatible backends such as [Valkey](https://valkey.io/) can be used with the existing Redis configuration surface.
 
-All `--redis.*` CLI flags, Helm values, and environment variables (e.g. `REDIS_URL`) work unchanged with Valkey — point them at your Valkey endpoint the same way you would with Redis.
+The `url` field in the transport configuration (see [Transport Configuration](#transport-configuration)), the `REDIS_URL` environment variable, and the deprecated `--redis.*` CLI flags all work unchanged with Valkey — point them at your Valkey endpoint the same way you would with Redis.
 
-> **Note:** CLI flags and Helm values retain the `redis.*` prefix because it refers to the wire protocol, not a specific product.
+> **Note:** The `url`/`redis.*` naming is retained because it refers to the wire protocol, not a specific product.
 
 ## Deployment
 
@@ -95,8 +96,10 @@ make deploy-ap-on-k8s
 
 ## Command line parameters
 - `concurrency`: The number of concurrent workers (per pool if unspecified), default is 64. The processor is I/O-bound (each worker holds one in-flight request for its full duration), so by Little's Law in-flight concurrency caps throughput — tune this to your backend's latency/throughput target (see the [Async Processor Operations Guide](https://github.com/llm-d/llm-d/blob/main/docs/operations/async-processor.md)).
-- `request-merge-policy-config`: Path to the JSON configuration file containing the request merge policy specification (`type` and `parameters`). If not specified, defaults to the `random-robin` policy.
-- `message-queue-impl`: Implementation of the queueing system. Options are <u>gcp-pubsub</u> for GCP PubSub, <u>gcp-pubsub-gated</u> for GCP PubSub with per-topic gating, <u>redis-sortedset</u> for Redis Sorted Set (persisted and sorted), and <u>redis-pubsub</u> for ephemeral Redis-based implementation.
+- `transport`: The transport (message queue) implementation to use. One of <u>redis-pubsub</u> (ephemeral Redis channels), <u>redis-sortedset</u> (persisted, priority-sorted Redis), and <u>gcp-pubsub</u> (GCP Pub/Sub). Default <u>redis-pubsub</u>. Gating is configured per queue/topic via `gate_type` in the transport config (this replaces the former `gcp-pubsub-gated` implementation).
+- `transport-config`: Inline JSON transport configuration. See [Transport Configuration](#transport-configuration). Mutually exclusive with `transport-config-file`.
+- `transport-config-file`: Path to a JSON file with the transport configuration. Mutually exclusive with `transport-config`.
+- `request-merge-policy-config-file`: Path to the JSON configuration file containing the request merge policy specification (`type` and `parameters`). If not specified, defaults to the `random-robin` policy.
 - `pool-config-file`: Path to the JSON configuration file containing the worker pool definitions. If omitted, a single `"default"` worker pool is created with concurrency determined by the global `concurrency` flag.
 
  - `prometheus-url`: Prometheus server URL for metric-based gates (e.g., http://localhost:9090). For Google Managed Prometheus (GMP), point this to a local proxy or GMP frontend that handles authentication — direct GMP URLs are not supported as the Async Processor does not perform GMP authentication.
@@ -104,6 +107,49 @@ make deploy-ap-on-k8s
  - `prometheus-cache-ttl`: TTL for cached Prometheus metric sources (e.g. 1m, 0s to disable). Default is 5s. Increasing this reduces Prometheus load but also reduces the responsiveness of dispatch gates to metric changes.
 
 <i>additional parameters may be specified for concrete message queue implementations</i>
+
+## Transport Configuration
+
+The transport (message queue) is selected with `--transport` and configured with a single JSON document, supplied either inline via `--transport-config` or from a file via `--transport-config-file` (the two are mutually exclusive; exactly one is required). This is the recommended configuration surface for all backends.
+
+The JSON document is transport-specific. Its `queues`/`topics` entries use the same per-entry fields documented under each implementation below ([Multiple Queues Configuration File Syntax](#multiple-queues-configuration-file-syntax), [Multiple Topics Configuration File Syntax](#multiple-topics-configuration-file-syntax)).
+
+**`redis-pubsub`:**
+```json
+{
+  "url": "redis://user:pass@host:6379/0",
+  "retry_queue_name": "retry-sortedset",
+  "result_queue_name": "result-queue",
+  "enable_tracing": false,
+  "queues": [ { "queue_name": "request-queue", "igw_base_url": "http://localhost:30800" } ]
+}
+```
+
+**`redis-sortedset`:**
+```json
+{
+  "url": "redis://user:pass@host:6379/0",
+  "result_queue_name": "result-list",
+  "poll_interval_ms": 1000,
+  "batch_size": 10,
+  "enable_tracing": false,
+  "queues": [ { "queue_name": "request-sortedset", "igw_base_url": "http://localhost:30800", "gate_type": "redis", "gate_params": { "address": "localhost:6379" } } ]
+}
+```
+
+**`gcp-pubsub`:**
+```json
+{
+  "project_id": "my-project",
+  "result_topic_id": "results",
+  "batch_size": 10,
+  "topics": [ { "subscriber_id": "requests-sub", "igw_base_url": "http://localhost:30800", "gate_type": "constant", "gate_params": {} } ]
+}
+```
+
+The `url` field honors the `REDIS_URL` environment variable as an override for the Redis transports. Per-queue/topic dispatch gates are configured with the `gate_type`/`gate_params` fields (see [Dispatch Gates](#dispatch-gates)).
+
+> **Deprecated:** The per-backend flags — `--message-queue-impl`, `--redis.url`, `--redis.*`, `--redis.ss.*`, `--pubsub.*`, `--redis-tracing`, and `--request-merge-policy-config` — still work for backwards compatibility but are deprecated. When used, the processor logs a warning and translates them into the transport config above. `--transport`/`--transport-config` take precedence when both are set. Prefer the new flags.
 
 ## Worker Pools Configuration
 
@@ -440,7 +486,7 @@ This per-pool topology provides complete backpressure and queue-level isolation:
 
 #### Configuration
 
-The merge policy is configured using the `--request-merge-policy-config` CLI flag. It points to a JSON configuration file specifying the policy `type` and optional custom `parameters`:
+The merge policy is configured using the `--request-merge-policy-config-file` CLI flag (the older `--request-merge-policy-config` name is a deprecated alias). It points to a JSON configuration file specifying the policy `type` and optional custom `parameters`:
 
 ```json
 {
@@ -559,7 +605,7 @@ Tracing is controlled via standard OpenTelemetry environment variables. Set `OTE
 
 **CLI flag:**
 
-- `--redis-tracing`: Enable per-command Redis tracing spans via `redisotel`. Produces high span volume — use only for debugging. Default: `false`.
+- `enable_tracing` (transport config): Enable per-command Redis tracing spans via `redisotel`. Produces high span volume — use only for debugging. Default: `false`. Set it in the Redis `--transport-config` (the older `--redis-tracing` CLI flag is a deprecated alias).
 
 **Helm chart:**
 
@@ -687,6 +733,9 @@ A persisted implementation based on Redis SortedSets.
 ![Async Processor - Redis Sorted Set architecture](/docs/images/redis_sortedset_architecture.png "AP - Redis SortedSet")
 
 #### Redis Sorted Set Command line parameters
+
+> **Deprecated:** Prefer `--transport redis-sortedset` with `--transport-config`/`--transport-config-file` (see [Transport Configuration](#transport-configuration)). The `--redis.ss.*` and `--redis.url` flags below still work but are deprecated aliases translated into the transport config: `--redis.url` → `url`, `--redis.ss.poll-interval-ms` → `poll_interval_ms`, `--redis.ss.batch-size` → `batch_size`, `--redis.ss.result-queue-name` → `result_queue_name`, and the single-queue `--redis.ss.igw-base-url`/`--redis.ss.request-queue-name`/`--redis.ss.request-path-url`/`--redis.ss.inference-objective`/`--redis.ss.gate-type`/`--redis.ss.gate-params` (or `--redis.ss.queues-config`/`--redis.ss.queues-config-file`) → the `queues` array.
+
 - `redis.url`: Redis/Valkey URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Supports Redis-protocol-compatible backends such as Valkey. Can also be set via `REDIS_URL` env var.
 - `redis.ss.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.ss.queues-config-file` flag.
 - `redis.ss.request-path-url`: Request path url (e.g.: "/v1/completions"). <br> Mutually exclusive with `redis.ss.queues-config-file` flag.")
@@ -714,6 +763,8 @@ An example implementation based on Redis channels is provided.
 ![Async Processor - Redis architecture](/docs/images/redis_pubsub_architecture.png "AP - Redis")
 
 #### Redis Channels Command line parameters
+
+> **Deprecated:** Prefer `--transport redis-pubsub` with `--transport-config`/`--transport-config-file` (see [Transport Configuration](#transport-configuration)). The `--redis.*` and `--redis.url` flags below still work but are deprecated aliases translated into the transport config: `--redis.url` → `url`, `--redis.retry-queue-name` → `retry_queue_name`, `--redis.result-queue-name` → `result_queue_name`, and the single-queue `--redis.igw-base-url`/`--redis.request-queue-name`/`--redis.request-path-url`/`--redis.inference-objective` (or `--redis.queues-config`/`--redis.queues-config-file`) → the `queues` array.
 
 - `redis.url`: Redis/Valkey URL (e.g. `redis://user:pass@host:port/db` or `rediss://...` for TLS). Supports Redis-protocol-compatible backends such as Valkey. Can also be set via `REDIS_URL` env var.
 - `redis.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `redis.queues-config-file` flag.
@@ -777,6 +828,8 @@ The GCP PubSub implementation requires the user to configure the following:
 ![Async Processor - GCP PubSub Architecture](/docs/images/gcp_pubsub_architecture.png "AP - GCP PubSub")
 
 #### GCP PubSub Command line parameters
+
+> **Deprecated:** Prefer `--transport gcp-pubsub` with `--transport-config`/`--transport-config-file` (see [Transport Configuration](#transport-configuration)). The `--pubsub.*` flags below still work but are deprecated aliases translated into the transport config: `--pubsub.project-id` → `project_id`, `--pubsub.result-topic-id` → `result_topic_id`, `--pubsub.batch-size` → `batch_size`, and the single-topic `--pubsub.request-subscriber-id`/`--pubsub.igw-base-url`/`--pubsub.request-path-url`/`--pubsub.inference-objective` (or `--pubsub.topics-config-file`) → the `topics` array. Per-topic gating (formerly the `gcp-pubsub-gated` implementation) is now configured with `gate_type`/`gate_params` in each topic entry.
 
 - `pubsub.project-id`: The name GCP project ID using the PubSub API.
 - `pubsub.igw-base-url`: Base URL of the IGW (e.g. https://localhost:30800).<br> Mutually exclusive with `pubsub.topics-config-file` flag.

--- a/pkg/pubsub/options.go
+++ b/pkg/pubsub/options.go
@@ -47,6 +47,12 @@ func (c *Config) Validate() error {
 	if c.ProjectID == "" {
 		return fmt.Errorf("project_id is required for gcp-pubsub transport")
 	}
+	if c.ResultTopicID == "" {
+		return fmt.Errorf("result_topic_id is required for gcp-pubsub transport")
+	}
+	if c.BatchSize <= 0 {
+		return fmt.Errorf("batch_size must be a positive integer, got %d", c.BatchSize)
+	}
 	if len(c.Topics) == 0 {
 		return fmt.Errorf("at least one topic must be configured")
 	}

--- a/pkg/pubsub/options.go
+++ b/pkg/pubsub/options.go
@@ -1,8 +1,65 @@
 package pubsub
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/spf13/pflag"
 )
+
+// Config is the transport config for the GCP PubSub flow.
+// It is parsed from JSON provided via --transport-config or --transport-config-file.
+type Config struct {
+	ProjectID     string        `json:"project_id"`
+	ResultTopicID string        `json:"result_topic_id"`
+	BatchSize     int           `json:"batch_size,omitempty"`
+	Topics        []TopicConfig `json:"topics"`
+}
+
+// LoadConfig parses, applies defaults, and validates a GCP PubSub Config.
+func LoadConfig(data []byte) (*Config, error) {
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse gcp-pubsub transport config: %w", err)
+	}
+	cfg.ApplyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid gcp-pubsub transport config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func (c *Config) ApplyDefaults() {
+	if c.BatchSize == 0 {
+		c.BatchSize = 10
+	}
+	for i := range c.Topics {
+		if c.Topics[i].RequestPathURL == "" {
+			c.Topics[i].RequestPathURL = "/v1/completions"
+		}
+		if c.Topics[i].WorkerPoolID == "" {
+			c.Topics[i].WorkerPoolID = "default"
+		}
+	}
+}
+
+func (c *Config) Validate() error {
+	if c.ProjectID == "" {
+		return fmt.Errorf("project_id is required for gcp-pubsub transport")
+	}
+	if len(c.Topics) == 0 {
+		return fmt.Errorf("at least one topic must be configured")
+	}
+	for _, t := range c.Topics {
+		if t.SubscriberID == "" {
+			return fmt.Errorf("subscriber_id is required for each topic")
+		}
+		if t.IGWBaseURL == "" {
+			return fmt.Errorf("topic subscriber %q: igw_base_url must be specified", t.SubscriberID)
+		}
+	}
+	return nil
+}
 
 // Options holds CLI flags for the GCP PubSub flow.
 type Options struct {

--- a/pkg/pubsub/pubsubimpl.go
+++ b/pkg/pubsub/pubsubimpl.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"sync"
 	"time"
 
@@ -85,60 +84,28 @@ type RequestChannelData struct {
 	labels         map[string]string
 }
 
-// PubSubOption is a functional option for configuring PubSubMQFlow
-type PubSubOption func(*PubSubMQFlow)
-
-// WithGateFactory sets a GateFactory for per-topic gate instantiation.
-// When set, gates are created per topic from config, overriding any global gate.
-func WithGateFactory(factory pipeline.GateFactory) PubSubOption {
-	return func(p *PubSubMQFlow) {
-		p.gateFactory = factory
-	}
-}
-
-// WithWorkerPools sets the pool configurations to resolve named pools.
-func WithWorkerPools(workerPools []pipeline.WorkerPoolConfig) PubSubOption {
-	return func(p *PubSubMQFlow) {
-		p.workerPools = workerPools
-	}
-}
-
-func NewGCPPubSubMQFlow(pubsubOpts Options, fns ...PubSubOption) (*PubSubMQFlow, error) {
-
+// NewGCPPubSubMQFlow builds a GCP Pub/Sub flow from a parsed Config. The config
+// is expected to have had ApplyDefaults applied (LoadConfig does this).
+// workerPools resolves the named pool each topic routes to; gateFactory, when
+// non-nil, instantiates a per-topic gate for any topic that declares a gate_type.
+func NewGCPPubSubMQFlow(cfg Config, workerPools []pipeline.WorkerPoolConfig, gateFactory pipeline.GateFactory) (*PubSubMQFlow, error) {
 	ctx := context.Background()
 	var err error
-	pubSubClient, err = pubsub.NewClient(ctx, pubsubOpts.ProjectID)
+	pubSubClient, err = pubsub.NewClient(ctx, cfg.ProjectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PubSub client: %w", err)
 	}
-	var configs []TopicConfig
-	if pubsubOpts.TopicsConfigFile != "" {
-		data, err := os.ReadFile(pubsubOpts.TopicsConfigFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read topics config file: %w", err)
-		}
-
-		if err := json.Unmarshal(data, &configs); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal topics config: %w", err)
-		}
-	} else {
-		configs = []TopicConfig{{
-			SubscriberID:       pubsubOpts.RequestSubscriberID,
-			WorkerPoolID:       "default",
-			InferenceObjective: pubsubOpts.InferenceObjective,
-			IGWBaseURL:         pubsubOpts.IGWBaseURL,
-			RequestPathURL:     pubsubOpts.RequestPathURL,
-		}}
-	}
 	p := &PubSubMQFlow{
-		resultTopicID:   pubsubOpts.ResultTopicID,
-		requestChannels: make([]RequestChannelData, 0, len(configs)),
+		resultTopicID:   cfg.ResultTopicID,
+		requestChannels: make([]RequestChannelData, 0, len(cfg.Topics)),
 		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage),
-		batchSize:       pubsubOpts.BatchSize,
-		projectID:       pubsubOpts.ProjectID,
+		batchSize:       cfg.BatchSize,
+		projectID:       cfg.ProjectID,
 		client:          pubSubClient,
-		consumeHealth:   make(map[string]*subHealth, len(configs)),
+		consumeHealth:   make(map[string]*subHealth, len(cfg.Topics)),
+		workerPools:     workerPools,
+		gateFactory:     gateFactory,
 	}
 
 	if metricClient, mErr := monitoring.NewMetricClient(ctx); mErr != nil {
@@ -147,12 +114,8 @@ func NewGCPPubSubMQFlow(pubsubOpts Options, fns ...PubSubOption) (*PubSubMQFlow,
 		p.metricClient = metricClient
 	}
 
-	for _, fn := range fns {
-		fn(p)
-	}
-
 	// Create per-topic channels with gates
-	for _, cfg := range configs {
+	for _, cfg := range cfg.Topics {
 		workerPoolID := cfg.WorkerPoolID
 		if workerPoolID == "" {
 			workerPoolID = "default"

--- a/pkg/pubsub/pubsubimpl_test.go
+++ b/pkg/pubsub/pubsubimpl_test.go
@@ -147,87 +147,54 @@ func TestNewGCPPubSubMQFlow_PoolRequiredAndValidation(t *testing.T) {
 		}
 	}()
 
-	tmpFile, err := os.CreateTemp("", "topics-config-*.json")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
+	newCfg := func(jsonStr string) Config {
+		var topics []TopicConfig
+		if err := json.Unmarshal([]byte(jsonStr), &topics); err != nil {
+			t.Fatalf("Failed to parse topics: %v", err)
+		}
+		cfg := Config{ProjectID: "test-project", Topics: topics}
+		cfg.ApplyDefaults()
+		return cfg
 	}
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
-
-	baseOpts := Options{ProjectID: "test-project"}
 
 	// Case 1: worker_pool_id is missing, and pool "default" does not exist
-	missingPoolConfig := `[{"subscriber_id":"sub-1","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	if err := os.WriteFile(tmpFile.Name(), []byte(missingPoolConfig), 0644); err != nil {
-		t.Fatalf("Failed to write config: %v", err)
-	}
-	opts := baseOpts
-	opts.TopicsConfigFile = tmpFile.Name()
-
-	_, err = NewGCPPubSubMQFlow(opts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg := newCfg(`[{"subscriber_id":"sub-1","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err := NewGCPPubSubMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "not found in pool configuration") {
 		t.Errorf("Expected error about missing pool, got: %v", err)
 	}
 
 	// Case 5: worker_pool_id is missing, but only a single 'default' pool is specified
-	if err := os.WriteFile(tmpFile.Name(), []byte(missingPoolConfig), 0644); err != nil {
-		t.Fatalf("Failed to write config: %v", err)
-	}
-	opts = baseOpts
-	opts.TopicsConfigFile = tmpFile.Name()
-
-	_, err = NewGCPPubSubMQFlow(opts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg = newCfg(`[{"subscriber_id":"sub-1","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewGCPPubSubMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
 	if err != nil {
 		t.Errorf("Unexpected error when worker_pool_id is missing but default pool exists: %v", err)
 	}
 
 	// Case 6: worker_pool_id is specified as custom, but only a single 'default' pool is specified
-	customPoolConfig := `[{"subscriber_id":"sub-1","worker_pool_id":"custom-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	if err := os.WriteFile(tmpFile.Name(), []byte(customPoolConfig), 0644); err != nil {
-		t.Fatalf("Failed to write config: %v", err)
-	}
-	opts = baseOpts
-	opts.TopicsConfigFile = tmpFile.Name()
-
-	_, err = NewGCPPubSubMQFlow(opts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg = newCfg(`[{"subscriber_id":"sub-1","worker_pool_id":"custom-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewGCPPubSubMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
 	if err == nil {
 		t.Error("Expected error when worker_pool_id is custom but only default pool exists")
 	}
 
 	// Case 2: worker_pool_id specified but pool does not exist
-	nonExistentPoolConfig := `[{"subscriber_id":"sub-1","worker_pool_id":"non-existent","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	if err := os.WriteFile(tmpFile.Name(), []byte(nonExistentPoolConfig), 0644); err != nil {
-		t.Fatalf("Failed to write config: %v", err)
-	}
-	opts = baseOpts
-	opts.TopicsConfigFile = tmpFile.Name()
-
-	_, err = NewGCPPubSubMQFlow(opts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg(`[{"subscriber_id":"sub-1","worker_pool_id":"non-existent","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewGCPPubSubMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "not found in pool configuration") {
 		t.Errorf("Expected error about missing pool, got: %v", err)
 	}
 
 	// Case 3: worker_pool_id specified and pool exists, but igw_base_url is missing
-	missingIgwConfig := `[{"subscriber_id":"sub-1","worker_pool_id":"test-pool","inference_objective":"obj"}]`
-	if err := os.WriteFile(tmpFile.Name(), []byte(missingIgwConfig), 0644); err != nil {
-		t.Fatalf("Failed to write config: %v", err)
-	}
-	opts = baseOpts
-	opts.TopicsConfigFile = tmpFile.Name()
-
-	_, err = NewGCPPubSubMQFlow(opts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg(`[{"subscriber_id":"sub-1","worker_pool_id":"test-pool","inference_objective":"obj"}]`)
+	_, err = NewGCPPubSubMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "igw_base_url must be specified") {
 		t.Errorf("Expected error about missing igw_base_url, got: %v", err)
 	}
 
 	// Case 4: worker_pool_id and igw_base_url specified and pool exists
-	validConfig := `[{"subscriber_id":"sub-1","worker_pool_id":"test-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	if err := os.WriteFile(tmpFile.Name(), []byte(validConfig), 0644); err != nil {
-		t.Fatalf("Failed to write config: %v", err)
-	}
-	opts = baseOpts
-	opts.TopicsConfigFile = tmpFile.Name()
-
-	_, err = NewGCPPubSubMQFlow(opts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg(`[{"subscriber_id":"sub-1","worker_pool_id":"test-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewGCPPubSubMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err != nil {
 		t.Errorf("Unexpected error when worker_pool_id and igw_base_url exist: %v", err)
 	}

--- a/pkg/redis/options.go
+++ b/pkg/redis/options.go
@@ -1,10 +1,158 @@
 package redis
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/spf13/pflag"
 )
+
+// PubSubConfig is the transport config for the Redis pub/sub flow.
+// It is parsed from JSON provided via --transport-config or --transport-config-file.
+type PubSubConfig struct {
+	URL             string        `json:"url,omitempty"`
+	RetryQueueName  string        `json:"retry_queue_name,omitempty"`
+	ResultQueueName string        `json:"result_queue_name,omitempty"`
+	EnableTracing   bool          `json:"enable_tracing,omitempty"`
+	Queues          []QueueConfig `json:"queues"`
+}
+
+// LoadPubSubConfig parses, applies env overrides/defaults, and validates a PubSubConfig.
+func LoadPubSubConfig(data []byte) (*PubSubConfig, error) {
+	var cfg PubSubConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse redis-pubsub transport config: %w", err)
+	}
+	cfg.ApplyEnvOverrides()
+	cfg.ApplyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid redis-pubsub transport config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func (c *PubSubConfig) ApplyEnvOverrides() {
+	if envURL := os.Getenv("REDIS_URL"); envURL != "" {
+		c.URL = envURL
+	}
+}
+
+func (c *PubSubConfig) ApplyDefaults() {
+	if c.RetryQueueName == "" {
+		c.RetryQueueName = "retry-sortedset"
+	}
+	if c.ResultQueueName == "" {
+		c.ResultQueueName = "result-queue"
+	}
+	for i := range c.Queues {
+		if c.Queues[i].RequestPathURL == "" {
+			c.Queues[i].RequestPathURL = "/v1/completions"
+		}
+		if c.Queues[i].WorkerPoolID == "" {
+			c.Queues[i].WorkerPoolID = "default"
+		}
+	}
+}
+
+func (c *PubSubConfig) Validate() error {
+	if len(c.Queues) == 0 {
+		return fmt.Errorf("at least one queue must be configured")
+	}
+	for _, q := range c.Queues {
+		if q.QueueName == "" {
+			return fmt.Errorf("queue_name is required for each queue")
+		}
+		if q.IGWBaseURL == "" {
+			return fmt.Errorf("queue %q: igw_base_url must be specified", q.QueueName)
+		}
+	}
+	return nil
+}
+
+// SortedSetConfig is the transport config for the Redis sorted-set flow.
+// It is parsed from JSON provided via --transport-config or --transport-config-file.
+type SortedSetConfig struct {
+	URL             string                 `json:"url,omitempty"`
+	ResultQueueName string                 `json:"result_queue_name,omitempty"`
+	PollIntervalMs  int                    `json:"poll_interval_ms,omitempty"`
+	BatchSize       int                    `json:"batch_size,omitempty"`
+	EnableTracing   bool                   `json:"enable_tracing,omitempty"`
+	Queues          []SortedSetQueueConfig `json:"queues"`
+}
+
+// LoadSortedSetConfig parses, applies env overrides/defaults, and validates a SortedSetConfig.
+func LoadSortedSetConfig(data []byte) (*SortedSetConfig, error) {
+	var cfg SortedSetConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse redis-sortedset transport config: %w", err)
+	}
+	cfg.ApplyEnvOverrides()
+	cfg.ApplyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid redis-sortedset transport config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func (c *SortedSetConfig) ApplyEnvOverrides() {
+	if envURL := os.Getenv("REDIS_URL"); envURL != "" {
+		c.URL = envURL
+	}
+}
+
+func (c *SortedSetConfig) ApplyDefaults() {
+	if c.ResultQueueName == "" {
+		c.ResultQueueName = "result-list"
+	}
+	if c.PollIntervalMs == 0 {
+		c.PollIntervalMs = 1000
+	}
+	if c.BatchSize == 0 {
+		c.BatchSize = 10
+	}
+	for i := range c.Queues {
+		if c.Queues[i].RequestPathURL == "" {
+			c.Queues[i].RequestPathURL = "/v1/completions"
+		}
+		if c.Queues[i].WorkerPoolID == "" {
+			c.Queues[i].WorkerPoolID = "default"
+		}
+		if c.Queues[i].ID == "" {
+			c.Queues[i].ID = c.Queues[i].QueueName
+		}
+	}
+}
+
+func (c *SortedSetConfig) Validate() error {
+	if len(c.Queues) == 0 {
+		return fmt.Errorf("at least one queue must be configured")
+	}
+	seenID := make(map[string]bool, len(c.Queues))
+	seenQueue := make(map[string]bool, len(c.Queues))
+	for _, q := range c.Queues {
+		if q.QueueName == "" {
+			return fmt.Errorf("queue_name is required for each queue")
+		}
+		if q.IGWBaseURL == "" {
+			return fmt.Errorf("queue %q: igw_base_url must be specified", q.QueueName)
+		}
+		if seenID[q.ID] {
+			return fmt.Errorf("duplicate queue id %q", q.ID)
+		}
+		seenID[q.ID] = true
+		if seenQueue[q.QueueName] {
+			return fmt.Errorf("duplicate queue_name %q", q.QueueName)
+		}
+		seenQueue[q.QueueName] = true
+	}
+	return nil
+}
+
+// --- Deprecated per-backend flag options (kept for backwards compatibility) ---
+// These structs and their AddFlags register the legacy --redis.* / --redis.ss.*
+// flags. They are translated into the transport configs above by the server's
+// backwards-compat shim. Prefer --transport-config / --transport-config-file.
 
 // ConnectionOptions holds the Redis connection configuration.
 type ConnectionOptions struct {

--- a/pkg/redis/options.go
+++ b/pkg/redis/options.go
@@ -56,6 +56,9 @@ func (c *PubSubConfig) ApplyDefaults() {
 }
 
 func (c *PubSubConfig) Validate() error {
+	if c.URL == "" {
+		return fmt.Errorf("url is required (set url in the transport config or REDIS_URL)")
+	}
 	if len(c.Queues) == 0 {
 		return fmt.Errorf("at least one queue must be configured")
 	}
@@ -125,6 +128,9 @@ func (c *SortedSetConfig) ApplyDefaults() {
 }
 
 func (c *SortedSetConfig) Validate() error {
+	if c.URL == "" {
+		return fmt.Errorf("url is required (set url in the transport config or REDIS_URL)")
+	}
 	if len(c.Queues) == 0 {
 		return fmt.Errorf("at least one queue must be configured")
 	}

--- a/pkg/redis/options.go
+++ b/pkg/redis/options.go
@@ -32,9 +32,12 @@ func LoadPubSubConfig(data []byte) (*PubSubConfig, error) {
 	return &cfg, nil
 }
 
+// ApplyEnvOverrides seeds URL from REDIS_URL only when it is not already set in
+// the config. An explicit url in --transport-config therefore wins over the
+// environment; REDIS_URL is a fallback default, not an override.
 func (c *PubSubConfig) ApplyEnvOverrides() {
-	if envURL := os.Getenv("REDIS_URL"); envURL != "" {
-		c.URL = envURL
+	if c.URL == "" {
+		c.URL = os.Getenv("REDIS_URL")
 	}
 }
 
@@ -98,9 +101,12 @@ func LoadSortedSetConfig(data []byte) (*SortedSetConfig, error) {
 	return &cfg, nil
 }
 
+// ApplyEnvOverrides seeds URL from REDIS_URL only when it is not already set in
+// the config. An explicit url in --transport-config therefore wins over the
+// environment; REDIS_URL is a fallback default, not an override.
 func (c *SortedSetConfig) ApplyEnvOverrides() {
-	if envURL := os.Getenv("REDIS_URL"); envURL != "" {
-		c.URL = envURL
+	if c.URL == "" {
+		c.URL = os.Getenv("REDIS_URL")
 	}
 }
 

--- a/pkg/redis/redisimpl.go
+++ b/pkg/redis/redisimpl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -151,67 +150,29 @@ type RedisMQFlow struct {
 	enableTracing   bool
 }
 
-// RedisOption is a functional option for configuring RedisMQFlow.
-type RedisOption func(*RedisMQFlow)
-
-// WithRedisTracing enables per-command Redis tracing spans via redisotel.
-func WithRedisTracing(enable bool) RedisOption {
-	return func(r *RedisMQFlow) {
-		r.enableTracing = enable
-	}
-}
-
-// WithWorkerPools sets the pool configurations to resolve named pools.
-func WithWorkerPools(workerPools []pipeline.WorkerPoolConfig) RedisOption {
-	return func(r *RedisMQFlow) {
-		r.workerPools = workerPools
-	}
-}
-
-func NewRedisMQFlow(flowOpts PubSubFlowOptions, connOpts ConnectionOptions, fns ...RedisOption) (*RedisMQFlow, error) {
-	redisOpts, err := ParseRedisOptions(connOpts.URL)
+// NewRedisMQFlow builds a Redis pub/sub flow from a parsed PubSubConfig.
+// The config is expected to have had ApplyDefaults applied (LoadPubSubConfig
+// does this); workerPools resolves the named pool each queue routes to.
+func NewRedisMQFlow(cfg PubSubConfig, workerPools []pipeline.WorkerPoolConfig) (*RedisMQFlow, error) {
+	redisOpts, err := ParseRedisOptions(cfg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Redis connection config: %w", err)
 	}
 	rdb := redis.NewClient(redisOpts)
-	var configs []QueueConfig
-	if flowOpts.QueuesConfig != "" {
-		if err := json.Unmarshal([]byte(flowOpts.QueuesConfig), &configs); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal inline queues config: %w", err)
-		}
-	} else if flowOpts.QueuesConfigFile != "" {
-		data, err := os.ReadFile(flowOpts.QueuesConfigFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read queues config file: %w", err)
-		}
-		if err := json.Unmarshal(data, &configs); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal queues config: %w", err)
-		}
-	} else {
-		configs = []QueueConfig{{
-			QueueName:          flowOpts.RequestQueueName,
-			WorkerPoolID:       "default",
-			InferenceObjective: flowOpts.InferenceObjective,
-			IGWBaseURL:         flowOpts.IGWBaseURL,
-			RequestPathURL:     flowOpts.RequestPathURL,
-		}}
-	}
 
 	flow := &RedisMQFlow{
 		rdb:             rdb,
 		retryChannel:    make(chan pipeline.RetryMessage),
 		resultChannel:   make(chan api.ResultMessage, resultChannelBuffer),
-		retryQueueName:  flowOpts.RetryQueueName,
-		resultQueueName: flowOpts.ResultQueueName,
-	}
-
-	for _, fn := range fns {
-		fn(flow)
+		retryQueueName:  cfg.RetryQueueName,
+		resultQueueName: cfg.ResultQueueName,
+		workerPools:     workerPools,
+		enableTracing:   cfg.EnableTracing,
 	}
 
 	var channels []RequestChannelData
 
-	for _, cfg := range configs {
+	for _, cfg := range cfg.Queues {
 		ch := make(chan *api.InternalRequest)
 
 		workerPoolID := cfg.WorkerPoolID

--- a/pkg/redis/redisimpl_test.go
+++ b/pkg/redis/redisimpl_test.go
@@ -792,46 +792,52 @@ func TestMQRetryWorker_ExitsPromptlyOnCancelDuringSleep(t *testing.T) {
 func TestNewRedisMQFlow_PoolRequiredAndValidation(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
-	connOpts := ConnectionOptions{URL: "redis://" + s.Addr()}
+	url := "redis://" + s.Addr()
+
+	newCfg := func(queues []QueueConfig) PubSubConfig {
+		cfg := PubSubConfig{URL: url, Queues: queues}
+		cfg.ApplyDefaults()
+		return cfg
+	}
 
 	// Case 1: worker_pool_id is missing from configuration, and pool "default" does not exist
-	opts := PubSubFlowOptions{QueuesConfig: `[{"queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`}
-	_, err := NewRedisMQFlow(opts, connOpts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg := newCfg([]QueueConfig{{QueueName: "test-queue", InferenceObjective: "obj", IGWBaseURL: "http://gw"}})
+	_, err := NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}})
 	if err == nil {
 		t.Error("Expected error when worker_pool_id is missing and 'default' pool does not exist, got nil")
 	}
 
 	// Case 5: worker_pool_id is missing, but only a single 'default' pool is specified
-	opts = PubSubFlowOptions{QueuesConfig: `[{"queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`}
-	_, err = NewRedisMQFlow(opts, connOpts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg = newCfg([]QueueConfig{{QueueName: "test-queue", InferenceObjective: "obj", IGWBaseURL: "http://gw"}})
+	_, err = NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}})
 	if err != nil {
 		t.Errorf("Unexpected error when worker_pool_id is missing but default pool exists: %v", err)
 	}
 
 	// Case 6: worker_pool_id is specified as custom, but only a single 'default' pool is specified
-	opts = PubSubFlowOptions{QueuesConfig: `[{"queue_name":"test-queue","worker_pool_id":"custom-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`}
-	_, err = NewRedisMQFlow(opts, connOpts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg = newCfg([]QueueConfig{{QueueName: "test-queue", WorkerPoolID: "custom-pool", InferenceObjective: "obj", IGWBaseURL: "http://gw"}})
+	_, err = NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}})
 	if err == nil {
 		t.Error("Expected error when worker_pool_id is custom but only default pool exists, got nil")
 	}
 
 	// Case 2: worker_pool_id is specified but pool does not exist
-	opts = PubSubFlowOptions{QueuesConfig: `[{"queue_name":"test-queue","worker_pool_id":"non-existent","inference_objective":"obj","igw_base_url":"http://gw"}]`}
-	_, err = NewRedisMQFlow(opts, connOpts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg([]QueueConfig{{QueueName: "test-queue", WorkerPoolID: "non-existent", InferenceObjective: "obj", IGWBaseURL: "http://gw"}})
+	_, err = NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}})
 	if err == nil {
 		t.Error("Expected error when specified worker_pool_id does not exist, got nil")
 	}
 
 	// Case 3: worker_pool_id specified and pool exists, but igw_base_url is missing
-	opts = PubSubFlowOptions{QueuesConfig: `[{"queue_name":"test-queue","worker_pool_id":"test-pool","inference_objective":"obj"}]`}
-	_, err = NewRedisMQFlow(opts, connOpts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg([]QueueConfig{{QueueName: "test-queue", WorkerPoolID: "test-pool", InferenceObjective: "obj"}})
+	_, err = NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}})
 	if err == nil {
 		t.Error("Expected error when igw_base_url is missing in queue config, got nil")
 	}
 
 	// Case 4: worker_pool_id and igw_base_url specified and pool exists
-	opts = PubSubFlowOptions{QueuesConfig: `[{"queue_name":"test-queue","worker_pool_id":"test-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`}
-	_, err = NewRedisMQFlow(opts, connOpts, WithWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg([]QueueConfig{{QueueName: "test-queue", WorkerPoolID: "test-pool", InferenceObjective: "obj", IGWBaseURL: "http://gw"}})
+	_, err = NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}})
 	if err != nil {
 		t.Errorf("Unexpected error when worker_pool_id exists: %v", err)
 	}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -129,6 +129,14 @@ func NewRedisSortedSetFlow(cfg SortedSetConfig, workerPools []pipeline.WorkerPoo
 		}
 	}
 
+	// Retry messages that lack an explicit RequestQueueName fall back to this
+	// name when re-enqueued (flushRetryBatch). Default to the first configured
+	// queue so retries land on a real key rather than "" — preserving the
+	// previous single-queue fallback behavior.
+	if len(cfg.Queues) > 0 {
+		r.defaultRequestQueueName = cfg.Queues[0].QueueName
+	}
+
 	r.configMap = make(map[string]SortedSetQueueConfig, len(cfg.Queues))
 	for _, cfg := range cfg.Queues {
 		// Normalize before anything reads it: configMap is the source of the

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"sync"
 	"time"
 
@@ -20,21 +19,8 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
-// parseGateParams parses a JSON-encoded string (from --redis.ss.gate-params)
-// into a map[string]any for gate parameter configuration.
-// Used to pass gate parameters from CLI or YAML to the gate factory.
-func parseGateParams(s string) (map[string]any, error) {
-	m := map[string]any{}
-	if s == "" || s == "{}" {
-		return m, nil
-	}
-	if err := json.Unmarshal([]byte(s), &m); err != nil {
-		return nil, fmt.Errorf("failed to parse gate params JSON: %w", err)
-	}
-	return m, nil
-}
-
-type queueConfig struct {
+// SortedSetQueueConfig defines a single queue entry in the sorted-set transport config.
+type SortedSetQueueConfig struct {
 	ID                 string `json:"id,omitempty"`
 	QueueName          string `json:"queue_name,omitempty"`
 	ResultQueueName    string `json:"result_queue_name,omitempty"`
@@ -84,7 +70,7 @@ type RedisSortedSetFlow struct {
 	activeReleases          sync.Map
 	gate                    pipeline.Gate
 	gateFactory             pipeline.GateFactory
-	configMap               map[string]queueConfig
+	configMap               map[string]SortedSetQueueConfig
 	defaultRequestQueueName string
 	defaultResultQueueName  string
 	workerPools             []pipeline.WorkerPoolConfig
@@ -113,53 +99,27 @@ func (c *redisCancellationChecker) IsCancelled(ctx context.Context, requestID, r
 	return token == requestToken, nil
 }
 
-// SortedSetOption is a functional option for configuring RedisSortedSetFlow
-type SortedSetOption func(*RedisSortedSetFlow)
-
-// WithGateFactory sets a GateFactory for per-queue gate instantiation.
-// When set, gates are created per queue from config, overriding any global gate.
-func WithGateFactory(factory pipeline.GateFactory) SortedSetOption {
-	return func(r *RedisSortedSetFlow) {
-		r.gateFactory = factory
-	}
-}
-
-// WithSortedSetRedisTracing enables per-command Redis tracing spans via redisotel.
-func WithSortedSetRedisTracing(enable bool) SortedSetOption {
-	return func(r *RedisSortedSetFlow) {
-		r.enableTracing = enable
-	}
-}
-
-// WithSortedSetWorkerPools sets the pool configurations to resolve named pools.
-func WithSortedSetWorkerPools(workerPools []pipeline.WorkerPoolConfig) SortedSetOption {
-	return func(r *RedisSortedSetFlow) {
-		r.workerPools = workerPools
-	}
-}
-
-func NewRedisSortedSetFlow(flowOpts SortedSetFlowOptions, connOpts ConnectionOptions, fns ...SortedSetOption) (*RedisSortedSetFlow, error) {
-	configs, err := loadQueueConfigs(flowOpts)
-	if err != nil {
-		return nil, err
-	}
-	redisOpts, err := ParseRedisOptions(connOpts.URL)
+// NewRedisSortedSetFlow builds a Redis sorted-set flow from a parsed
+// SortedSetConfig. The config is expected to have had ApplyDefaults applied
+// (LoadSortedSetConfig does this). workerPools resolves the named pool each
+// queue routes to; gateFactory, when non-nil, instantiates a per-queue gate for
+// any queue that declares a gate_type.
+func NewRedisSortedSetFlow(cfg SortedSetConfig, workerPools []pipeline.WorkerPoolConfig, gateFactory pipeline.GateFactory) (*RedisSortedSetFlow, error) {
+	redisOpts, err := ParseRedisOptions(cfg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Redis connection config: %w", err)
 	}
 	r := &RedisSortedSetFlow{
-		rdb:                     redis.NewClient(redisOpts),
-		requestChannels:         make([]requestChannelData, 0, len(configs)),
-		retryChannel:            make(chan pipeline.RetryMessage),
-		resultChannel:           make(chan api.ResultMessage, resultChannelBuffer),
-		pollInterval:            time.Duration(flowOpts.PollIntervalMs) * time.Millisecond,
-		batchSize:               flowOpts.BatchSize,
-		defaultRequestQueueName: flowOpts.RequestQueueName,
-		defaultResultQueueName:  flowOpts.ResultQueueName,
-	}
-
-	for _, fn := range fns {
-		fn(r)
+		rdb:                    redis.NewClient(redisOpts),
+		requestChannels:        make([]requestChannelData, 0, len(cfg.Queues)),
+		retryChannel:           make(chan pipeline.RetryMessage),
+		resultChannel:          make(chan api.ResultMessage, resultChannelBuffer),
+		pollInterval:           time.Duration(cfg.PollIntervalMs) * time.Millisecond,
+		batchSize:              cfg.BatchSize,
+		defaultResultQueueName: cfg.ResultQueueName,
+		workerPools:            workerPools,
+		gateFactory:            gateFactory,
+		enableTracing:          cfg.EnableTracing,
 	}
 
 	if r.enableTracing {
@@ -169,8 +129,8 @@ func NewRedisSortedSetFlow(flowOpts SortedSetFlowOptions, connOpts ConnectionOpt
 		}
 	}
 
-	r.configMap = make(map[string]queueConfig, len(configs))
-	for _, cfg := range configs {
+	r.configMap = make(map[string]SortedSetQueueConfig, len(cfg.Queues))
+	for _, cfg := range cfg.Queues {
 		// Normalize before anything reads it: configMap is the source of the
 		// pool_name label on this queue's metrics, and an unset WorkerPoolID
 		// there would label them "" while the request channel below — and every
@@ -241,67 +201,6 @@ func NewRedisSortedSetFlow(flowOpts SortedSetFlowOptions, connOpts ConnectionOpt
 	}
 
 	return r, nil
-}
-
-func parseQueueConfigs(data []byte) ([]queueConfig, error) {
-	var configs []queueConfig
-	if err := json.Unmarshal(data, &configs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal queues config: %w", err)
-	}
-	return configs, nil
-}
-
-func loadQueueConfigs(opts SortedSetFlowOptions) ([]queueConfig, error) {
-	var configs []queueConfig
-	if opts.QueuesConfig != "" {
-		var err error
-		configs, err = parseQueueConfigs([]byte(opts.QueuesConfig))
-		if err != nil {
-			return nil, err
-		}
-	} else if opts.QueuesConfigFile != "" {
-		data, err := os.ReadFile(opts.QueuesConfigFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read config file: %w", err)
-		}
-		configs, err = parseQueueConfigs(data)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		gateParams, err := parseGateParams(opts.GateParamsJSON)
-		if err != nil {
-			return nil, err
-		}
-		configs = []queueConfig{{
-			QueueName:          opts.RequestQueueName,
-			InferenceObjective: opts.InferenceObjective,
-			IGWBaseURL:         opts.IGWBaseURL,
-			RequestPathURL:     opts.RequestPathURL,
-			GateConfig:         pipeline.GateConfig{GateType: opts.GateType, GateParams: gateParams},
-			WorkerPoolID:       "default",
-		}}
-	}
-	seenID := make(map[string]bool, len(configs))
-	seenQueue := make(map[string]bool, len(configs))
-	for i := range configs {
-		applyQueueConfigDefaults(&configs[i])
-		if seenID[configs[i].ID] {
-			return nil, fmt.Errorf("duplicate queue id %q", configs[i].ID)
-		}
-		seenID[configs[i].ID] = true
-		if seenQueue[configs[i].QueueName] {
-			return nil, fmt.Errorf("duplicate queue_name %q", configs[i].QueueName)
-		}
-		seenQueue[configs[i].QueueName] = true
-	}
-	return configs, nil
-}
-
-func applyQueueConfigDefaults(cfg *queueConfig) {
-	if cfg.ID == "" {
-		cfg.ID = cfg.QueueName
-	}
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -54,19 +55,19 @@ func envelopeJSON(rm api.RequestMessage) string {
 	return string(b)
 }
 
-func TestParseQueueConfigs(t *testing.T) {
+func TestParseSortedSetQueueConfigs(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
 		wantLen  int
 		wantErr  bool
-		validate func(t *testing.T, configs []queueConfig)
+		validate func(t *testing.T, configs []SortedSetQueueConfig)
 	}{
 		{
 			name:    "single queue with string gate params",
 			input:   `[{"queue_name":"q1","igw_base_url":"http://gw","gate_type":"redis","gate_params":{"address":"localhost:6379"}}]`,
 			wantLen: 1,
-			validate: func(t *testing.T, configs []queueConfig) {
+			validate: func(t *testing.T, configs []SortedSetQueueConfig) {
 				if configs[0].QueueName != "q1" {
 					t.Errorf("expected q1, got %s", configs[0].QueueName)
 				}
@@ -79,7 +80,7 @@ func TestParseQueueConfigs(t *testing.T) {
 			name:    "numeric gate params preserved as native types",
 			input:   `[{"queue_name":"q1","igw_base_url":"http://gw","gate_type":"prometheus-saturation","gate_params":{"threshold":0.7,"pool":"p1"}}]`,
 			wantLen: 1,
-			validate: func(t *testing.T, configs []queueConfig) {
+			validate: func(t *testing.T, configs []SortedSetQueueConfig) {
 				if configs[0].GateParams["threshold"] != 0.7 {
 					t.Errorf("expected 0.7, got '%v'", configs[0].GateParams["threshold"])
 				}
@@ -92,7 +93,7 @@ func TestParseQueueConfigs(t *testing.T) {
 			name:    "multiple queues",
 			input:   `[{"queue_name":"q1","igw_base_url":"http://igw:80"},{"queue_name":"q2","igw_base_url":"http://gw","gate_type":"redis","gate_params":{"address":"redis:6379"}}]`,
 			wantLen: 2,
-			validate: func(t *testing.T, configs []queueConfig) {
+			validate: func(t *testing.T, configs []SortedSetQueueConfig) {
 				if configs[0].QueueName != "q1" {
 					t.Errorf("expected q1, got %s", configs[0].QueueName)
 				}
@@ -105,7 +106,7 @@ func TestParseQueueConfigs(t *testing.T) {
 			name:    "no gate params",
 			input:   `[{"queue_name":"q1","igw_base_url":"http://gw","request_path_url":"/v1/completions"}]`,
 			wantLen: 1,
-			validate: func(t *testing.T, configs []queueConfig) {
+			validate: func(t *testing.T, configs []SortedSetQueueConfig) {
 				if len(configs[0].GateParams) != 0 {
 					t.Errorf("expected empty gate params, got %v", configs[0].GateParams)
 				}
@@ -120,9 +121,10 @@ func TestParseQueueConfigs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configs, err := parseQueueConfigs([]byte(tt.input))
+			var configs []SortedSetQueueConfig
+			err := json.Unmarshal([]byte(tt.input), &configs)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("parseQueueConfigs() error = %v, wantErr = %v", err, tt.wantErr)
+				t.Fatalf("json.Unmarshal() error = %v, wantErr = %v", err, tt.wantErr)
 			}
 			if tt.wantErr {
 				return
@@ -811,7 +813,7 @@ func TestSortedSetFlow_ResultBatchMultiQueue(t *testing.T) {
 		batchSize:              10,
 		gate:                   noopGate(),
 		defaultResultQueueName: defaultQueue,
-		configMap: map[string]queueConfig{
+		configMap: map[string]SortedSetQueueConfig{
 			"queue-a": {ID: "queue-a", QueueName: "request:queue-a", ResultQueueName: "result:queue-a"},
 			"queue-b": {ID: "queue-b", QueueName: "request:queue-b", ResultQueueName: "result:queue-b"},
 		},
@@ -941,16 +943,18 @@ func TestSortedSetFlow_Integration(t *testing.T) {
 
 	queue := "integration-queue"
 
-	flowOpts := SortedSetFlowOptions{
-		RequestQueueName: queue,
-		IGWBaseURL:       "http://gw",
-		ResultQueueName:  "result-list",
-		PollIntervalMs:   1000,
-		BatchSize:        10,
-		GateParamsJSON:   "{}",
+	cfg := SortedSetConfig{
+		URL:             "redis://" + s.Addr(),
+		ResultQueueName: "result-list",
+		PollIntervalMs:  1000,
+		BatchSize:       10,
+		Queues: []SortedSetQueueConfig{{
+			QueueName:  queue,
+			IGWBaseURL: "http://gw",
+		}},
 	}
-	connOpts := ConnectionOptions{URL: "redis://" + s.Addr()}
-	flow, err := NewRedisSortedSetFlow(flowOpts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg.ApplyDefaults()
+	flow, err := NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1376,105 +1380,75 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 	}
 }
 
-func TestApplyQueueConfigDefaults_IDPreserved(t *testing.T) {
-	cfg := queueConfig{ID: "my-id", QueueName: "my-queue", ResultQueueName: "my-result"}
-	applyQueueConfigDefaults(&cfg)
+func TestSortedSetConfigApplyDefaults_IDPreserved(t *testing.T) {
+	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+		{ID: "my-id", QueueName: "my-queue", ResultQueueName: "my-result"},
+	}}
+	cfg.ApplyDefaults()
 
-	if cfg.ID != "my-id" {
-		t.Errorf("Expected ID 'my-id', got %q", cfg.ID)
+	q := cfg.Queues[0]
+	if q.ID != "my-id" {
+		t.Errorf("Expected ID 'my-id', got %q", q.ID)
 	}
-	if cfg.QueueName != "my-queue" {
-		t.Errorf("Expected QueueName 'my-queue', got %q", cfg.QueueName)
+	if q.QueueName != "my-queue" {
+		t.Errorf("Expected QueueName 'my-queue', got %q", q.QueueName)
 	}
-	if cfg.ResultQueueName != "my-result" {
-		t.Errorf("Expected ResultQueueName 'my-result', got %q", cfg.ResultQueueName)
+	if q.ResultQueueName != "my-result" {
+		t.Errorf("Expected ResultQueueName 'my-result', got %q", q.ResultQueueName)
 	}
 }
 
-func TestApplyQueueConfigDefaults_IDInferredFromQueueName(t *testing.T) {
-	cfg := queueConfig{QueueName: "my-request-sortedset"}
-	applyQueueConfigDefaults(&cfg)
+func TestSortedSetConfigApplyDefaults_IDInferredFromQueueName(t *testing.T) {
+	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+		{QueueName: "my-request-sortedset"},
+	}}
+	cfg.ApplyDefaults()
 
-	if cfg.ID != "my-request-sortedset" {
-		t.Errorf("Expected ID inferred as 'my-request-sortedset', got %q", cfg.ID)
+	q := cfg.Queues[0]
+	if q.ID != "my-request-sortedset" {
+		t.Errorf("Expected ID inferred as 'my-request-sortedset', got %q", q.ID)
 	}
-	if cfg.QueueName != "my-request-sortedset" {
-		t.Errorf("Expected QueueName unchanged, got %q", cfg.QueueName)
+	if q.QueueName != "my-request-sortedset" {
+		t.Errorf("Expected QueueName unchanged, got %q", q.QueueName)
 	}
-	if cfg.ResultQueueName != "" {
-		t.Errorf("Expected empty ResultQueueName, got %q", cfg.ResultQueueName)
+	if q.ResultQueueName != "" {
+		t.Errorf("Expected empty ResultQueueName, got %q", q.ResultQueueName)
 	}
 }
 
-func TestLoadQueueConfigs_DuplicateIDError(t *testing.T) {
-	input := `[{"id":"same","igw_base_url":"http://a"},{"id":"same","igw_base_url":"http://b"}]`
-	_, err := parseQueueConfigs([]byte(input))
-	if err != nil {
-		t.Fatalf("parseQueueConfigs should succeed: %v", err)
-	}
-
-	configs := []queueConfig{
-		{ID: "same", QueueName: "q1"},
-		{ID: "same", QueueName: "q2"},
-	}
-	seen := make(map[string]bool, len(configs))
-	var dupErr error
-	for i := range configs {
-		applyQueueConfigDefaults(&configs[i])
-		if seen[configs[i].ID] {
-			dupErr = fmt.Errorf("duplicate queue id %q", configs[i].ID)
-			break
-		}
-		seen[configs[i].ID] = true
-	}
-	if dupErr == nil {
-		t.Fatal("Expected duplicate ID error, got nil")
+func TestSortedSetConfigValidate_DuplicateIDError(t *testing.T) {
+	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+		{ID: "same", QueueName: "q1", IGWBaseURL: "http://a"},
+		{ID: "same", QueueName: "q2", IGWBaseURL: "http://b"},
+	}}
+	cfg.ApplyDefaults()
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "duplicate queue id") {
+		t.Fatalf("Expected duplicate ID error, got: %v", err)
 	}
 }
 
-func TestLoadQueueConfigs_InferredDuplicateIDError(t *testing.T) {
-	configs := []queueConfig{
-		{QueueName: "same-queue"},
-		{QueueName: "same-queue"},
-	}
-	seen := make(map[string]bool, len(configs))
-	var dupErr error
-	for i := range configs {
-		applyQueueConfigDefaults(&configs[i])
-		if seen[configs[i].ID] {
-			dupErr = fmt.Errorf("duplicate queue id %q", configs[i].ID)
-			break
-		}
-		seen[configs[i].ID] = true
-	}
-	if dupErr == nil {
-		t.Fatal("Expected duplicate ID error for inferred IDs, got nil")
+func TestSortedSetConfigValidate_InferredDuplicateIDError(t *testing.T) {
+	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+		{QueueName: "same-queue", IGWBaseURL: "http://a"},
+		{QueueName: "same-queue", IGWBaseURL: "http://b"},
+	}}
+	cfg.ApplyDefaults()
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "duplicate queue id") {
+		t.Fatalf("Expected duplicate ID error for inferred IDs, got: %v", err)
 	}
 }
 
-func TestLoadQueueConfigs_DuplicateQueueNameError(t *testing.T) {
-	configs := []queueConfig{
-		{ID: "id-1", QueueName: "same-queue"},
-		{ID: "id-2", QueueName: "same-queue"},
-	}
-	seenID := make(map[string]bool, len(configs))
-	seenQueue := make(map[string]bool, len(configs))
-	var dupErr error
-	for i := range configs {
-		applyQueueConfigDefaults(&configs[i])
-		if seenID[configs[i].ID] {
-			dupErr = fmt.Errorf("duplicate queue id %q", configs[i].ID)
-			break
-		}
-		seenID[configs[i].ID] = true
-		if seenQueue[configs[i].QueueName] {
-			dupErr = fmt.Errorf("duplicate queue_name %q", configs[i].QueueName)
-			break
-		}
-		seenQueue[configs[i].QueueName] = true
-	}
-	if dupErr == nil {
-		t.Fatal("Expected duplicate queue_name error, got nil")
+func TestSortedSetConfigValidate_DuplicateQueueNameError(t *testing.T) {
+	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+		{ID: "id-1", QueueName: "same-queue", IGWBaseURL: "http://a"},
+		{ID: "id-2", QueueName: "same-queue", IGWBaseURL: "http://b"},
+	}}
+	cfg.ApplyDefaults()
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "duplicate queue_name") {
+		t.Fatalf("Expected duplicate queue_name error, got: %v", err)
 	}
 }
 
@@ -1532,7 +1506,7 @@ func TestSortedSetFlow_ResultQueueIgnoresMessagePayload(t *testing.T) {
 		batchSize:              10,
 		gate:                   noopGate(),
 		defaultResultQueueName: "global-default",
-		configMap: map[string]queueConfig{
+		configMap: map[string]SortedSetQueueConfig{
 			"my-queue": {ID: "my-queue", ResultQueueName: configResult},
 		},
 	}
@@ -1572,7 +1546,7 @@ func TestSortedSetFlow_ResultQueueFallsBackToMessageLevel(t *testing.T) {
 		batchSize:              10,
 		gate:                   noopGate(),
 		defaultResultQueueName: "global-default",
-		configMap: map[string]queueConfig{
+		configMap: map[string]SortedSetQueueConfig{
 			"no-result-cfg": {ID: "no-result-cfg", QueueName: "req", ResultQueueName: ""},
 		},
 	}
@@ -1607,53 +1581,63 @@ func TestSortedSetFlow_ResultQueueFallsBackToMessageLevel(t *testing.T) {
 func TestNewRedisSortedSetFlow_PoolRequiredAndValidation(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
-	connOpts := ConnectionOptions{URL: "redis://" + s.Addr()}
-	baseOpts := SortedSetFlowOptions{PollIntervalMs: 1000, BatchSize: 10, GateParamsJSON: "{}"}
+
+	parseQueues := func(queuesJSON string) []SortedSetQueueConfig {
+		var queues []SortedSetQueueConfig
+		if err := json.Unmarshal([]byte(queuesJSON), &queues); err != nil {
+			t.Fatalf("failed to parse queues: %v", err)
+		}
+		return queues
+	}
+	newCfg := func(queuesJSON string) SortedSetConfig {
+		cfg := SortedSetConfig{
+			URL:            "redis://" + s.Addr(),
+			PollIntervalMs: 1000,
+			BatchSize:      10,
+			Queues:         parseQueues(queuesJSON),
+		}
+		cfg.ApplyDefaults()
+		return cfg
+	}
 
 	// Case 1: worker_pool_id is missing from configuration, and pool "default" does not exist
-	opts := baseOpts
-	opts.QueuesConfig = `[{"queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	_, err := NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg := newCfg(`[{"queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err := NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err == nil {
 		t.Error("Expected error when worker_pool_id is missing and 'default' pool does not exist, got nil")
 	}
 
 	// Case 5: worker_pool_id is missing, but only a single 'default' pool is specified
-	opts = baseOpts
-	opts.QueuesConfig = `[{"queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	_, err = NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg = newCfg(`[{"queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
 	if err != nil {
 		t.Errorf("Unexpected error when worker_pool_id is missing but default pool exists: %v", err)
 	}
 
 	// Case 6: worker_pool_id is specified as custom, but only a single 'default' pool is specified
-	opts = baseOpts
-	opts.QueuesConfig = `[{"queue_name":"test-queue","worker_pool_id":"custom-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	_, err = NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	cfg = newCfg(`[{"queue_name":"test-queue","worker_pool_id":"custom-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
 	if err == nil {
 		t.Error("Expected error when worker_pool_id is custom but only default pool exists, got nil")
 	}
 
 	// Case 2: worker_pool_id is specified but pool does not exist
-	opts = baseOpts
-	opts.QueuesConfig = `[{"queue_name":"test-queue","worker_pool_id":"non-existent","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	_, err = NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg(`[{"queue_name":"test-queue","worker_pool_id":"non-existent","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err == nil {
 		t.Error("Expected error when specified worker_pool_id does not exist, got nil")
 	}
 
 	// Case 3: worker_pool_id specified and pool exists, but igw_base_url is missing
-	opts = baseOpts
-	opts.QueuesConfig = `[{"queue_name":"test-queue","worker_pool_id":"test-pool","inference_objective":"obj"}]`
-	_, err = NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg(`[{"queue_name":"test-queue","worker_pool_id":"test-pool","inference_objective":"obj"}]`)
+	_, err = NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err == nil {
 		t.Error("Expected error when igw_base_url is missing in queue config, got nil")
 	}
 
 	// Case 4: worker_pool_id and igw_base_url specified and pool exists
-	opts = baseOpts
-	opts.QueuesConfig = `[{"queue_name":"test-queue","worker_pool_id":"test-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`
-	_, err = NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}))
+	cfg = newCfg(`[{"queue_name":"test-queue","worker_pool_id":"test-pool","inference_objective":"obj","igw_base_url":"http://gw"}]`)
+	_, err = NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "test-pool", Workers: 1}}, nil)
 	if err != nil {
 		t.Errorf("Unexpected error when worker_pool_id exists: %v", err)
 	}
@@ -1667,28 +1651,30 @@ func TestNewRedisSortedSetFlow_PoolRequiredAndValidation(t *testing.T) {
 func TestNewRedisSortedSetFlow_DefaultsWorkerPoolIDInConfigMap(t *testing.T) {
 	s := miniredis.RunT(t)
 	defer s.Close()
-	connOpts := ConnectionOptions{URL: "redis://" + s.Addr()}
-	opts := SortedSetFlowOptions{
+	cfg := SortedSetConfig{
+		URL:            "redis://" + s.Addr(),
 		PollIntervalMs: 1000,
 		BatchSize:      10,
-		GateParamsJSON: "{}",
-		QueuesConfig:   `[{"id":"q1","queue_name":"test-queue","inference_objective":"obj","igw_base_url":"http://gw"}]`,
+		Queues: []SortedSetQueueConfig{
+			{ID: "q1", QueueName: "test-queue", InferenceObjective: "obj", IGWBaseURL: "http://gw"},
+		},
 	}
+	cfg.ApplyDefaults()
 
-	flow, err := NewRedisSortedSetFlow(opts, connOpts, WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}))
+	flow, err := NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error creating flow: %v", err)
 	}
 
-	cfg, ok := flow.configMap["q1"]
+	qcfg, ok := flow.configMap["q1"]
 	if !ok {
 		t.Fatal("Expected queue q1 in configMap")
 	}
-	if cfg.WorkerPoolID != "default" {
-		t.Errorf("configMap worker pool = %q, want %q", cfg.WorkerPoolID, "default")
+	if qcfg.WorkerPoolID != "default" {
+		t.Errorf("configMap worker pool = %q, want %q", qcfg.WorkerPoolID, "default")
 	}
-	if got := flow.requestChannels[0].channel.WorkerPoolID; got != cfg.WorkerPoolID {
-		t.Errorf("request channel worker pool = %q, configMap says %q; the two must agree or the metrics do not join", got, cfg.WorkerPoolID)
+	if got := flow.requestChannels[0].channel.WorkerPoolID; got != qcfg.WorkerPoolID {
+		t.Errorf("request channel worker pool = %q, configMap says %q; the two must agree or the metrics do not join", got, qcfg.WorkerPoolID)
 	}
 }
 
@@ -1791,7 +1777,7 @@ func TestSortedSetFlow_QueueLabelsSetOnDequeue(t *testing.T) {
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
-		configMap: map[string]queueConfig{
+		configMap: map[string]SortedSetQueueConfig{
 			queueID: {
 				ID:     queueID,
 				Labels: labels,

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -1417,7 +1417,7 @@ func TestSortedSetConfigApplyDefaults_IDInferredFromQueueName(t *testing.T) {
 }
 
 func TestSortedSetConfigValidate_DuplicateIDError(t *testing.T) {
-	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+	cfg := SortedSetConfig{URL: "redis://localhost:6379", Queues: []SortedSetQueueConfig{
 		{ID: "same", QueueName: "q1", IGWBaseURL: "http://a"},
 		{ID: "same", QueueName: "q2", IGWBaseURL: "http://b"},
 	}}
@@ -1429,7 +1429,7 @@ func TestSortedSetConfigValidate_DuplicateIDError(t *testing.T) {
 }
 
 func TestSortedSetConfigValidate_InferredDuplicateIDError(t *testing.T) {
-	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+	cfg := SortedSetConfig{URL: "redis://localhost:6379", Queues: []SortedSetQueueConfig{
 		{QueueName: "same-queue", IGWBaseURL: "http://a"},
 		{QueueName: "same-queue", IGWBaseURL: "http://b"},
 	}}
@@ -1441,7 +1441,7 @@ func TestSortedSetConfigValidate_InferredDuplicateIDError(t *testing.T) {
 }
 
 func TestSortedSetConfigValidate_DuplicateQueueNameError(t *testing.T) {
-	cfg := SortedSetConfig{Queues: []SortedSetQueueConfig{
+	cfg := SortedSetConfig{URL: "redis://localhost:6379", Queues: []SortedSetQueueConfig{
 		{ID: "id-1", QueueName: "same-queue", IGWBaseURL: "http://a"},
 		{ID: "id-2", QueueName: "same-queue", IGWBaseURL: "http://b"},
 	}}
@@ -1675,6 +1675,53 @@ func TestNewRedisSortedSetFlow_DefaultsWorkerPoolIDInConfigMap(t *testing.T) {
 	}
 	if got := flow.requestChannels[0].channel.WorkerPoolID; got != qcfg.WorkerPoolID {
 		t.Errorf("request channel worker pool = %q, configMap says %q; the two must agree or the metrics do not join", got, qcfg.WorkerPoolID)
+	}
+}
+
+// TestNewRedisSortedSetFlow_RetryFallsBackToFirstQueue is a regression test: a
+// retry message that carries no RequestQueueName must be re-enqueued to a real
+// queue key, not "". NewRedisSortedSetFlow seeds defaultRequestQueueName from
+// the first configured queue; without that seed flushRetryBatch ZADDs the retry
+// to the empty key "" and the message is lost.
+func TestNewRedisSortedSetFlow_RetryFallsBackToFirstQueue(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+
+	const primaryQueue = "primary-queue"
+	cfg := SortedSetConfig{
+		URL:            "redis://" + s.Addr(),
+		PollIntervalMs: 1000,
+		BatchSize:      10,
+		Queues: []SortedSetQueueConfig{
+			{ID: "q1", QueueName: primaryQueue, InferenceObjective: "obj", IGWBaseURL: "http://gw"},
+		},
+	}
+	cfg.ApplyDefaults()
+
+	flow, err := NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error creating flow: %v", err)
+	}
+	defer flow.rdb.Close() // nolint:errcheck
+
+	// RetryMessage with no RequestQueueName in its routing.
+	retryMsg := pipeline.RetryMessage{
+		EmbelishedRequestMessage: pipeline.EmbelishedRequestMessage{
+			InternalRequest: api.NewInternalRequest(
+				api.InternalRouting{RetryCount: 1},
+				&api.RequestMessage{ID: "retry-no-queue", Created: time.Now().Unix(), Deadline: 9999999999},
+			),
+		},
+		BackoffDurationSeconds: 0,
+	}
+
+	flow.flushRetryBatch(context.Background(), []pipeline.RetryMessage{retryMsg})
+
+	if n, _ := flow.rdb.ZCard(context.Background(), primaryQueue).Result(); n != 1 {
+		t.Errorf("Expected retry re-enqueued to %q (ZCARD=1), got ZCARD=%d", primaryQueue, n)
+	}
+	if n, _ := flow.rdb.ZCard(context.Background(), "").Result(); n != 0 {
+		t.Errorf("Retry landed on the empty key \"\" (ZCARD=%d); default request queue was not seeded", n)
 	}
 }
 

--- a/pkg/server/compat.go
+++ b/pkg/server/compat.go
@@ -57,10 +57,10 @@ func deprecatedFlags() map[string]string {
 	}
 }
 
-// WarnDeprecatedFlags logs a deprecation warning for every deprecated flag the
+// warnDeprecatedFlags logs a deprecation warning for every deprecated flag the
 // user explicitly set. When the new transport flags are in use, the legacy flags
 // are ignored and the warning says so.
-func (o *Options) WarnDeprecatedFlags(logger logr.Logger) {
+func (o *Options) warnDeprecatedFlags(logger logr.Logger) {
 	if o.flagSet == nil {
 		return
 	}
@@ -116,6 +116,16 @@ func (o *Options) resolveTransport() (string, []byte, error) {
 		return "", nil, err
 	}
 	return transportType, data, nil
+}
+
+// legacyUngatedPubSub reports whether the flow was selected via the deprecated
+// --message-queue-impl=gcp-pubsub alias (the plain, ungated one). On the legacy
+// path that alias wired no gate factory, so a gate_type in a topics-config file
+// was inert and every topic got an always-open gate. We preserve that by
+// withholding the factory for it: the retired gcp-pubsub-gated alias and the new
+// --transport surface both gate normally.
+func (o *Options) legacyUngatedPubSub() bool {
+	return !o.usingNewTransport() && o.MessageQueueImpl == "gcp-pubsub"
 }
 
 // normalizeLegacyImpl maps the retired gcp-pubsub-gated alias onto gcp-pubsub;

--- a/pkg/server/compat.go
+++ b/pkg/server/compat.go
@@ -14,45 +14,47 @@ import (
 // deprecatedFlags maps a deprecated flag name to the suggested replacement.
 // The new --transport / --transport-config[-file] surface supersedes all of
 // these; they are kept working via the translation shim below.
-var deprecatedFlags = map[string]string{
-	"message-queue-impl": "--transport",
-	"redis-tracing":      "enable_tracing in --transport-config",
+func deprecatedFlags() map[string]string {
+	return map[string]string{
+		"message-queue-impl": "--transport",
+		"redis-tracing":      "enable_tracing in --transport-config",
 
-	// Redis connection (shared by redis-pubsub and redis-sortedset).
-	"redis.url": "url in --transport-config",
+		// Redis connection (shared by redis-pubsub and redis-sortedset).
+		"redis.url": "url in --transport-config",
 
-	// redis-pubsub per-backend flags.
-	"redis.igw-base-url":        "--transport-config (redis-pubsub)",
-	"redis.request-path-url":    "--transport-config (redis-pubsub)",
-	"redis.inference-objective": "--transport-config (redis-pubsub)",
-	"redis.request-queue-name":  "--transport-config (redis-pubsub)",
-	"redis.retry-queue-name":    "--transport-config (redis-pubsub)",
-	"redis.result-queue-name":   "--transport-config (redis-pubsub)",
-	"redis.queues-config":       "--transport-config (redis-pubsub)",
-	"redis.queues-config-file":  "--transport-config-file (redis-pubsub)",
+		// redis-pubsub per-backend flags.
+		"redis.igw-base-url":        "--transport-config (redis-pubsub)",
+		"redis.request-path-url":    "--transport-config (redis-pubsub)",
+		"redis.inference-objective": "--transport-config (redis-pubsub)",
+		"redis.request-queue-name":  "--transport-config (redis-pubsub)",
+		"redis.retry-queue-name":    "--transport-config (redis-pubsub)",
+		"redis.result-queue-name":   "--transport-config (redis-pubsub)",
+		"redis.queues-config":       "--transport-config (redis-pubsub)",
+		"redis.queues-config-file":  "--transport-config-file (redis-pubsub)",
 
-	// redis-sortedset per-backend flags.
-	"redis.ss.igw-base-url":        "--transport-config (redis-sortedset)",
-	"redis.ss.request-path-url":    "--transport-config (redis-sortedset)",
-	"redis.ss.inference-objective": "--transport-config (redis-sortedset)",
-	"redis.ss.request-queue-name":  "--transport-config (redis-sortedset)",
-	"redis.ss.result-queue-name":   "--transport-config (redis-sortedset)",
-	"redis.ss.queues-config":       "--transport-config (redis-sortedset)",
-	"redis.ss.queues-config-file":  "--transport-config-file (redis-sortedset)",
-	"redis.ss.poll-interval-ms":    "poll_interval_ms in --transport-config",
-	"redis.ss.batch-size":          "batch_size in --transport-config",
-	"redis.ss.gate-type":           "gate_type in --transport-config",
-	"redis.ss.gate-params":         "gate_params in --transport-config",
+		// redis-sortedset per-backend flags.
+		"redis.ss.igw-base-url":        "--transport-config (redis-sortedset)",
+		"redis.ss.request-path-url":    "--transport-config (redis-sortedset)",
+		"redis.ss.inference-objective": "--transport-config (redis-sortedset)",
+		"redis.ss.request-queue-name":  "--transport-config (redis-sortedset)",
+		"redis.ss.result-queue-name":   "--transport-config (redis-sortedset)",
+		"redis.ss.queues-config":       "--transport-config (redis-sortedset)",
+		"redis.ss.queues-config-file":  "--transport-config-file (redis-sortedset)",
+		"redis.ss.poll-interval-ms":    "poll_interval_ms in --transport-config",
+		"redis.ss.batch-size":          "batch_size in --transport-config",
+		"redis.ss.gate-type":           "gate_type in --transport-config",
+		"redis.ss.gate-params":         "gate_params in --transport-config",
 
-	// gcp-pubsub per-backend flags.
-	"pubsub.igw-base-url":          "--transport-config (gcp-pubsub)",
-	"pubsub.project-id":            "project_id in --transport-config",
-	"pubsub.request-path-url":      "--transport-config (gcp-pubsub)",
-	"pubsub.inference-objective":   "--transport-config (gcp-pubsub)",
-	"pubsub.request-subscriber-id": "--transport-config (gcp-pubsub)",
-	"pubsub.result-topic-id":       "result_topic_id in --transport-config",
-	"pubsub.topics-config-file":    "--transport-config-file (gcp-pubsub)",
-	"pubsub.batch-size":            "batch_size in --transport-config",
+		// gcp-pubsub per-backend flags.
+		"pubsub.igw-base-url":          "--transport-config (gcp-pubsub)",
+		"pubsub.project-id":            "project_id in --transport-config",
+		"pubsub.request-path-url":      "--transport-config (gcp-pubsub)",
+		"pubsub.inference-objective":   "--transport-config (gcp-pubsub)",
+		"pubsub.request-subscriber-id": "--transport-config (gcp-pubsub)",
+		"pubsub.result-topic-id":       "result_topic_id in --transport-config",
+		"pubsub.topics-config-file":    "--transport-config-file (gcp-pubsub)",
+		"pubsub.batch-size":            "batch_size in --transport-config",
+	}
 }
 
 // WarnDeprecatedFlags logs a deprecation warning for every deprecated flag the
@@ -63,7 +65,7 @@ func (o *Options) WarnDeprecatedFlags(logger logr.Logger) {
 		return
 	}
 	newPath := o.usingNewTransport()
-	for name, replacement := range deprecatedFlags {
+	for name, replacement := range deprecatedFlags() {
 		if !o.flagSet.Changed(name) {
 			continue
 		}
@@ -152,7 +154,11 @@ func (o *Options) synthesizeRedisPubSubConfig() ([]byte, error) {
 		EnableTracing:   o.Observability.RedisTracing,
 		Queues:          queues,
 	}
-	return json.Marshal(cfg)
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal redis-pubsub config: %w", err)
+	}
+	return data, nil
 }
 
 func legacyRedisPubSubQueues(opts redis.PubSubFlowOptions) ([]redis.QueueConfig, error) {
@@ -196,7 +202,11 @@ func (o *Options) synthesizeRedisSortedSetConfig() ([]byte, error) {
 		EnableTracing:   o.Observability.RedisTracing,
 		Queues:          queues,
 	}
-	return json.Marshal(cfg)
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal redis-sortedset config: %w", err)
+	}
+	return data, nil
 }
 
 func legacyRedisSortedSetQueues(opts redis.SortedSetFlowOptions) ([]redis.SortedSetQueueConfig, error) {
@@ -243,7 +253,11 @@ func (o *Options) synthesizePubSubConfig() ([]byte, error) {
 		BatchSize:     o.PubSub.BatchSize,
 		Topics:        topics,
 	}
-	return json.Marshal(cfg)
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal gcp-pubsub config: %w", err)
+	}
+	return data, nil
 }
 
 func legacyPubSubTopics(opts pubsub.Options) ([]pubsub.TopicConfig, error) {

--- a/pkg/server/compat.go
+++ b/pkg/server/compat.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/pubsub"
+	"github.com/llm-d/llm-d-async/pkg/redis"
+)
+
+// deprecatedFlags maps a deprecated flag name to the suggested replacement.
+// The new --transport / --transport-config[-file] surface supersedes all of
+// these; they are kept working via the translation shim below.
+var deprecatedFlags = map[string]string{
+	"message-queue-impl": "--transport",
+	"redis-tracing":      "enable_tracing in --transport-config",
+
+	// Redis connection (shared by redis-pubsub and redis-sortedset).
+	"redis.url": "url in --transport-config",
+
+	// redis-pubsub per-backend flags.
+	"redis.igw-base-url":        "--transport-config (redis-pubsub)",
+	"redis.request-path-url":    "--transport-config (redis-pubsub)",
+	"redis.inference-objective": "--transport-config (redis-pubsub)",
+	"redis.request-queue-name":  "--transport-config (redis-pubsub)",
+	"redis.retry-queue-name":    "--transport-config (redis-pubsub)",
+	"redis.result-queue-name":   "--transport-config (redis-pubsub)",
+	"redis.queues-config":       "--transport-config (redis-pubsub)",
+	"redis.queues-config-file":  "--transport-config-file (redis-pubsub)",
+
+	// redis-sortedset per-backend flags.
+	"redis.ss.igw-base-url":        "--transport-config (redis-sortedset)",
+	"redis.ss.request-path-url":    "--transport-config (redis-sortedset)",
+	"redis.ss.inference-objective": "--transport-config (redis-sortedset)",
+	"redis.ss.request-queue-name":  "--transport-config (redis-sortedset)",
+	"redis.ss.result-queue-name":   "--transport-config (redis-sortedset)",
+	"redis.ss.queues-config":       "--transport-config (redis-sortedset)",
+	"redis.ss.queues-config-file":  "--transport-config-file (redis-sortedset)",
+	"redis.ss.poll-interval-ms":    "poll_interval_ms in --transport-config",
+	"redis.ss.batch-size":          "batch_size in --transport-config",
+	"redis.ss.gate-type":           "gate_type in --transport-config",
+	"redis.ss.gate-params":         "gate_params in --transport-config",
+
+	// gcp-pubsub per-backend flags.
+	"pubsub.igw-base-url":          "--transport-config (gcp-pubsub)",
+	"pubsub.project-id":            "project_id in --transport-config",
+	"pubsub.request-path-url":      "--transport-config (gcp-pubsub)",
+	"pubsub.inference-objective":   "--transport-config (gcp-pubsub)",
+	"pubsub.request-subscriber-id": "--transport-config (gcp-pubsub)",
+	"pubsub.result-topic-id":       "result_topic_id in --transport-config",
+	"pubsub.topics-config-file":    "--transport-config-file (gcp-pubsub)",
+	"pubsub.batch-size":            "batch_size in --transport-config",
+}
+
+// WarnDeprecatedFlags logs a deprecation warning for every deprecated flag the
+// user explicitly set. When the new transport flags are in use, the legacy flags
+// are ignored and the warning says so.
+func (o *Options) WarnDeprecatedFlags(logger logr.Logger) {
+	if o.flagSet == nil {
+		return
+	}
+	newPath := o.usingNewTransport()
+	for name, replacement := range deprecatedFlags {
+		if !o.flagSet.Changed(name) {
+			continue
+		}
+		if newPath {
+			logger.Info("Deprecated flag ignored because --transport/--transport-config was provided",
+				"flag", "--"+name, "use", replacement)
+		} else {
+			logger.Info("Deprecated flag used; it still works but will be removed in a future release. Prefer the transport config.",
+				"flag", "--"+name, "use", replacement)
+		}
+	}
+
+	// The merge-policy config flag was renamed for naming consistency with
+	// --transport-config-file. It is independent of the transport selection, so
+	// it is never "ignored" — it always works, just under the new name.
+	if o.flagSet.Changed("request-merge-policy-config") {
+		logger.Info("Deprecated flag used; it still works but will be removed in a future release.",
+			"flag", "--request-merge-policy-config", "use", "--request-merge-policy-config-file")
+	}
+}
+
+// effectiveTransportType returns the transport that will be used, honoring the
+// new --transport flag first and falling back to the deprecated
+// --message-queue-impl (normalizing the retired gcp-pubsub-gated alias).
+func (o *Options) effectiveTransportType() string {
+	if o.usingNewTransport() {
+		return o.Transport.Type
+	}
+	return normalizeLegacyImpl(o.MessageQueueImpl)
+}
+
+// resolveTransport returns the effective transport type and its config bytes. It
+// prefers the new --transport / --transport-config[-file] flags; when those are
+// not set it translates the deprecated per-backend flags into an equivalent
+// transport config.
+func (o *Options) resolveTransport() (string, []byte, error) {
+	if o.usingNewTransport() {
+		data, err := loadTransportConfigBytes(o.Transport)
+		if err != nil {
+			return "", nil, err
+		}
+		return o.Transport.Type, data, nil
+	}
+
+	transportType := normalizeLegacyImpl(o.MessageQueueImpl)
+	data, err := o.synthesizeTransportConfig(transportType)
+	if err != nil {
+		return "", nil, err
+	}
+	return transportType, data, nil
+}
+
+// normalizeLegacyImpl maps the retired gcp-pubsub-gated alias onto gcp-pubsub;
+// gating is now expressed per-topic via gate_type in the transport config.
+func normalizeLegacyImpl(impl string) string {
+	if impl == "gcp-pubsub-gated" {
+		return "gcp-pubsub"
+	}
+	return impl
+}
+
+// synthesizeTransportConfig builds a transport config JSON blob from the
+// deprecated per-backend flags for the given transport type.
+func (o *Options) synthesizeTransportConfig(transportType string) ([]byte, error) {
+	switch transportType {
+	case "redis-pubsub":
+		return o.synthesizeRedisPubSubConfig()
+	case "redis-sortedset":
+		return o.synthesizeRedisSortedSetConfig()
+	case "gcp-pubsub":
+		return o.synthesizePubSubConfig()
+	default:
+		return nil, fmt.Errorf("unknown message queue implementation: %s", o.MessageQueueImpl)
+	}
+}
+
+func (o *Options) synthesizeRedisPubSubConfig() ([]byte, error) {
+	queues, err := legacyRedisPubSubQueues(o.Redis)
+	if err != nil {
+		return nil, err
+	}
+	cfg := redis.PubSubConfig{
+		URL:             o.RedisConnection.URL,
+		RetryQueueName:  o.Redis.RetryQueueName,
+		ResultQueueName: o.Redis.ResultQueueName,
+		EnableTracing:   o.Observability.RedisTracing,
+		Queues:          queues,
+	}
+	return json.Marshal(cfg)
+}
+
+func legacyRedisPubSubQueues(opts redis.PubSubFlowOptions) ([]redis.QueueConfig, error) {
+	if opts.QueuesConfig != "" {
+		var qs []redis.QueueConfig
+		if err := json.Unmarshal([]byte(opts.QueuesConfig), &qs); err != nil {
+			return nil, fmt.Errorf("failed to parse --redis.queues-config: %w", err)
+		}
+		return qs, nil
+	}
+	if opts.QueuesConfigFile != "" {
+		data, err := os.ReadFile(opts.QueuesConfigFile) // #nosec G304 -- path from trusted CLI flag
+		if err != nil {
+			return nil, fmt.Errorf("failed to read --redis.queues-config-file: %w", err)
+		}
+		var qs []redis.QueueConfig
+		if err := json.Unmarshal(data, &qs); err != nil {
+			return nil, fmt.Errorf("failed to parse --redis.queues-config-file: %w", err)
+		}
+		return qs, nil
+	}
+	return []redis.QueueConfig{{
+		QueueName:          opts.RequestQueueName,
+		WorkerPoolID:       "default",
+		InferenceObjective: opts.InferenceObjective,
+		IGWBaseURL:         opts.IGWBaseURL,
+		RequestPathURL:     opts.RequestPathURL,
+	}}, nil
+}
+
+func (o *Options) synthesizeRedisSortedSetConfig() ([]byte, error) {
+	queues, err := legacyRedisSortedSetQueues(o.RedisSortedSet)
+	if err != nil {
+		return nil, err
+	}
+	cfg := redis.SortedSetConfig{
+		URL:             o.RedisConnection.URL,
+		ResultQueueName: o.RedisSortedSet.ResultQueueName,
+		PollIntervalMs:  o.RedisSortedSet.PollIntervalMs,
+		BatchSize:       o.RedisSortedSet.BatchSize,
+		EnableTracing:   o.Observability.RedisTracing,
+		Queues:          queues,
+	}
+	return json.Marshal(cfg)
+}
+
+func legacyRedisSortedSetQueues(opts redis.SortedSetFlowOptions) ([]redis.SortedSetQueueConfig, error) {
+	if opts.QueuesConfig != "" {
+		var qs []redis.SortedSetQueueConfig
+		if err := json.Unmarshal([]byte(opts.QueuesConfig), &qs); err != nil {
+			return nil, fmt.Errorf("failed to parse --redis.ss.queues-config: %w", err)
+		}
+		return qs, nil
+	}
+	if opts.QueuesConfigFile != "" {
+		data, err := os.ReadFile(opts.QueuesConfigFile) // #nosec G304 -- path from trusted CLI flag
+		if err != nil {
+			return nil, fmt.Errorf("failed to read --redis.ss.queues-config-file: %w", err)
+		}
+		var qs []redis.SortedSetQueueConfig
+		if err := json.Unmarshal(data, &qs); err != nil {
+			return nil, fmt.Errorf("failed to parse --redis.ss.queues-config-file: %w", err)
+		}
+		return qs, nil
+	}
+	gateParams, err := parseGateParamsJSON(opts.GateParamsJSON)
+	if err != nil {
+		return nil, err
+	}
+	return []redis.SortedSetQueueConfig{{
+		QueueName:          opts.RequestQueueName,
+		WorkerPoolID:       "default",
+		InferenceObjective: opts.InferenceObjective,
+		IGWBaseURL:         opts.IGWBaseURL,
+		RequestPathURL:     opts.RequestPathURL,
+		GateConfig:         pipeline.GateConfig{GateType: opts.GateType, GateParams: gateParams},
+	}}, nil
+}
+
+func (o *Options) synthesizePubSubConfig() ([]byte, error) {
+	topics, err := legacyPubSubTopics(o.PubSub)
+	if err != nil {
+		return nil, err
+	}
+	cfg := pubsub.Config{
+		ProjectID:     o.PubSub.ProjectID,
+		ResultTopicID: o.PubSub.ResultTopicID,
+		BatchSize:     o.PubSub.BatchSize,
+		Topics:        topics,
+	}
+	return json.Marshal(cfg)
+}
+
+func legacyPubSubTopics(opts pubsub.Options) ([]pubsub.TopicConfig, error) {
+	if opts.TopicsConfigFile != "" {
+		data, err := os.ReadFile(opts.TopicsConfigFile) // #nosec G304 -- path from trusted CLI flag
+		if err != nil {
+			return nil, fmt.Errorf("failed to read --pubsub.topics-config-file: %w", err)
+		}
+		var ts []pubsub.TopicConfig
+		if err := json.Unmarshal(data, &ts); err != nil {
+			return nil, fmt.Errorf("failed to parse --pubsub.topics-config-file: %w", err)
+		}
+		return ts, nil
+	}
+	return []pubsub.TopicConfig{{
+		SubscriberID:       opts.RequestSubscriberID,
+		WorkerPoolID:       "default",
+		InferenceObjective: opts.InferenceObjective,
+		IGWBaseURL:         opts.IGWBaseURL,
+		RequestPathURL:     opts.RequestPathURL,
+	}}, nil
+}
+
+// parseGateParamsJSON parses the deprecated --redis.ss.gate-params JSON string
+// into a map for the synthesized gate config.
+func parseGateParamsJSON(s string) (map[string]any, error) {
+	m := map[string]any{}
+	if s == "" || s == "{}" {
+		return m, nil
+	}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, fmt.Errorf("failed to parse --redis.ss.gate-params: %w", err)
+	}
+	return m, nil
+}

--- a/pkg/server/compat_test.go
+++ b/pkg/server/compat_test.go
@@ -1,0 +1,257 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/llm-d/llm-d-async/pkg/pubsub"
+	"github.com/llm-d/llm-d-async/pkg/redis"
+	"github.com/spf13/pflag"
+)
+
+// newTestOptions builds an Options with a fresh flag set parsed from args, so
+// tests exercise the same fs.Changed bookkeeping the real CLI relies on.
+func newTestOptions(t *testing.T, args ...string) *Options {
+	t.Helper()
+	o := NewOptions()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	o.AddFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	return o
+}
+
+func TestSynthesizeRedisPubSubConfig_SingleQueue(t *testing.T) {
+	o := newTestOptions(t,
+		"--message-queue-impl=redis-pubsub",
+		"--redis.url=redis://localhost:6379",
+		"--redis.igw-base-url=http://gw",
+		"--redis.request-queue-name=my-queue",
+		"--redis.retry-queue-name=my-retry",
+		"--redis.result-queue-name=my-result",
+		"--redis-tracing",
+	)
+
+	data, err := o.synthesizeRedisPubSubConfig()
+	if err != nil {
+		t.Fatalf("synthesizeRedisPubSubConfig: %v", err)
+	}
+	var cfg redis.PubSubConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal synthesized config: %v", err)
+	}
+
+	if cfg.URL != "redis://localhost:6379" {
+		t.Errorf("URL = %q, want redis://localhost:6379", cfg.URL)
+	}
+	if cfg.RetryQueueName != "my-retry" || cfg.ResultQueueName != "my-result" {
+		t.Errorf("queue names = %q/%q, want my-retry/my-result", cfg.RetryQueueName, cfg.ResultQueueName)
+	}
+	if !cfg.EnableTracing {
+		t.Error("EnableTracing = false, want true (from --redis-tracing)")
+	}
+	if len(cfg.Queues) != 1 || cfg.Queues[0].QueueName != "my-queue" || cfg.Queues[0].IGWBaseURL != "http://gw" {
+		t.Errorf("queues = %+v, want single my-queue/http://gw", cfg.Queues)
+	}
+
+	// The synthesized blob must satisfy the real loader end to end.
+	if _, err := redis.LoadPubSubConfig(data); err != nil {
+		t.Errorf("LoadPubSubConfig rejected synthesized config: %v", err)
+	}
+}
+
+func TestSynthesizeRedisSortedSetConfig_SingleQueueGate(t *testing.T) {
+	o := newTestOptions(t,
+		"--message-queue-impl=redis-sortedset",
+		"--redis.url=redis://localhost:6379",
+		"--redis.ss.igw-base-url=http://gw",
+		"--redis.ss.request-queue-name=ss-queue",
+		"--redis.ss.gate-type=prometheus-saturation",
+		"--redis.ss.gate-params={\"threshold\":0.7}",
+	)
+
+	data, err := o.synthesizeRedisSortedSetConfig()
+	if err != nil {
+		t.Fatalf("synthesizeRedisSortedSetConfig: %v", err)
+	}
+	var cfg redis.SortedSetConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal synthesized config: %v", err)
+	}
+	if len(cfg.Queues) != 1 {
+		t.Fatalf("queues = %+v, want 1", cfg.Queues)
+	}
+	q := cfg.Queues[0]
+	if q.QueueName != "ss-queue" || q.IGWBaseURL != "http://gw" {
+		t.Errorf("queue = %+v, want ss-queue/http://gw", q)
+	}
+	if q.GateType != "prometheus-saturation" {
+		t.Errorf("GateType = %q, want prometheus-saturation", q.GateType)
+	}
+	if q.GateParams["threshold"] != 0.7 {
+		t.Errorf("GateParams[threshold] = %v, want 0.7", q.GateParams["threshold"])
+	}
+}
+
+func TestSynthesizePubSubConfig_SingleTopic(t *testing.T) {
+	o := newTestOptions(t,
+		"--message-queue-impl=gcp-pubsub",
+		"--pubsub.project-id=proj",
+		"--pubsub.request-subscriber-id=sub-1",
+		"--pubsub.igw-base-url=http://gw",
+		"--pubsub.result-topic-id=results",
+	)
+
+	data, err := o.synthesizePubSubConfig()
+	if err != nil {
+		t.Fatalf("synthesizePubSubConfig: %v", err)
+	}
+	var cfg pubsub.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal synthesized config: %v", err)
+	}
+	if cfg.ProjectID != "proj" || cfg.ResultTopicID != "results" {
+		t.Errorf("project/result = %q/%q, want proj/results", cfg.ProjectID, cfg.ResultTopicID)
+	}
+	if len(cfg.Topics) != 1 || cfg.Topics[0].SubscriberID != "sub-1" || cfg.Topics[0].IGWBaseURL != "http://gw" {
+		t.Errorf("topics = %+v, want single sub-1/http://gw", cfg.Topics)
+	}
+	if _, err := pubsub.LoadConfig(data); err != nil {
+		t.Errorf("LoadConfig rejected synthesized config: %v", err)
+	}
+}
+
+func TestResolveTransport_PrefersNewFlags(t *testing.T) {
+	inline := `{"url":"redis://new","queues":[{"queue_name":"q","igw_base_url":"http://gw"}]}`
+	o := newTestOptions(t,
+		"--transport=redis-pubsub",
+		"--transport-config="+inline,
+		// Legacy flags set too; they must be ignored.
+		"--message-queue-impl=gcp-pubsub",
+		"--redis.url=redis://legacy",
+	)
+
+	transportType, data, err := o.resolveTransport()
+	if err != nil {
+		t.Fatalf("resolveTransport: %v", err)
+	}
+	if transportType != "redis-pubsub" {
+		t.Errorf("transportType = %q, want redis-pubsub (new flag wins)", transportType)
+	}
+	if string(data) != inline {
+		t.Errorf("config bytes = %q, want the inline --transport-config", string(data))
+	}
+}
+
+func TestResolveTransport_NormalizesGatedAlias(t *testing.T) {
+	o := newTestOptions(t,
+		"--message-queue-impl=gcp-pubsub-gated",
+		"--pubsub.project-id=proj",
+		"--pubsub.request-subscriber-id=sub-1",
+		"--pubsub.igw-base-url=http://gw",
+	)
+	transportType, _, err := o.resolveTransport()
+	if err != nil {
+		t.Fatalf("resolveTransport: %v", err)
+	}
+	if transportType != "gcp-pubsub" {
+		t.Errorf("transportType = %q, want gcp-pubsub (gated alias normalized)", transportType)
+	}
+}
+
+func TestWarnDeprecatedFlags_LegacyUsed(t *testing.T) {
+	o := newTestOptions(t,
+		"--message-queue-impl=redis-sortedset",
+		"--redis.url=redis://localhost:6379",
+	)
+
+	var msgs []string
+	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
+	o.WarnDeprecatedFlags(logger)
+
+	joined := strings.Join(msgs, "\n")
+	if !strings.Contains(joined, "--message-queue-impl") || !strings.Contains(joined, "--redis.url") {
+		t.Errorf("expected deprecation warnings for the set legacy flags, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "ignored because") {
+		t.Errorf("legacy-only run should warn about deprecation, not ignore, got:\n%s", joined)
+	}
+}
+
+func TestWarnDeprecatedFlags_IgnoredWhenNewTransport(t *testing.T) {
+	o := newTestOptions(t,
+		"--transport=redis-pubsub",
+		"--transport-config={\"url\":\"redis://new\",\"queues\":[]}",
+		"--redis.url=redis://legacy",
+	)
+
+	var msgs []string
+	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
+	o.WarnDeprecatedFlags(logger)
+
+	joined := strings.Join(msgs, "\n")
+	if !strings.Contains(joined, "ignored because") || !strings.Contains(joined, "--redis.url") {
+		t.Errorf("expected 'ignored' warning for --redis.url when new transport used, got:\n%s", joined)
+	}
+}
+
+func TestMergePolicyConfigFile_Resolution(t *testing.T) {
+	t.Run("canonical flag", func(t *testing.T) {
+		o := newTestOptions(t, "--request-merge-policy-config-file=/etc/new.json")
+		if got := o.mergePolicyConfigFile(); got != "/etc/new.json" {
+			t.Errorf("mergePolicyConfigFile() = %q, want /etc/new.json", got)
+		}
+	})
+	t.Run("deprecated alias", func(t *testing.T) {
+		o := newTestOptions(t, "--request-merge-policy-config=/etc/old.json")
+		if got := o.mergePolicyConfigFile(); got != "/etc/old.json" {
+			t.Errorf("mergePolicyConfigFile() = %q, want /etc/old.json", got)
+		}
+	})
+	t.Run("canonical wins when both set", func(t *testing.T) {
+		o := newTestOptions(t,
+			"--request-merge-policy-config=/etc/old.json",
+			"--request-merge-policy-config-file=/etc/new.json",
+		)
+		if got := o.mergePolicyConfigFile(); got != "/etc/new.json" {
+			t.Errorf("mergePolicyConfigFile() = %q, want /etc/new.json (canonical wins)", got)
+		}
+	})
+}
+
+func TestWarnDeprecatedFlags_MergePolicyRenameNotIgnored(t *testing.T) {
+	// Even with the new transport flags in use, the merge-policy alias still
+	// works (it is orthogonal to transport), so it must not be reported "ignored".
+	o := newTestOptions(t,
+		"--transport-config={\"url\":\"redis://x\",\"queues\":[]}",
+		"--request-merge-policy-config=/etc/old.json",
+	)
+
+	var msgs []string
+	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
+	o.WarnDeprecatedFlags(logger)
+
+	joined := strings.Join(msgs, "\n")
+	if !strings.Contains(joined, "--request-merge-policy-config") ||
+		!strings.Contains(joined, "--request-merge-policy-config-file") {
+		t.Errorf("expected rename warning for merge-policy flag, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "ignored because") {
+		t.Errorf("merge-policy flag must not be reported as ignored, got:\n%s", joined)
+	}
+}
+
+func TestWarnDeprecatedFlags_NoneSet(t *testing.T) {
+	o := newTestOptions(t, "--transport-config={\"url\":\"redis://x\",\"queues\":[]}")
+
+	var msgs []string
+	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
+	o.WarnDeprecatedFlags(logger)
+
+	if len(msgs) != 0 {
+		t.Errorf("expected no deprecation warnings when no deprecated flags set, got:\n%s", strings.Join(msgs, "\n"))
+	}
+}

--- a/pkg/server/compat_test.go
+++ b/pkg/server/compat_test.go
@@ -162,6 +162,52 @@ func TestResolveTransport_NormalizesGatedAlias(t *testing.T) {
 	}
 }
 
+// TestLegacyUngatedPubSub guards the regression where the retired plain
+// gcp-pubsub alias started honoring gate_type: on main it wired no gate factory,
+// so only that ungated alias must withhold the factory. The gated alias and the
+// new --transport surface gate normally.
+func TestLegacyUngatedPubSub(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "legacy plain gcp-pubsub is ungated",
+			args: []string{"--message-queue-impl=gcp-pubsub"},
+			want: true,
+		},
+		{
+			name: "legacy gated alias gates",
+			args: []string{"--message-queue-impl=gcp-pubsub-gated"},
+			want: false,
+		},
+		{
+			name: "new transport surface gates",
+			args: []string{
+				"--transport=gcp-pubsub",
+				`--transport-config={"project_id":"p","result_topic_id":"r","topics":[{"subscriber_id":"s","igw_base_url":"http://gw"}]}`,
+				// A legacy impl set alongside the new flags must not flip the switch.
+				"--message-queue-impl=gcp-pubsub",
+			},
+			want: false,
+		},
+		{
+			name: "legacy redis impl is irrelevant",
+			args: []string{"--message-queue-impl=redis-pubsub"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newTestOptions(t, tt.args...)
+			if got := o.legacyUngatedPubSub(); got != tt.want {
+				t.Errorf("legacyUngatedPubSub() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWarnDeprecatedFlags_LegacyUsed(t *testing.T) {
 	o := newTestOptions(t,
 		"--message-queue-impl=redis-sortedset",
@@ -170,7 +216,7 @@ func TestWarnDeprecatedFlags_LegacyUsed(t *testing.T) {
 
 	var msgs []string
 	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
-	o.WarnDeprecatedFlags(logger)
+	o.warnDeprecatedFlags(logger)
 
 	joined := strings.Join(msgs, "\n")
 	if !strings.Contains(joined, "--message-queue-impl") || !strings.Contains(joined, "--redis.url") {
@@ -190,7 +236,7 @@ func TestWarnDeprecatedFlags_IgnoredWhenNewTransport(t *testing.T) {
 
 	var msgs []string
 	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
-	o.WarnDeprecatedFlags(logger)
+	o.warnDeprecatedFlags(logger)
 
 	joined := strings.Join(msgs, "\n")
 	if !strings.Contains(joined, "ignored because") || !strings.Contains(joined, "--redis.url") {
@@ -232,7 +278,7 @@ func TestWarnDeprecatedFlags_MergePolicyRenameNotIgnored(t *testing.T) {
 
 	var msgs []string
 	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
-	o.WarnDeprecatedFlags(logger)
+	o.warnDeprecatedFlags(logger)
 
 	joined := strings.Join(msgs, "\n")
 	if !strings.Contains(joined, "--request-merge-policy-config") ||
@@ -249,7 +295,7 @@ func TestWarnDeprecatedFlags_NoneSet(t *testing.T) {
 
 	var msgs []string
 	logger := funcr.New(func(prefix, args string) { msgs = append(msgs, args) }, funcr.Options{})
-	o.WarnDeprecatedFlags(logger)
+	o.warnDeprecatedFlags(logger)
 
 	if len(msgs) != 0 {
 		t.Errorf("expected no deprecation warnings when no deprecated flags set, got:\n%s", strings.Join(msgs, "\n"))

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"fmt"
+	"os"
+)
+
+// loadTransportConfigBytes returns the transport configuration bytes, from the
+// inline --transport-config value or the --transport-config-file path.
+func loadTransportConfigBytes(t TransportOptions) ([]byte, error) {
+	if t.Config != "" {
+		return []byte(t.Config), nil
+	}
+	data, err := os.ReadFile(t.ConfigFile) // #nosec G304 -- path from trusted CLI flag
+	if err != nil {
+		return nil, fmt.Errorf("failed to read transport config file %q: %w", t.ConfigFile, err)
+	}
+	return data, nil
+}

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -34,8 +34,11 @@ type WorkerConfig struct {
 	PoolConfigFile string
 }
 
-type QueueConfig struct {
-	Impl                  string
+// TransportOptions groups the transport selection and configuration flags.
+type TransportOptions struct {
+	Type                  string
+	Config                string
+	ConfigFile            string
 	MergePolicyConfigFile string
 	BacklogPollInterval   time.Duration
 }
@@ -54,21 +57,35 @@ type Config struct {
 	Server              ServerConfig
 	TLS                 TLSConfig
 	Worker              WorkerConfig
-	Queue               QueueConfig
+	Transport           TransportOptions
 	Observability       ObservabilityConfig
 	Prometheus          PrometheusConfig
 	TransformConfigFile string
+
+	// MessageQueueImpl backs the deprecated --message-queue-impl flag. Prefer
+	// Transport.Type (--transport). Retained for backwards compatibility.
+	MessageQueueImpl string
 }
 
 type Options struct {
 	Config
 
+	// Deprecated per-backend flag options, retained for backwards compatibility.
+	// They are translated into the transport config by the compat shim.
 	Redis           redis.PubSubFlowOptions
 	RedisSortedSet  redis.SortedSetFlowOptions
 	RedisConnection redis.ConnectionOptions
 	PubSub          pubsub.Options
 
 	loggingOptions zap.Options
+
+	// legacyMergePolicyConfigFile backs the deprecated --request-merge-policy-config
+	// flag. Prefer Transport.MergePolicyConfigFile (--request-merge-policy-config-file).
+	legacyMergePolicyConfigFile string
+
+	// flagSet is captured in AddFlags so Validate/Complete and the compat shim
+	// can inspect which flags were explicitly set (fs.Changed).
+	flagSet *pflag.FlagSet
 }
 
 func NewOptions() *Options {
@@ -84,8 +101,8 @@ func NewOptions() *Options {
 				RequestTimeout: 5 * time.Minute,
 				DrainTimeout:   2 * time.Minute,
 			},
-			Queue: QueueConfig{
-				Impl:                "redis-pubsub",
+			Transport: TransportOptions{
+				Type:                "redis-pubsub",
 				BacklogPollInterval: 15 * time.Second,
 			},
 			Observability: ObservabilityConfig{
@@ -94,6 +111,7 @@ func NewOptions() *Options {
 			Prometheus: PrometheusConfig{
 				CacheTTL: flowcontrol.DefaultCacheTTL,
 			},
+			MessageQueueImpl: "redis-pubsub",
 		},
 		Redis:           *redis.NewPubSubFlowOptions(),
 		RedisSortedSet:  *redis.NewSortedSetFlowOptions(),
@@ -104,6 +122,8 @@ func NewOptions() *Options {
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	o.flagSet = fs
+
 	fs.IntVarP(&o.Observability.Verbosity, "v", "v", o.Observability.Verbosity, "number for the log level verbosity")
 
 	fs.IntVar(&o.Server.HealthPort, "health-port", o.Server.HealthPort, "The health probe port")
@@ -115,11 +135,17 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.Worker.DrainTimeout, "drain-timeout", o.Worker.DrainTimeout, "maximum time to wait for in-flight requests to complete after SIGTERM")
 	fs.StringVar(&o.Worker.PoolConfigFile, "pool-config-file", o.Worker.PoolConfigFile, "Path to the pools configuration JSON file")
 
-	fs.StringVar(&o.Queue.MergePolicyConfigFile, "request-merge-policy-config", o.Queue.MergePolicyConfigFile, "Path to the request merge policy configuration JSON file (empty defaults to random-robin)")
-	fs.StringVar(&o.Queue.Impl, "message-queue-impl", o.Queue.Impl, "The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
-	fs.DurationVar(&o.Queue.BacklogPollInterval, "metrics-backlog-poll-interval", o.Queue.BacklogPollInterval, "interval to poll the broker for queue backlog metrics (0 disables); only applies to flows that support it (redis-sortedset, gcp-pubsub)")
+	fs.StringVar(&o.Transport.Type, "transport", o.Transport.Type, "The transport implementation to use. Supported: redis-pubsub, redis-sortedset, gcp-pubsub")
+	fs.StringVar(&o.Transport.Config, "transport-config", o.Transport.Config, "Inline JSON transport configuration. Mutually exclusive with --transport-config-file.")
+	fs.StringVar(&o.Transport.ConfigFile, "transport-config-file", o.Transport.ConfigFile, "Path to transport configuration JSON file. Mutually exclusive with --transport-config.")
+	fs.StringVar(&o.Transport.MergePolicyConfigFile, "request-merge-policy-config-file", o.Transport.MergePolicyConfigFile, "Path to the request merge policy configuration JSON file (empty defaults to random-robin)")
+	// Deprecated: use --request-merge-policy-config-file. Retained for backwards compatibility.
+	fs.StringVar(&o.legacyMergePolicyConfigFile, "request-merge-policy-config", o.legacyMergePolicyConfigFile, "Deprecated: use --request-merge-policy-config-file. Path to the request merge policy configuration JSON file")
+	fs.DurationVar(&o.Transport.BacklogPollInterval, "metrics-backlog-poll-interval", o.Transport.BacklogPollInterval, "interval to poll the broker for queue backlog metrics (0 disables); only applies to flows that support it (redis-sortedset, gcp-pubsub)")
 
-	fs.BoolVar(&o.Observability.RedisTracing, "redis-tracing", o.Observability.RedisTracing, "Enable per-command Redis tracing spans (high volume, use for debugging only)")
+	// Deprecated: use --transport / --transport-config instead. Retained for backwards compatibility.
+	fs.StringVar(&o.MessageQueueImpl, "message-queue-impl", o.MessageQueueImpl, "Deprecated: use --transport. The message queue implementation to use. Supported implementations: redis-pubsub, redis-sortedset, gcp-pubsub, gcp-pubsub-gated")
+	fs.BoolVar(&o.Observability.RedisTracing, "redis-tracing", o.Observability.RedisTracing, "Deprecated: set enable_tracing in --transport-config. Enable per-command Redis tracing spans (high volume, use for debugging only)")
 
 	fs.StringVar(&o.TLS.CACert, "tls-ca-cert", o.TLS.CACert, "Path to CA certificate file (PEM) for verifying the inference gateway")
 	fs.StringVar(&o.TLS.Cert, "tls-cert", o.TLS.Cert, "Path to client certificate file (PEM) for mTLS")
@@ -153,33 +179,90 @@ func (o *Options) IsQueueConfigSet() bool {
 	return o.Redis.HasQueueConfig() || o.RedisSortedSet.HasQueueConfig() || o.PubSub.HasTopicConfig()
 }
 
+// usingNewTransport reports whether the caller opted into the new transport
+// flags (--transport / --transport-config / --transport-config-file). When true,
+// the deprecated per-backend flags are ignored.
+func (o *Options) usingNewTransport() bool {
+	if o.flagSet == nil {
+		return false
+	}
+	return o.flagSet.Changed("transport") ||
+		o.flagSet.Changed("transport-config") ||
+		o.flagSet.Changed("transport-config-file")
+}
+
+// mergePolicyConfigFile returns the effective merge-policy config file path,
+// preferring the canonical --request-merge-policy-config-file over the
+// deprecated --request-merge-policy-config alias when both are set.
+func (o *Options) mergePolicyConfigFile() string {
+	if o.flagSet != nil &&
+		o.flagSet.Changed("request-merge-policy-config") &&
+		!o.flagSet.Changed("request-merge-policy-config-file") {
+		return o.legacyMergePolicyConfigFile
+	}
+	return o.Transport.MergePolicyConfigFile
+}
+
 func (o *Options) Complete() error {
-	hasQueueConfig := o.IsQueueConfigSet()
 	hasPoolConfig := o.Worker.PoolConfigFile != ""
 
-	if hasPoolConfig && !hasQueueConfig {
-		return fmt.Errorf("pool-config-file can only be specified when queues/topics config file is also specified")
+	var hasTransportConfig bool
+	if o.usingNewTransport() {
+		hasTransportConfig = o.Transport.Config != "" || o.Transport.ConfigFile != ""
+	} else {
+		hasTransportConfig = o.IsQueueConfigSet()
+	}
+
+	if hasPoolConfig && !hasTransportConfig {
+		return fmt.Errorf("pool-config-file can only be specified when a transport/queues config is also specified")
 	}
 
 	return nil
 }
 
 var (
+	validTransports = []string{"redis-pubsub", "redis-sortedset", "gcp-pubsub"}
 	validQueueImpls = []string{"redis-pubsub", "redis-sortedset", "gcp-pubsub", "gcp-pubsub-gated"}
 )
 
 func (o *Options) Validate() error {
-	if !contains(validQueueImpls, o.Queue.Impl) {
-		return fmt.Errorf("--message-queue-impl must be one of: %s", strings.Join(validQueueImpls, ", "))
-	}
-	if strings.HasPrefix(o.Queue.Impl, "redis") && o.RedisConnection.URL == "" {
-		return fmt.Errorf("--redis.url (or REDIS_URL env var) is required when using %s", o.Queue.Impl)
-	}
-	if strings.HasPrefix(o.Queue.Impl, "gcp-pubsub") && o.PubSub.ProjectID == "" {
-		return fmt.Errorf("--pubsub.project-id is required when using %s", o.Queue.Impl)
+	if o.usingNewTransport() {
+		if err := o.validateNewTransport(); err != nil {
+			return err
+		}
+	} else if err := o.validateLegacyTransport(); err != nil {
+		return err
 	}
 	if (o.TLS.Cert != "") != (o.TLS.Key != "") {
 		return fmt.Errorf("both --tls-cert and --tls-key must be provided together")
+	}
+	return nil
+}
+
+func (o *Options) validateNewTransport() error {
+	if !contains(validTransports, o.Transport.Type) {
+		return fmt.Errorf("--transport must be one of: %s", strings.Join(validTransports, ", "))
+	}
+	hasInline := o.Transport.Config != ""
+	hasFile := o.Transport.ConfigFile != ""
+	if hasInline && hasFile {
+		return fmt.Errorf("--transport-config and --transport-config-file are mutually exclusive")
+	}
+	if !hasInline && !hasFile {
+		return fmt.Errorf("--transport-config or --transport-config-file is required")
+	}
+	return nil
+}
+
+func (o *Options) validateLegacyTransport() error {
+	if !contains(validQueueImpls, o.MessageQueueImpl) {
+		return fmt.Errorf("--message-queue-impl must be one of: %s", strings.Join(validQueueImpls, ", "))
+	}
+	if strings.HasPrefix(o.MessageQueueImpl, "redis") && o.RedisConnection.URL == "" {
+		return fmt.Errorf("--redis.url (or REDIS_URL env var) is required when using %s", o.MessageQueueImpl)
+	}
+	if strings.HasPrefix(o.MessageQueueImpl, "gcp-pubsub") && o.PubSub.ProjectID == "" {
+		return fmt.Errorf("--pubsub.project-id is required when using %s", o.MessageQueueImpl)
 	}
 	return nil
 }

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -87,7 +87,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	setupLog.Info("Async Processor starting", "version", version.Version, "commit", version.Commit, "buildDate", version.BuildDate)
 
 	printAllFlags(setupLog)
-	opts.WarnDeprecatedFlags(setupLog)
+	opts.warnDeprecatedFlags(setupLog)
 
 	poolsMap, totalConcurrency, err := loadWorkerPools(opts.Worker, setupLog)
 	if err != nil {
@@ -301,6 +301,11 @@ func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[
 		cfg, err := pubsub.LoadConfig(configBytes)
 		if err != nil {
 			return nil, err
+		}
+		// The legacy plain gcp-pubsub alias never gated (see legacyUngatedPubSub);
+		// pass a nil factory so a gate_type in a legacy topics file stays inert.
+		if opts.legacyUngatedPubSub() {
+			return pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, nil)
 		}
 		return pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, gateFactory)
 	default:

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -87,6 +87,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	setupLog.Info("Async Processor starting", "version", version.Version, "commit", version.Commit, "buildDate", version.BuildDate)
 
 	printAllFlags(setupLog)
+	opts.WarnDeprecatedFlags(setupLog)
 
 	poolsMap, totalConcurrency, err := loadWorkerPools(opts.Worker, setupLog)
 	if err != nil {
@@ -96,7 +97,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	gateFactory = flowcontrol.NewGateFactoryWithCacheTTL(opts.Prometheus.URL, opts.Prometheus.CacheTTL).
 		WithLogger(setupLog)
 
-	policy, err := loadRequestMergePolicy(opts.Queue.MergePolicyConfigFile, ctx)
+	policy, err := loadRequestMergePolicy(opts.mergePolicyConfigFile(), ctx)
 	if err != nil {
 		return err
 	}
@@ -173,10 +174,10 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	flow.Start(ctx)
 	healthServer.SetReady()
 
-	if reporter, ok := flow.(pipeline.BacklogReporter); ok && opts.Queue.BacklogPollInterval > 0 {
-		go pollBacklog(ctx, reporter, opts.Queue.BacklogPollInterval)
+	if reporter, ok := flow.(pipeline.BacklogReporter); ok && opts.Transport.BacklogPollInterval > 0 {
+		go pollBacklog(ctx, reporter, opts.Transport.BacklogPollInterval)
 	} else if !ok {
-		setupLog.Info("Selected flow does not support broker backlog metrics", "message-queue-impl", opts.Queue.Impl)
+		setupLog.Info("Selected flow does not support broker backlog metrics", "transport", opts.effectiveTransportType())
 	}
 
 	<-ctx.Done()
@@ -277,17 +278,33 @@ func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[
 	for _, p := range poolsMap {
 		workerPools = append(workerPools, p)
 	}
-	switch opts.Queue.Impl {
+
+	transportType, configBytes, err := opts.resolveTransport()
+	if err != nil {
+		return nil, err
+	}
+
+	switch transportType {
 	case "redis-pubsub":
-		return redis.NewRedisMQFlow(opts.Redis, opts.RedisConnection, redis.WithRedisTracing(opts.Observability.RedisTracing), redis.WithWorkerPools(workerPools))
+		cfg, err := redis.LoadPubSubConfig(configBytes)
+		if err != nil {
+			return nil, err
+		}
+		return redis.NewRedisMQFlow(*cfg, workerPools)
 	case "redis-sortedset":
-		return redis.NewRedisSortedSetFlow(opts.RedisSortedSet, opts.RedisConnection, redis.WithGateFactory(gateFactory), redis.WithSortedSetRedisTracing(opts.Observability.RedisTracing), redis.WithSortedSetWorkerPools(workerPools))
+		cfg, err := redis.LoadSortedSetConfig(configBytes)
+		if err != nil {
+			return nil, err
+		}
+		return redis.NewRedisSortedSetFlow(*cfg, workerPools, gateFactory)
 	case "gcp-pubsub":
-		return pubsub.NewGCPPubSubMQFlow(opts.PubSub, pubsub.WithWorkerPools(workerPools))
-	case "gcp-pubsub-gated":
-		return pubsub.NewGCPPubSubMQFlow(opts.PubSub, pubsub.WithGateFactory(gateFactory), pubsub.WithWorkerPools(workerPools))
+		cfg, err := pubsub.LoadConfig(configBytes)
+		if err != nil {
+			return nil, err
+		}
+		return pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, gateFactory)
 	default:
-		return nil, fmt.Errorf("unknown message queue implementation: %s", opts.Queue.Impl)
+		return nil, fmt.Errorf("unknown transport: %s", transportType)
 	}
 }
 
@@ -436,6 +453,8 @@ func pollBacklog(ctx context.Context, reporter pipeline.BacklogReporter, interva
 
 var sensitiveFlags = map[string]bool{
 	"redis.url": true,
+	// transport-config may embed a connection URL with credentials.
+	"transport-config": true,
 }
 
 func printAllFlags(setupLog logr.Logger) {

--- a/release-notes.d/unreleased/378.md
+++ b/release-notes.d/unreleased/378.md
@@ -1,0 +1,29 @@
+---
+pr: 378
+url: https://github.com/llm-d/llm-d-async/pull/378
+author: evacchi
+date: 2026-07-31
+---
+Add a unified transport-config surface: select a backend with `--transport`
+(`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it from one
+JSON document supplied via `--transport-config` (inline) or
+`--transport-config-file` (file). The previous per-backend flags
+(`--message-queue-impl`, `--redis.*`, `--redis.ss.*`, `--pubsub.*`,
+`--redis-tracing`) are translated internally and still work, logging a
+deprecation warning that names the replacement; `--request-merge-policy-config`
+is likewise superseded by `--request-merge-policy-config-file`. **Deprecated:**
+these legacy flags will be removed no earlier than `v0.10.0`.
+
+Behavior notes for the legacy path:
+
+- **Breaking (legacy path):** for the Redis transports, `REDIS_URL` is now a
+  fallback default for `url` rather than an override — an explicit `--redis.url`
+  (or inline `url` in `--transport-config`) wins when both are set. The Helm
+  chart, which injects `REDIS_URL` and never sets `url`, is unaffected.
+- `--message-queue-impl=gcp-pubsub` (the plain, ungated alias) stays ungated: a
+  `gate_type` in its topics-config file remains inert, as before. Per-topic
+  gating is available on the new `--transport gcp-pubsub` surface via
+  `gate_type`/`gate_params`.
+- The `redis-sortedset` single-queue retry fallback now uses the first
+  configured queue's `queue_name` (previously `--redis.ss.request-queue-name`).
+  In multi-queue configs the fallback is order-dependent on the `queues` array.

--- a/release-notes.d/unreleased/378.md
+++ b/release-notes.d/unreleased/378.md
@@ -4,7 +4,7 @@ url: https://github.com/llm-d/llm-d-async/pull/378
 author: evacchi
 date: 2026-07-31
 ---
-Add a unified transport-config surface: select a backend with `--transport`
+Breaking: Add a unified transport-config surface: select a backend with `--transport`
 (`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it from one
 JSON document supplied via `--transport-config` (inline) or
 `--transport-config-file` (file). The previous per-backend flags
@@ -27,3 +27,6 @@ Behavior notes for the legacy path:
 - The `redis-sortedset` single-queue retry fallback now uses the first
   configured queue's `queue_name` (previously `--redis.ss.request-queue-name`).
   In multi-queue configs the fallback is order-dependent on the `queues` array.
+
+
+Deprecation window: 2 releases from now.

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -22,20 +22,24 @@ func TestRedisImpl(t *testing.T) {
 
 	ctx := context.Background()
 
-	flowOpts := redis.PubSubFlowOptions{
-		IGWBaseURL:       "http://localhost:30800",
-		RequestPathURL:   "/v1/completions",
-		RequestQueueName: "request-queue",
-		RetryQueueName:   "retry-sortedset",
-		ResultQueueName:  "result-queue",
+	cfg := redis.PubSubConfig{
+		URL:             redisURL,
+		RetryQueueName:  "retry-sortedset",
+		ResultQueueName: "result-queue",
+		Queues: []redis.QueueConfig{{
+			QueueName:      "request-queue",
+			WorkerPoolID:   "default",
+			RequestPathURL: "/v1/completions",
+			IGWBaseURL:     "http://localhost:30800",
+		}},
 	}
-	connOpts := redis.ConnectionOptions{URL: redisURL}
-	flow, err := redis.NewRedisMQFlow(flowOpts, connOpts, redis.WithWorkerPools([]pipeline.WorkerPoolConfig{
+	cfg.ApplyDefaults()
+	flow, err := redis.NewRedisMQFlow(cfg, []pipeline.WorkerPoolConfig{
 		{
 			ID:      "default",
 			Workers: 1,
 		},
-	}))
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,22 +102,25 @@ func TestRedisImplWithAuth(t *testing.T) {
 
 	ctx := context.Background()
 
-	flowOpts := redis.SortedSetFlowOptions{
-		IGWBaseURL:       "http://localhost:30800",
-		RequestPathURL:   "/v1/completions",
-		RequestQueueName: "request-sortedset",
-		ResultQueueName:  "result-list",
-		PollIntervalMs:   1000,
-		BatchSize:        10,
-		GateParamsJSON:   "{}",
+	cfg := redis.SortedSetConfig{
+		URL:             redisURL,
+		ResultQueueName: "result-list",
+		PollIntervalMs:  1000,
+		BatchSize:       10,
+		Queues: []redis.SortedSetQueueConfig{{
+			QueueName:      "request-sortedset",
+			WorkerPoolID:   "default",
+			RequestPathURL: "/v1/completions",
+			IGWBaseURL:     "http://localhost:30800",
+		}},
 	}
-	connOpts := redis.ConnectionOptions{URL: redisURL}
-	flow, err := redis.NewRedisSortedSetFlow(flowOpts, connOpts, redis.WithSortedSetWorkerPools([]pipeline.WorkerPoolConfig{
+	cfg.ApplyDefaults()
+	flow, err := redis.NewRedisSortedSetFlow(cfg, []pipeline.WorkerPoolConfig{
 		{
 			ID:      "default",
 			Workers: 1,
 		},
-	}))
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What does this PR do?

Reorganizes backend/transport configuration around a single **transport** abstraction: each backend is now selected with `--transport` and configured from one JSON document supplied via `--transport-config` (inline) or `--transport-config-file` (file). This replaces the previous sprawl of per-backend CLI flags (`--redis.*`, `--redis.ss.*`, `--pubsub.*`, `--message-queue-impl`).

Key changes:

- **New transport-config surface**
  - `--transport` — `redis-pubsub` | `redis-sortedset` | `gcp-pubsub` (default `redis-pubsub`).
  - `--transport-config` / `--transport-config-file` — inline or file JSON, mutually exclusive, one required when using the new path.
  - Backends parse their config via `redis.LoadPubSubConfig`, `redis.LoadSortedSetConfig`, `pubsub.LoadConfig` (each with `ApplyDefaults`/`Validate`/env overrides), and expose new constructor signatures:
    - `NewRedisMQFlow(cfg, workerPools)`
    - `NewRedisSortedSetFlow(cfg, workerPools, gateFactory)`
    - `NewGCPPubSubMQFlow(cfg, workerPools, gateFactory)`
  - `runner.go`'s `loadFlow` selects by transport type and passes config bytes.
- **Backwards compatibility (`pkg/server/compat.go`)**
  - Every legacy flag stays registered and functional; a `logr` deprecation warning names the replacement when one is used.
  - Legacy flags are translated into the equivalent transport JSON (`synthesizeTransportConfig`), including single-queue fallback and `--redis-tracing` → `enable_tracing`.
  - New flags win when both are set (the legacy ones are then reported as ignored).
  - The retired `gcp-pubsub-gated` implementation is accepted via `--message-queue-impl` and normalized to `gcp-pubsub` with per-topic `gate_type`.
- **Flag naming consistency**
  - Added `--request-merge-policy-config-file` (matching `--transport-config-file`); the older `--request-merge-policy-config` is kept as a deprecated alias. Precedence resolved by `Options.mergePolicyConfigFile()`.
- **Docs**
  - `README.md`: new **Transport Configuration** section with per-backend JSON schemas; per-backend flag sections marked deprecated with alias→field mappings; merge-policy and redis-tracing references updated.

Preserved from main (not regressed): module path `github.com/llm-d/llm-d-async`; Valkey support; EPP budget cascade / gate factory; plugin-based merge policy; redis tracing; backlog polling; and all newer sorted-set/pubsub runtime behavior (cancellation, retry-reservation release #311, gate-closed accounting #368, `GateOwner` stamping #369, structured results, pubsub health probing). Only the config/constructor surface was swapped; runtime logic is main's.


## Why is this change needed?

The per-backend flag surface had grown large and duplicative, with many mutually-exclusive flags per backend. A single JSON config per transport is easier to document, template in Helm, and extend, and it unifies single-queue and multi-queue configuration. All previous flags are retained and still work, so existing deployments keep functioning while migrating.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

Details:
- `make build` and `make test` pass across all modules (root, `api/`, `pipeline/`, `producer/`); `go fmt`/`go vet` clean.
- Ported the four backend flow tests to the new constructors (keeping main's added tests) and added `pkg/server/compat_test.go` covering config synthesis, new-vs-legacy precedence, gated-alias normalization, deprecation warnings, and the merge-policy resolver.
- `go vet -tags integration ./test/integration/` compiles.
- Manual smoke: `--help` shows both surfaces; validation paths verified for new-path (`--transport-config` required), legacy-path (`--pubsub.project-id` required), and invalid `--transport`.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Follow up to #283, #287, #295
Related https://github.com/llm-d/llm-d-async/issues/284

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
Breaking: Add a unified transport-config surface: select a backend with `--transport`
(`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it from one
JSON document supplied via `--transport-config` (inline) or
`--transport-config-file` (file). The previous per-backend flags
(`--message-queue-impl`, `--redis.*`, `--redis.ss.*`, `--pubsub.*`,
`--redis-tracing`) are translated internally and still work, logging a
deprecation warning that names the replacement; `--request-merge-policy-config`
is likewise superseded by `--request-merge-policy-config-file`. **Deprecated:**
these legacy flags will be removed no earlier than `v0.10.0`.

Behavior notes for the legacy path:

- **Breaking (legacy path):** for the Redis transports, `REDIS_URL` is now a
  fallback default for `url` rather than an override — an explicit `--redis.url`
  (or inline `url` in `--transport-config`) wins when both are set. The Helm
  chart, which injects `REDIS_URL` and never sets `url`, is unaffected.
- `--message-queue-impl=gcp-pubsub` (the plain, ungated alias) stays ungated: a
  `gate_type` in its topics-config file remains inert, as before. Per-topic
  gating is available on the new `--transport gcp-pubsub` surface via
  `gate_type`/`gate_params`.
- The `redis-sortedset` single-queue retry fallback now uses the first
  configured queue's `queue_name` (previously `--redis.ss.request-queue-name`).
  In multi-queue configs the fallback is order-dependent on the `queues` array.


Deprecation window: 2 releases from now.
```

