### PR TITLE
feat(mergepolicy): stamp inference fairness ID from tenant metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,13 +400,13 @@ The merge policy is configured using the `--request-merge-policy-config` CLI fla
 
 1. **`random-robin`**: Randomly picks messages from all queues configured for a given pool. This is the default policy.
    - **Parameters**:
-     - `fairness_header` (optional, string): The HTTP header name used to pass the tenant's fairness identity to the gateway's flow control. Set to `""` to disable stamping. Default is `"x-llm-d-inference-fairness-id"`.
-     - `fairness_attribute` (optional, string): The message metadata attribute holding the tenant identity (the same attribute the `redis-quota` gate keys on). The header is only stamped when the attribute is present, non-empty, and a legal HTTP header value; a caller-supplied header with the same name (any letter case) takes precedence. Default is `"userid"`.
+     - `fairness_header` (optional, string): The HTTP header name used to pass the tenant's fairness identity to the gateway's flow control. Set to `""` to disable stamping. A name that is not a legal HTTP header name is rejected at startup. Default is `"x-llm-d-inference-fairness-id"`.
+     - `fairness_attribute` (optional, string): The message metadata attribute holding the tenant identity (the same attribute the `redis-quota` gate keys on). The stamped value replaces any caller-supplied header of the same name under any letter case, so the identity the gateway arbitrates on is the one quota is accounted against. The header is only stamped when the attribute is present, non-empty, at most 256 bytes, and a legal HTTP header value; otherwise the request dispatches with the header untouched. Default is `"userid"`.
    - **Note**: Stamping is on by default and sends the attribute's value to the gateway, where it may be recorded in access logs. Prefer an opaque tenant ID over personally identifying values such as email addresses, or set `fairness_header` to `""` to disable stamping.
 2. **`tier-priority`**: Buckets requests into 6 strict priority lanes using routing tags (`(classification, tier)`). Within each bucket, it round-robins across different client channels and stamps the chosen priority header (`x-gateway-priority` by default).
    - **Note**: The `tier-priority` merge policy assumes that all messages within a single queue share the same priority. Message classification relies on the FIFO order of an individual queue, and a message's classification does not change after it is pulled off the queue.
    - **Parameters**:
-     - `priority_header` (optional, string): The HTTP header name used to pass the priority value downstream to the inference scheduler. Default is `"x-gateway-priority"`.
+     - `priority_header` (optional, string): The HTTP header name used to pass the priority value downstream to the inference scheduler. A name that is not a legal HTTP header name is rejected at startup. Default is `"x-gateway-priority"`.
      - `tier_label` (optional, string): The label name on `InternalRequest.Labels` used to look up the request's priority tier. Default is `"tier"`.
      - `fairness_header` / `fairness_attribute` (optional, string): Same as for `random-robin`.
 

--- a/README.md
+++ b/README.md
@@ -398,12 +398,17 @@ The merge policy is configured using the `--request-merge-policy-config` CLI fla
 
 #### Supported Policies
 
-1. **`random-robin`**: Randomly picks messages from all queues configured for a given pool. This is the default policy and accepts no parameters.
+1. **`random-robin`**: Randomly picks messages from all queues configured for a given pool. This is the default policy.
+   - **Parameters**:
+     - `fairness_header` (optional, string): The HTTP header name used to pass the tenant's fairness identity to the gateway's flow control. Set to `""` to disable stamping. Default is `"x-llm-d-inference-fairness-id"`.
+     - `fairness_attribute` (optional, string): The message metadata attribute holding the tenant identity (the same attribute the `redis-quota` gate keys on). The header is only stamped when the attribute is present, non-empty, and a legal HTTP header value; a caller-supplied header with the same name (any letter case) takes precedence. Default is `"userid"`.
+   - **Note**: Stamping is on by default and sends the attribute's value to the gateway, where it may be recorded in access logs. Prefer an opaque tenant ID over personally identifying values such as email addresses, or set `fairness_header` to `""` to disable stamping.
 2. **`tier-priority`**: Buckets requests into 6 strict priority lanes using routing tags (`(classification, tier)`). Within each bucket, it round-robins across different client channels and stamps the chosen priority header (`x-gateway-priority` by default).
    - **Note**: The `tier-priority` merge policy assumes that all messages within a single queue share the same priority. Message classification relies on the FIFO order of an individual queue, and a message's classification does not change after it is pulled off the queue.
    - **Parameters**:
      - `priority_header` (optional, string): The HTTP header name used to pass the priority value downstream to the inference scheduler. Default is `"x-gateway-priority"`.
      - `tier_label` (optional, string): The label name on `InternalRequest.Labels` used to look up the request's priority tier. Default is `"tier"`.
+     - `fairness_header` / `fairness_attribute` (optional, string): Same as for `random-robin`.
 
 ## Request Body Transforms
 

--- a/api/api.go
+++ b/api/api.go
@@ -19,8 +19,10 @@ type Request interface {
 }
 
 // FairnessIDHeader is the request header llm-d-router's flow control reads to
-// arbitrate fairness between flows. The processor stamps it with the tenant
-// attribute it keys quota on, so tenant isolation extends past dispatch.
+// arbitrate fairness between flows. The processor stamps it with the same tenant
+// attribute it keys quota on, replacing any caller-supplied value, so a tenant is
+// arbitrated under the identity it is accounted under. Messages carrying no such
+// attribute reach the gateway with whatever the caller sent.
 const FairnessIDHeader = "x-llm-d-inference-fairness-id"
 
 // RequestMessage contains the caller-visible fields of a request. Metadata is

--- a/api/api.go
+++ b/api/api.go
@@ -18,9 +18,16 @@ type Request interface {
 	ReqEndpoint() string
 }
 
-// RequestMessage contains the caller-visible fields of a request. Metadata is reserved
-// for opaque, caller-supplied pass-through data (e.g. tracing IDs, user labels).
-// The system does not read or write Metadata for its own routing or correlation.
+// FairnessIDHeader is the request header llm-d-router's flow control reads to
+// arbitrate fairness between flows. The processor stamps it with the tenant
+// attribute it keys quota on, so tenant isolation extends past dispatch.
+const FairnessIDHeader = "x-llm-d-inference-fairness-id"
+
+// RequestMessage contains the caller-visible fields of a request. Metadata is
+// caller-supplied pass-through data (e.g. tracing IDs, user labels). The system
+// never writes Metadata, and reads it only where an opt-in feature is configured
+// to key on a named attribute (the redis-quota gate, request body transforms,
+// and merge-policy fairness stamping); it is otherwise opaque.
 // Request interface accessors use the Req prefix (e.g. ReqPayload) to avoid
 // colliding with the struct's exported field names used for JSON serialization.
 type RequestMessage struct {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.290.0
 	google.golang.org/grpc v1.82.1
@@ -108,7 +109,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20250808145144-a408d31f581a // indirect
 	golang.org/x/mod v0.37.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect

--- a/pkg/async/mergepolicy/internal/fairness/fairness.go
+++ b/pkg/async/mergepolicy/internal/fairness/fairness.go
@@ -5,7 +5,10 @@
 package fairness
 
 import (
+	"fmt"
 	"strings"
+
+	"golang.org/x/net/http/httpguts"
 
 	"github.com/llm-d/llm-d-async/api"
 )
@@ -14,6 +17,13 @@ import (
 // not configure one. It matches the redis-quota gate's default so both sides key
 // on the same tenant.
 const DefaultAttribute = "userid"
+
+// maxIdentityLen bounds the stamped identity. Envoy's default header limit is
+// around 60 KiB, so an oversized attribute would turn every one of a tenant's
+// requests into a 431 at the gateway, and it amplifies gateway access logs. A
+// tenant ID is far shorter than this in practice; anything longer is skipped
+// rather than stamped.
+const maxIdentityLen = 256
 
 // Params are the fairness parameters every merge policy accepts in its plugin
 // configuration. Embed it in a policy's parameter struct; encoding/json promotes
@@ -25,14 +35,22 @@ type Params struct {
 	Attribute string  `json:"fairness_attribute"`
 }
 
-// HeaderOrDefault returns the configured header name, falling back to
+// ResolveHeader returns the configured header name, falling back to
 // api.FairnessIDHeader when the parameter was absent. An explicit "" is returned
 // unchanged, since that disables stamping.
-func (p Params) HeaderOrDefault() string {
+//
+// It errors when the configured name is not a legal HTTP header name. net/http
+// refuses to write such a header, which would fail every dispatched request
+// permanently as a non-retryable error, so an operator's typo has to surface at
+// startup rather than at dispatch.
+func (p Params) ResolveHeader() (string, error) {
 	if p.Header == nil {
-		return api.FairnessIDHeader
+		return api.FairnessIDHeader, nil
 	}
-	return *p.Header
+	if *p.Header != "" && !httpguts.ValidHeaderFieldName(*p.Header) {
+		return "", fmt.Errorf("fairness_header %q is not a legal HTTP header name", *p.Header)
+	}
+	return *p.Header, nil
 }
 
 // Stamper writes a tenant identity into an HTTP header. The zero Stamper is
@@ -52,40 +70,36 @@ func New(header string, attribute string) Stamper {
 	return Stamper{header: header, attribute: attribute}
 }
 
-// Stamp writes the tenant identity from req's metadata into headers. It is a
-// no-op when stamping is disabled, when req already carries the header, when the
-// attribute is absent or empty, or when the identity is not a legal HTTP header
-// value.
+// Stamp writes the tenant identity from req's metadata into headers, replacing
+// any value already there. Call it after the caller's own headers have been
+// merged in: the identity the quota gate accounts on must be the one the gateway
+// arbitrates on, or a tenant could be charged as one flow while presenting as
+// another.
+//
+// It is a no-op when stamping is disabled, when the attribute is absent or
+// empty, or when the identity is too long or not a legal HTTP header value. In
+// those cases there is no identity to assert, so a caller-supplied header is
+// left as it was rather than dropped for nothing.
 func (s Stamper) Stamp(headers map[string]string, req api.Request) {
 	if s.header == "" {
 		return
 	}
-	// HTTP header names are case-insensitive and net/http canonicalizes them on
-	// write, so a caller-set header under any casing takes precedence: stamping
-	// anyway would leave two map keys collapsing onto one wire header with
-	// nondeterministic precedence.
-	for k := range req.ReqHeaders() {
-		if strings.EqualFold(k, s.header) {
-			return
-		}
-	}
+	// Metadata is caller-supplied and has never reached the wire before now.
+	// net/http fails the entire request on a header value it cannot write, and a
+	// best-effort fairness hint must not cost a request, so an identity that
+	// cannot be stamped is skipped instead.
 	id := req.ReqMetadata()[s.attribute]
-	if id == "" || !validHeaderValue(id) {
+	if id == "" || len(id) > maxIdentityLen || !httpguts.ValidHeaderFieldValue(id) {
 		return
 	}
-	headers[s.header] = id
-}
-
-// validHeaderValue reports whether v can be written as an HTTP header value,
-// mirroring what net/http enforces at write time. Metadata is caller-supplied,
-// and net/http fails the entire request on a value it cannot write; a
-// best-effort fairness hint must not cost the request, so an invalid identity
-// skips the stamp instead.
-func validHeaderValue(v string) bool {
-	for i := range len(v) {
-		if b := v[i]; (b < 0x20 && b != '\t') || b == 0x7f {
-			return false
+	// HTTP header names are case-insensitive and net/http canonicalizes them on
+	// write, so leaving a caller's case variant in place alongside the stamp
+	// would collapse two map keys onto one wire header with nondeterministic
+	// precedence. Drop every variant first.
+	for k := range headers {
+		if strings.EqualFold(k, s.header) {
+			delete(headers, k)
 		}
 	}
-	return true
+	headers[s.header] = id
 }

--- a/pkg/async/mergepolicy/internal/fairness/fairness.go
+++ b/pkg/async/mergepolicy/internal/fairness/fairness.go
@@ -1,0 +1,91 @@
+// Package fairness stamps a tenant identity carried in request metadata into an
+// HTTP header, so the gateway's flow control can arbitrate between tenants after
+// dispatch. Both merge policies share it; stamping is best effort and never
+// fails a request.
+package fairness
+
+import (
+	"strings"
+
+	"github.com/llm-d/llm-d-async/api"
+)
+
+// DefaultAttribute is the message metadata attribute stamped when a policy does
+// not configure one. It matches the redis-quota gate's default so both sides key
+// on the same tenant.
+const DefaultAttribute = "userid"
+
+// Params are the fairness parameters every merge policy accepts in its plugin
+// configuration. Embed it in a policy's parameter struct; encoding/json promotes
+// the embedded fields.
+type Params struct {
+	// Header is a pointer so an absent parameter (use the default header) is
+	// distinguishable from an explicit "" (stamping disabled).
+	Header    *string `json:"fairness_header"`
+	Attribute string  `json:"fairness_attribute"`
+}
+
+// HeaderOrDefault returns the configured header name, falling back to
+// api.FairnessIDHeader when the parameter was absent. An explicit "" is returned
+// unchanged, since that disables stamping.
+func (p Params) HeaderOrDefault() string {
+	if p.Header == nil {
+		return api.FairnessIDHeader
+	}
+	return *p.Header
+}
+
+// Stamper writes a tenant identity into an HTTP header. The zero Stamper is
+// disabled and stamps nothing.
+type Stamper struct {
+	header    string
+	attribute string
+}
+
+// New returns a Stamper that writes the tenant identity found under the given
+// message metadata attribute into the given header. An empty header disables
+// stamping; an empty attribute falls back to DefaultAttribute.
+func New(header string, attribute string) Stamper {
+	if attribute == "" {
+		attribute = DefaultAttribute
+	}
+	return Stamper{header: header, attribute: attribute}
+}
+
+// Stamp writes the tenant identity from req's metadata into headers. It is a
+// no-op when stamping is disabled, when req already carries the header, when the
+// attribute is absent or empty, or when the identity is not a legal HTTP header
+// value.
+func (s Stamper) Stamp(headers map[string]string, req api.Request) {
+	if s.header == "" {
+		return
+	}
+	// HTTP header names are case-insensitive and net/http canonicalizes them on
+	// write, so a caller-set header under any casing takes precedence: stamping
+	// anyway would leave two map keys collapsing onto one wire header with
+	// nondeterministic precedence.
+	for k := range req.ReqHeaders() {
+		if strings.EqualFold(k, s.header) {
+			return
+		}
+	}
+	id := req.ReqMetadata()[s.attribute]
+	if id == "" || !validHeaderValue(id) {
+		return
+	}
+	headers[s.header] = id
+}
+
+// validHeaderValue reports whether v can be written as an HTTP header value,
+// mirroring what net/http enforces at write time. Metadata is caller-supplied,
+// and net/http fails the entire request on a value it cannot write; a
+// best-effort fairness hint must not cost the request, so an invalid identity
+// skips the stamp instead.
+func validHeaderValue(v string) bool {
+	for i := range len(v) {
+		if b := v[i]; (b < 0x20 && b != '\t') || b == 0x7f {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/async/mergepolicy/internal/fairness/fairness_test.go
+++ b/pkg/async/mergepolicy/internal/fairness/fairness_test.go
@@ -1,6 +1,7 @@
 package fairness
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/llm-d/llm-d-async/api"
@@ -12,8 +13,10 @@ func TestStamp(t *testing.T) {
 		header    string
 		attribute string
 		metadata  map[string]string
-		reqHeader map[string]string
-		want      map[string]string
+		// headers is the header map as it reaches Stamp, after the caller's own
+		// headers have already been merged in.
+		headers map[string]string
+		want    map[string]string
 	}{
 		{
 			name:      "stamps the identity under the configured header",
@@ -41,7 +44,8 @@ func TestStamp(t *testing.T) {
 			header:    "",
 			attribute: "userid",
 			metadata:  map[string]string{"userid": "tenant-a"},
-			want:      map[string]string{},
+			headers:   map[string]string{api.FairnessIDHeader: "caller-set"},
+			want:      map[string]string{api.FairnessIDHeader: "caller-set"},
 		},
 		{
 			name:      "attribute absent from metadata",
@@ -58,38 +62,63 @@ func TestStamp(t *testing.T) {
 			want:      map[string]string{},
 		},
 		{
-			name:      "caller-set header takes precedence",
+			// The quota gate accounts on the metadata attribute, so the gateway
+			// has to arbitrate on that same identity; a caller cannot present a
+			// different one.
+			name:      "identity replaces a caller-supplied header",
 			header:    api.FairnessIDHeader,
 			attribute: "userid",
 			metadata:  map[string]string{"userid": "tenant-a"},
-			reqHeader: map[string]string{api.FairnessIDHeader: "caller-set"},
-			want:      map[string]string{},
+			headers:   map[string]string{api.FairnessIDHeader: "caller-set"},
+			want:      map[string]string{api.FairnessIDHeader: "tenant-a"},
 		},
 		{
-			// Stamping the canonical key alongside a caller's case variant would
-			// leave two map keys collapsing onto one wire header.
-			name:      "caller-set header takes precedence under any casing",
+			// Both keys would collapse onto one wire header, so the caller's
+			// variant is dropped rather than left beside the stamp. A want of
+			// exactly one entry is what pins the delete.
+			name:      "caller case variant is replaced, not duplicated",
 			header:    api.FairnessIDHeader,
 			attribute: "userid",
 			metadata:  map[string]string{"userid": "tenant-a"},
-			reqHeader: map[string]string{"X-LLM-D-Inference-Fairness-ID": "caller-set"},
-			want:      map[string]string{},
+			headers:   map[string]string{"X-LLM-D-Inference-Fairness-ID": "caller-set"},
+			want:      map[string]string{api.FairnessIDHeader: "tenant-a"},
 		},
 		{
 			// net/http rejects control characters at write time, which would fail
-			// the whole request rather than just lose the fairness hint.
+			// the whole request rather than just lose the fairness hint. With no
+			// identity to assert, the caller's header is left as it was.
 			name:      "identity that is not a legal header value is skipped",
 			header:    api.FairnessIDHeader,
 			attribute: "userid",
 			metadata:  map[string]string{"userid": "tenant-a\r\nX-Injected: 1"},
+			headers:   map[string]string{api.FairnessIDHeader: "caller-set"},
+			want:      map[string]string{api.FairnessIDHeader: "caller-set"},
+		},
+		{
+			// An oversized header is a 431 at the gateway, so skip rather than
+			// stamp it.
+			name:      "identity longer than the cap is skipped",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": strings.Repeat("a", maxIdentityLen+1)},
 			want:      map[string]string{},
+		},
+		{
+			name:      "identity at exactly the cap is stamped",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": strings.Repeat("a", maxIdentityLen)},
+			want:      map[string]string{api.FairnessIDHeader: strings.Repeat("a", maxIdentityLen)},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			headers := map[string]string{}
-			req := &api.RequestMessage{Metadata: tt.metadata, Headers: tt.reqHeader}
+			for k, v := range tt.headers {
+				headers[k] = v
+			}
+			req := &api.RequestMessage{Metadata: tt.metadata}
 
 			New(tt.header, tt.attribute).Stamp(headers, req)
 
@@ -116,24 +145,39 @@ func TestZeroStamperIsDisabled(t *testing.T) {
 	}
 }
 
-func TestParamsHeaderOrDefault(t *testing.T) {
-	empty := ""
-	custom := "x-custom-fairness"
+func TestParamsResolveHeader(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
 
 	tests := []struct {
-		name   string
-		params Params
-		want   string
+		name    string
+		params  Params
+		want    string
+		wantErr bool
 	}{
 		{name: "absent parameter uses the default header", params: Params{}, want: api.FairnessIDHeader},
-		{name: "explicit empty disables stamping", params: Params{Header: &empty}, want: ""},
-		{name: "explicit header is used verbatim", params: Params{Header: &custom}, want: custom},
+		{name: "explicit empty disables stamping", params: Params{Header: strPtr("")}, want: ""},
+		{name: "explicit header is used verbatim", params: Params{Header: strPtr("x-custom-fairness")}, want: "x-custom-fairness"},
+		// net/http refuses to write these, which would fail every dispatched
+		// request permanently, so the factory has to reject them at startup.
+		{name: "header name with a space is rejected", params: Params{Header: strPtr("x-fair id")}, wantErr: true},
+		{name: "header name with a colon is rejected", params: Params{Header: strPtr("x-fair:id")}, wantErr: true},
+		{name: "header name with a newline is rejected", params: Params{Header: strPtr("x-fair\nid")}, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.params.HeaderOrDefault(); got != tt.want {
-				t.Errorf("HeaderOrDefault() = %q, want %q", got, tt.want)
+			got, err := tt.params.ResolveHeader()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveHeader() = %q, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveHeader() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveHeader() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/async/mergepolicy/internal/fairness/fairness_test.go
+++ b/pkg/async/mergepolicy/internal/fairness/fairness_test.go
@@ -1,0 +1,140 @@
+package fairness
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-async/api"
+)
+
+func TestStamp(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		attribute string
+		metadata  map[string]string
+		reqHeader map[string]string
+		want      map[string]string
+	}{
+		{
+			name:      "stamps the identity under the configured header",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": "tenant-a"},
+			want:      map[string]string{api.FairnessIDHeader: "tenant-a"},
+		},
+		{
+			name:      "reads the configured attribute, not the default",
+			header:    "x-custom-fairness",
+			attribute: "team",
+			metadata:  map[string]string{"team": "team-b", "userid": "ignored"},
+			want:      map[string]string{"x-custom-fairness": "team-b"},
+		},
+		{
+			name:      "empty attribute falls back to the default",
+			header:    api.FairnessIDHeader,
+			attribute: "",
+			metadata:  map[string]string{DefaultAttribute: "tenant-a"},
+			want:      map[string]string{api.FairnessIDHeader: "tenant-a"},
+		},
+		{
+			name:      "empty header disables stamping",
+			header:    "",
+			attribute: "userid",
+			metadata:  map[string]string{"userid": "tenant-a"},
+			want:      map[string]string{},
+		},
+		{
+			name:      "attribute absent from metadata",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"other": "x"},
+			want:      map[string]string{},
+		},
+		{
+			name:      "attribute present but empty",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": ""},
+			want:      map[string]string{},
+		},
+		{
+			name:      "caller-set header takes precedence",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": "tenant-a"},
+			reqHeader: map[string]string{api.FairnessIDHeader: "caller-set"},
+			want:      map[string]string{},
+		},
+		{
+			// Stamping the canonical key alongside a caller's case variant would
+			// leave two map keys collapsing onto one wire header.
+			name:      "caller-set header takes precedence under any casing",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": "tenant-a"},
+			reqHeader: map[string]string{"X-LLM-D-Inference-Fairness-ID": "caller-set"},
+			want:      map[string]string{},
+		},
+		{
+			// net/http rejects control characters at write time, which would fail
+			// the whole request rather than just lose the fairness hint.
+			name:      "identity that is not a legal header value is skipped",
+			header:    api.FairnessIDHeader,
+			attribute: "userid",
+			metadata:  map[string]string{"userid": "tenant-a\r\nX-Injected: 1"},
+			want:      map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := map[string]string{}
+			req := &api.RequestMessage{Metadata: tt.metadata, Headers: tt.reqHeader}
+
+			New(tt.header, tt.attribute).Stamp(headers, req)
+
+			if len(headers) != len(tt.want) {
+				t.Fatalf("headers = %v, want %v", headers, tt.want)
+			}
+			for k, want := range tt.want {
+				if got := headers[k]; got != want {
+					t.Errorf("headers[%q] = %q, want %q", k, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestZeroStamperIsDisabled(t *testing.T) {
+	headers := map[string]string{}
+	req := &api.RequestMessage{Metadata: map[string]string{DefaultAttribute: "tenant-a"}}
+
+	Stamper{}.Stamp(headers, req)
+
+	if len(headers) != 0 {
+		t.Errorf("zero Stamper wrote %v, want nothing", headers)
+	}
+}
+
+func TestParamsHeaderOrDefault(t *testing.T) {
+	empty := ""
+	custom := "x-custom-fairness"
+
+	tests := []struct {
+		name   string
+		params Params
+		want   string
+	}{
+		{name: "absent parameter uses the default header", params: Params{}, want: api.FairnessIDHeader},
+		{name: "explicit empty disables stamping", params: Params{Header: &empty}, want: ""},
+		{name: "explicit header is used verbatim", params: Params{Header: &custom}, want: custom},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.params.HeaderOrDefault(); got != tt.want {
+				t.Errorf("HeaderOrDefault() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/async/mergepolicy/randomrobin/fairness_header_test.go
+++ b/pkg/async/mergepolicy/randomrobin/fairness_header_test.go
@@ -1,0 +1,79 @@
+package randomrobin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/llm-d/llm-d-async/api"
+	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/plugins"
+)
+
+// Stamping behavior itself is covered by the shared fairness package. These
+// tests only pin that the policy wires the stamper into its dispatch path and
+// resolves its parameters.
+
+func mergeOne(t *testing.T, policy *RandomRobinPolicy) pipeline.EmbelishedRequestMessage {
+	t.Helper()
+	ch := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 1),
+		WorkerPoolID: "pool-f",
+		IGWBaseURL:   "http://gw",
+	}
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-f": {ID: "pool-f", Workers: 1},
+	}
+	ch.Channel <- api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{
+		ID:       "m1",
+		Created:  1,
+		Deadline: 9999999999,
+		Metadata: map[string]string{"userid": "tenant-a"},
+	})
+	close(ch.Channel)
+
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
+	select {
+	case msg := <-dispatch.Channels["pool-f"]:
+		return msg
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for merged message")
+		return pipeline.EmbelishedRequestMessage{}
+	}
+}
+
+func TestFairnessHeaderStamped(t *testing.T) {
+	policy := NewRandomRobinPolicy("test", Config{FairnessHeader: api.FairnessIDHeader})
+
+	msg := mergeOne(t, policy)
+	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
+		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+}
+
+func TestFairnessHeaderDefaultsAndDisableViaConfig(t *testing.T) {
+	factory, ok := plugins.Lookup("random-robin")
+	if !ok {
+		t.Fatal("random-robin plugin not registered")
+	}
+
+	// Absent parameters stamp the default header from the default attribute.
+	plugin, err := factory("test", nil, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	msg := mergeOne(t, plugin.(*RandomRobinPolicy))
+	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
+		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+
+	// An explicit empty header disables stamping.
+	plugin, err = factory("test", json.RawMessage(`{"fairness_header": ""}`), nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	msg = mergeOne(t, plugin.(*RandomRobinPolicy))
+	if _, stamped := msg.HttpHeaders[api.FairnessIDHeader]; stamped {
+		t.Error("fairness header should be absent when disabled")
+	}
+}

--- a/pkg/async/mergepolicy/randomrobin/fairness_header_test.go
+++ b/pkg/async/mergepolicy/randomrobin/fairness_header_test.go
@@ -2,6 +2,7 @@ package randomrobin
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 // tests only pin that the policy wires the stamper into its dispatch path and
 // resolves its parameters.
 
-func mergeOne(t *testing.T, policy *RandomRobinPolicy) pipeline.EmbelishedRequestMessage {
+func mergeOne(t *testing.T, policy *RandomRobinPolicy, callerHeaders map[string]string) pipeline.EmbelishedRequestMessage {
 	t.Helper()
 	ch := pipeline.RequestChannel{
 		Channel:      make(chan *api.InternalRequest, 1),
@@ -29,6 +30,7 @@ func mergeOne(t *testing.T, policy *RandomRobinPolicy) pipeline.EmbelishedReques
 		Created:  1,
 		Deadline: 9999999999,
 		Metadata: map[string]string{"userid": "tenant-a"},
+		Headers:  callerHeaders,
 	})
 	close(ch.Channel)
 
@@ -45,9 +47,38 @@ func mergeOne(t *testing.T, policy *RandomRobinPolicy) pipeline.EmbelishedReques
 func TestFairnessHeaderStamped(t *testing.T) {
 	policy := NewRandomRobinPolicy("test", Config{FairnessHeader: api.FairnessIDHeader})
 
-	msg := mergeOne(t, policy)
+	msg := mergeOne(t, policy, nil)
 	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
 		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+}
+
+// The stamp has to land after the caller's headers are merged in, or a caller
+// could present a fairness ID that differs from the one quota accounts on. Only
+// a dispatch-path test pins that ordering.
+func TestFairnessHeaderOverridesCallerSuppliedValue(t *testing.T) {
+	policy := NewRandomRobinPolicy("test", Config{FairnessHeader: api.FairnessIDHeader})
+
+	msg := mergeOne(t, policy, map[string]string{"X-LLM-D-Inference-Fairness-ID": "spoofed"})
+
+	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
+		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+	for k := range msg.HttpHeaders {
+		if k != api.FairnessIDHeader && strings.EqualFold(k, api.FairnessIDHeader) {
+			t.Errorf("caller case variant %q survived alongside the stamp", k)
+		}
+	}
+}
+
+func TestFairnessHeaderInvalidNameRejectedAtStartup(t *testing.T) {
+	factory, ok := plugins.Lookup("random-robin")
+	if !ok {
+		t.Fatal("random-robin plugin not registered")
+	}
+
+	if _, err := factory("test", json.RawMessage(`{"fairness_header": "x-fair id"}`), nil); err == nil {
+		t.Error("expected an error for an illegal fairness_header name, got nil")
 	}
 }
 
@@ -62,7 +93,7 @@ func TestFairnessHeaderDefaultsAndDisableViaConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("factory error: %v", err)
 	}
-	msg := mergeOne(t, plugin.(*RandomRobinPolicy))
+	msg := mergeOne(t, plugin.(*RandomRobinPolicy), nil)
 	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
 		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
 	}
@@ -72,7 +103,7 @@ func TestFairnessHeaderDefaultsAndDisableViaConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("factory error: %v", err)
 	}
-	msg = mergeOne(t, plugin.(*RandomRobinPolicy))
+	msg = mergeOne(t, plugin.(*RandomRobinPolicy), nil)
 	if _, stamped := msg.HttpHeaders[api.FairnessIDHeader]; stamped {
 		t.Error("fairness header should be absent when disabled")
 	}

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
@@ -21,8 +21,12 @@ func init() {
 				return nil, fmt.Errorf("failed to parse random-robin parameters: %w", err)
 			}
 		}
+		fairnessHeader, err := params.ResolveHeader()
+		if err != nil {
+			return nil, fmt.Errorf("invalid random-robin parameters: %w", err)
+		}
 		return NewRandomRobinPolicy(name, Config{
-			FairnessHeader:    params.HeaderOrDefault(),
+			FairnessHeader:    fairnessHeader,
 			FairnessAttribute: params.Attribute,
 		}), nil
 	})
@@ -126,12 +130,12 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 					if chMeta.InferenceObjective != "" {
 						headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
 					}
-					// Stamped before the caller's headers are merged in so that a
-					// caller-supplied fairness header wins.
-					r.fairness.Stamp(headers, ir.PublicRequest)
 					for k, v := range ir.PublicRequest.ReqHeaders() {
 						headers[k] = v
 					}
+					// Stamped after the caller's headers so the tenant the quota
+					// gate accounts on is the one the gateway arbitrates on.
+					r.fairness.Stamp(headers, ir.PublicRequest)
 					erm := pipeline.EmbelishedRequestMessage{
 						InternalRequest: ir,
 						HttpHeaders:     headers,

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
@@ -8,25 +8,53 @@ import (
 
 	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/async/mergepolicy/internal/fairness"
 	"github.com/llm-d/llm-d-async/pkg/metrics"
 	"github.com/llm-d/llm-d-async/pkg/plugins"
 )
 
 func init() {
 	plugins.MustRegister("random-robin", func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
-		return NewRandomRobinPolicy(name), nil
+		var params fairness.Params
+		if len(parameters) > 0 {
+			if err := json.Unmarshal(parameters, &params); err != nil {
+				return nil, fmt.Errorf("failed to parse random-robin parameters: %w", err)
+			}
+		}
+		return NewRandomRobinPolicy(name, Config{
+			FairnessHeader:    params.HeaderOrDefault(),
+			FairnessAttribute: params.Attribute,
+		}), nil
 	})
 }
 
-func NewRandomRobinPolicy(name string) *RandomRobinPolicy {
-	return &RandomRobinPolicy{name: name}
+// Config configures the random-robin merge policy. The zero Config disables
+// fairness stamping.
+type Config struct {
+	// FairnessHeader is the HTTP header stamped with the tenant identity so the
+	// gateway's flow control can arbitrate between tenants. Empty disables
+	// stamping.
+	FairnessHeader string
+	// FairnessAttribute is the message metadata attribute holding the tenant
+	// identity. Empty falls back to fairness.DefaultAttribute.
+	FairnessAttribute string
+}
+
+// NewRandomRobinPolicy returns a merge policy that randomly picks messages from
+// all of a pool's queues.
+func NewRandomRobinPolicy(name string, cfg Config) *RandomRobinPolicy {
+	return &RandomRobinPolicy{
+		name:     name,
+		fairness: fairness.New(cfg.FairnessHeader, cfg.FairnessAttribute),
+	}
 }
 
 var _ pipeline.RequestMergePolicy = (*RandomRobinPolicy)(nil)
 var _ plugins.Plugin = (*RandomRobinPolicy)(nil)
 
 type RandomRobinPolicy struct {
-	name string
+	name     string
+	fairness fairness.Stamper
 }
 
 func (r *RandomRobinPolicy) TypedName() plugins.TypedName {
@@ -98,6 +126,9 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 					if chMeta.InferenceObjective != "" {
 						headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
 					}
+					// Stamped before the caller's headers are merged in so that a
+					// caller-supplied fairness header wins.
+					r.fairness.Stamp(headers, ir.PublicRequest)
 					for k, v := range ir.PublicRequest.ReqHeaders() {
 						headers[k] = v
 					}

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
@@ -33,7 +33,7 @@ func TestProcessAllChannels(t *testing.T) {
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURL: "http://gw", RequestPathURL: "/v1"},
 		{Channel: make(chan *api.InternalRequest, msgsPerChannel), IGWBaseURL: "http://gw", RequestPathURL: "/v1"},
 	}
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 
 	// Send messages to each channel
 	for i, ch := range channels {
@@ -70,7 +70,7 @@ func TestProcessAllChannels(t *testing.T) {
 }
 
 func TestEmptyChannelsReturnsClosed(t *testing.T) {
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 	merged := policy.MergeRequestChannels(nil, nil)
 	if len(merged.Channels) != 0 {
 		t.Fatalf("expected 0 channels in dispatch, got %d", len(merged.Channels))
@@ -87,7 +87,7 @@ func TestMetaAlignmentAfterChannelClosure(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-a": {ID: "pool-a", Workers: 1},
 	}
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 	merged := policy.MergeRequestChannels(channels, pools)
 	mergedChannel := merged.Channels["pool-a"]
 
@@ -166,7 +166,7 @@ func TestPerMessageEndpointOverridesChannelURL(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"my-pool": {ID: "my-pool", Workers: 1},
 	}
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 
 	// One message with endpoint, one without.
 	ch.Channel <- irWithEndpoint("with-ep", "/v1/custom")
@@ -230,7 +230,7 @@ func TestURLJoinPathHandlesSlashes(t *testing.T) {
 			}
 			close(ch.Channel)
 
-			policy := NewRandomRobinPolicy("test")
+			policy := NewRandomRobinPolicy("test", Config{})
 			merged := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
 			mergedChannel := merged.Channels["test-pool"]
 
@@ -266,7 +266,7 @@ func TestPerRequestHeadersMerged(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"test-pool": {ID: "test-pool", Workers: 1},
 	}
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 
 	ch.Channel <- irWithHeaders("custom", map[string]string{
 		"Authorization": "Bearer tok",
@@ -318,7 +318,7 @@ func TestMergedChannelIsBuffered(t *testing.T) {
 	for i := range numChannels {
 		channels[i] = pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1), IGWBaseURL: "http://gw", RequestPathURL: "/v1"}
 	}
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"default": {ID: "default", Workers: 1},
 	}
@@ -350,7 +350,7 @@ func TestMergeRequestChannels_PanicOnMissingPool(t *testing.T) {
 	channels := []pipeline.RequestChannel{
 		{WorkerPoolID: "non-existent-pool"},
 	}
-	policy := NewRandomRobinPolicy("test")
+	policy := NewRandomRobinPolicy("test", Config{})
 
 	defer func() {
 		if r := recover(); r == nil {

--- a/pkg/async/mergepolicy/tierpriority/fairness_header_test.go
+++ b/pkg/async/mergepolicy/tierpriority/fairness_header_test.go
@@ -1,0 +1,83 @@
+package tierpriority
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/llm-d/llm-d-async/api"
+	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/plugins"
+)
+
+// Stamping behavior itself is covered by the shared fairness package. These
+// tests only pin that the policy wires the stamper into its dispatch path and
+// resolves its parameters.
+
+func mergeOne(t *testing.T, policy *TierPriorityPolicy) pipeline.EmbelishedRequestMessage {
+	t.Helper()
+	ch := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 1),
+		WorkerPoolID: "pool-f",
+		IGWBaseURL:   "http://gw",
+	}
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-f": {ID: "pool-f", Workers: 1},
+	}
+	ch.Channel <- api.NewInternalRequest(api.InternalRouting{}, &api.RequestMessage{
+		ID:       "m1",
+		Created:  1,
+		Deadline: 9999999999,
+		Metadata: map[string]string{"userid": "tenant-a"},
+	})
+	close(ch.Channel)
+
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
+	select {
+	case msg := <-dispatch.Channels["pool-f"]:
+		return msg
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for merged message")
+		return pipeline.EmbelishedRequestMessage{}
+	}
+}
+
+func TestFairnessHeaderStamped(t *testing.T) {
+	policy := NewTierPriorityPolicy("test-policy", Config{
+		PriorityHeader: "x-gateway-priority",
+		TierLabel:      "tier",
+		FairnessHeader: api.FairnessIDHeader,
+	})
+
+	msg := mergeOne(t, policy)
+	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
+		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+}
+
+func TestFairnessHeaderDefaultsAndDisableViaConfig(t *testing.T) {
+	factory, ok := plugins.Lookup("tier-priority")
+	if !ok {
+		t.Fatal("tier-priority plugin not registered")
+	}
+
+	// Absent parameters stamp the default header from the default attribute.
+	plugin, err := factory("test", nil, nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	msg := mergeOne(t, plugin.(*TierPriorityPolicy))
+	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
+		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+
+	// An explicit empty header disables stamping.
+	plugin, err = factory("test", json.RawMessage(`{"fairness_header": ""}`), nil)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	msg = mergeOne(t, plugin.(*TierPriorityPolicy))
+	if _, stamped := msg.HttpHeaders[api.FairnessIDHeader]; stamped {
+		t.Error("fairness header should be absent when disabled")
+	}
+}

--- a/pkg/async/mergepolicy/tierpriority/fairness_header_test.go
+++ b/pkg/async/mergepolicy/tierpriority/fairness_header_test.go
@@ -2,6 +2,7 @@ package tierpriority
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 // tests only pin that the policy wires the stamper into its dispatch path and
 // resolves its parameters.
 
-func mergeOne(t *testing.T, policy *TierPriorityPolicy) pipeline.EmbelishedRequestMessage {
+func mergeOne(t *testing.T, policy *TierPriorityPolicy, callerHeaders map[string]string) pipeline.EmbelishedRequestMessage {
 	t.Helper()
 	ch := pipeline.RequestChannel{
 		Channel:      make(chan *api.InternalRequest, 1),
@@ -29,6 +30,7 @@ func mergeOne(t *testing.T, policy *TierPriorityPolicy) pipeline.EmbelishedReque
 		Created:  1,
 		Deadline: 9999999999,
 		Metadata: map[string]string{"userid": "tenant-a"},
+		Headers:  callerHeaders,
 	})
 	close(ch.Channel)
 
@@ -49,7 +51,7 @@ func TestFairnessHeaderStamped(t *testing.T) {
 		FairnessHeader: api.FairnessIDHeader,
 	})
 
-	msg := mergeOne(t, policy)
+	msg := mergeOne(t, policy, nil)
 	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
 		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
 	}
@@ -66,7 +68,7 @@ func TestFairnessHeaderDefaultsAndDisableViaConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("factory error: %v", err)
 	}
-	msg := mergeOne(t, plugin.(*TierPriorityPolicy))
+	msg := mergeOne(t, plugin.(*TierPriorityPolicy), nil)
 	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
 		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
 	}
@@ -76,8 +78,55 @@ func TestFairnessHeaderDefaultsAndDisableViaConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("factory error: %v", err)
 	}
-	msg = mergeOne(t, plugin.(*TierPriorityPolicy))
+	msg = mergeOne(t, plugin.(*TierPriorityPolicy), nil)
 	if _, stamped := msg.HttpHeaders[api.FairnessIDHeader]; stamped {
 		t.Error("fairness header should be absent when disabled")
+	}
+}
+
+// The stamp has to land after the caller's headers are merged in, or a caller
+// could present a fairness ID that differs from the one quota accounts on. Only
+// a dispatch-path test pins that ordering.
+func TestFairnessHeaderOverridesCallerSuppliedValue(t *testing.T) {
+	policy := NewTierPriorityPolicy("test-policy", Config{
+		PriorityHeader: "x-gateway-priority",
+		TierLabel:      "tier",
+		FairnessHeader: api.FairnessIDHeader,
+	})
+
+	msg := mergeOne(t, policy, map[string]string{"X-LLM-D-Inference-Fairness-ID": "spoofed"})
+
+	if got := msg.HttpHeaders[api.FairnessIDHeader]; got != "tenant-a" {
+		t.Errorf("fairness header = %q, want %q", got, "tenant-a")
+	}
+	for k := range msg.HttpHeaders {
+		if k != api.FairnessIDHeader && strings.EqualFold(k, api.FairnessIDHeader) {
+			t.Errorf("caller case variant %q survived alongside the stamp", k)
+		}
+	}
+}
+
+// An illegal header name is one net/http refuses to write, which would fail
+// every dispatched request permanently rather than just losing the header.
+func TestIllegalHeaderNamesRejectedAtStartup(t *testing.T) {
+	factory, ok := plugins.Lookup("tier-priority")
+	if !ok {
+		t.Fatal("tier-priority plugin not registered")
+	}
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{name: "fairness_header", params: `{"fairness_header": "x-fair id"}`},
+		{name: "priority_header", params: `{"priority_header": "x-pri id"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := factory("test", json.RawMessage(tt.params), nil); err == nil {
+				t.Errorf("expected an error for an illegal %s name, got nil", tt.name)
+			}
+		})
 	}
 }

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"sync"
 
+	"golang.org/x/net/http/httpguts"
+
 	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
 	"github.com/llm-d/llm-d-async/pkg/async/mergepolicy/internal/fairness"
@@ -29,10 +31,19 @@ func init() {
 		if params.PriorityHeader == "" {
 			params.PriorityHeader = "x-gateway-priority"
 		}
+		// An illegal header name is one net/http refuses to write, which would
+		// fail every dispatched request permanently; surface it at startup.
+		if !httpguts.ValidHeaderFieldName(params.PriorityHeader) {
+			return nil, fmt.Errorf("invalid tier-priority parameters: priority_header %q is not a legal HTTP header name", params.PriorityHeader)
+		}
+		fairnessHeader, err := params.ResolveHeader()
+		if err != nil {
+			return nil, fmt.Errorf("invalid tier-priority parameters: %w", err)
+		}
 		return NewTierPriorityPolicy(name, Config{
 			PriorityHeader:    params.PriorityHeader,
 			TierLabel:         params.TierLabel,
-			FairnessHeader:    params.HeaderOrDefault(),
+			FairnessHeader:    fairnessHeader,
 			FairnessAttribute: params.Attribute,
 		}), nil
 	})
@@ -312,12 +323,12 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 				if chMeta.InferenceObjective != "" {
 					headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
 				}
-				// Stamped before the caller's headers are merged in so that a
-				// caller-supplied fairness header wins.
-				fairnessStamper.Stamp(headers, ir.PublicRequest)
 				for k, v := range ir.PublicRequest.ReqHeaders() {
 					headers[k] = v
 				}
+				// Stamped after the caller's headers so the tenant the quota
+				// gate accounts on is the one the gateway arbitrates on.
+				fairnessStamper.Stamp(headers, ir.PublicRequest)
 
 				pri := getPriorityIndex(ir, tierLabel)
 				if priorityHeader != "" {

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/async/mergepolicy/internal/fairness"
 	"github.com/llm-d/llm-d-async/pkg/metrics"
 	"github.com/llm-d/llm-d-async/pkg/plugins"
 )
@@ -18,6 +19,7 @@ func init() {
 		var params struct {
 			PriorityHeader string `json:"priority_header"`
 			TierLabel      string `json:"tier_label"`
+			fairness.Params
 		}
 		if len(parameters) > 0 {
 			if err := json.Unmarshal(parameters, &params); err != nil {
@@ -27,21 +29,45 @@ func init() {
 		if params.PriorityHeader == "" {
 			params.PriorityHeader = "x-gateway-priority"
 		}
-		if params.TierLabel == "" {
-			params.TierLabel = "tier"
-		}
-		return NewTierPriorityPolicy(name, params.PriorityHeader, params.TierLabel), nil
+		return NewTierPriorityPolicy(name, Config{
+			PriorityHeader:    params.PriorityHeader,
+			TierLabel:         params.TierLabel,
+			FairnessHeader:    params.HeaderOrDefault(),
+			FairnessAttribute: params.Attribute,
+		}), nil
 	})
 }
 
-func NewTierPriorityPolicy(name string, priorityHeader string, tierLabel string) *TierPriorityPolicy {
+// Config configures the tier-priority merge policy. The zero Config disables
+// both the priority header and fairness stamping.
+type Config struct {
+	// PriorityHeader is the HTTP header stamped with the computed priority
+	// index. Empty disables the priority header.
+	PriorityHeader string
+	// TierLabel is the InternalRequest label holding the request's priority
+	// tier. Empty falls back to "tier".
+	TierLabel string
+	// FairnessHeader is the HTTP header stamped with the tenant identity so the
+	// gateway's flow control can arbitrate between tenants. Empty disables
+	// stamping.
+	FairnessHeader string
+	// FairnessAttribute is the message metadata attribute holding the tenant
+	// identity. Empty falls back to fairness.DefaultAttribute.
+	FairnessAttribute string
+}
+
+// NewTierPriorityPolicy returns a merge policy that buckets requests into strict
+// priority lanes and round-robins across client channels within each lane.
+func NewTierPriorityPolicy(name string, cfg Config) *TierPriorityPolicy {
+	tierLabel := cfg.TierLabel
 	if tierLabel == "" {
 		tierLabel = "tier"
 	}
 	return &TierPriorityPolicy{
 		name:           name,
-		priorityHeader: priorityHeader,
+		priorityHeader: cfg.PriorityHeader,
 		tierLabel:      tierLabel,
+		fairness:       fairness.New(cfg.FairnessHeader, cfg.FairnessAttribute),
 	}
 }
 
@@ -52,6 +78,7 @@ type TierPriorityPolicy struct {
 	name           string
 	priorityHeader string
 	tierLabel      string
+	fairness       fairness.Stamper
 }
 
 func (p *TierPriorityPolicy) TypedName() plugins.TypedName {
@@ -263,7 +290,7 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 			}(ch, s)
 		}
 
-		go func(workerPoolID string, s *scheduler, mergedChannel chan pipeline.EmbelishedRequestMessage, priorityHeader string, tierLabel string) {
+		go func(workerPoolID string, s *scheduler, mergedChannel chan pipeline.EmbelishedRequestMessage, priorityHeader string, tierLabel string, fairnessStamper fairness.Stamper) {
 			defer close(mergedChannel)
 			defer s.Close()
 			for {
@@ -285,6 +312,9 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 				if chMeta.InferenceObjective != "" {
 					headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
 				}
+				// Stamped before the caller's headers are merged in so that a
+				// caller-supplied fairness header wins.
+				fairnessStamper.Stamp(headers, ir.PublicRequest)
 				for k, v := range ir.PublicRequest.ReqHeaders() {
 					headers[k] = v
 				}
@@ -303,7 +333,7 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 				metrics.IncQueueDepth(ir.QueueID, ir.RequestQueueName, workerPoolID)
 				mergedChannel <- erm
 			}
-		}(workerPoolID, s, mergedChannel, p.priorityHeader, p.tierLabel)
+		}(workerPoolID, s, mergedChannel, p.priorityHeader, p.tierLabel, p.fairness)
 	}
 
 	return dispatch

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
@@ -30,7 +30,7 @@ func TestTierPriorityOrdering(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-p": {ID: "pool-p", Workers: 1},
 	}
-	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority", "tier")
+	policy := NewTierPriorityPolicy("test-policy", Config{PriorityHeader: "x-gateway-priority", TierLabel: "tier"})
 
 	// Message 1: overflow + batch => Priority 5
 	m1 := irWithLabels("msg-5", map[string]string{
@@ -154,7 +154,7 @@ func TestTierPriorityFallback(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-fb": {ID: "pool-fb", Workers: 1},
 	}
-	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority", "tier")
+	policy := NewTierPriorityPolicy("test-policy", Config{PriorityHeader: "x-gateway-priority", TierLabel: "tier"})
 
 	// Message with missing labels should map to lowest priority (5)
 	m := irWithLabels("missing-labels", nil)
@@ -187,7 +187,7 @@ func TestTierPriorityCustomLabel(t *testing.T) {
 	pools := map[string]pipeline.WorkerPoolConfig{
 		"pool-fb": {ID: "pool-fb", Workers: 1},
 	}
-	policy := NewTierPriorityPolicy("test-policy", "x-gateway-priority", "my_custom_tier")
+	policy := NewTierPriorityPolicy("test-policy", Config{PriorityHeader: "x-gateway-priority", TierLabel: "my_custom_tier"})
 
 	// Message with my_custom_tier label
 	m := irWithLabels("custom-label-msg", map[string]string{

--- a/release-notes.d/unreleased/380.md
+++ b/release-notes.d/unreleased/380.md
@@ -4,4 +4,4 @@ url: https://github.com/llm-d/llm-d-async/pull/380
 author: LukeAVanDrie
 date: 2026-07-30
 ---
-Merge policies stamp the tenant identity attribute (default "userid") into the x-llm-d-inference-fairness-id request header so gateway flow control can arbitrate fairness per tenant; set fairness_header to "" to disable.
+Merge policies stamp the tenant identity attribute (default "userid") into the x-llm-d-inference-fairness-id request header so gateway flow control can arbitrate fairness per tenant. The stamp replaces any caller-supplied value of that header, so the identity the gateway arbitrates on is the one the redis-quota gate accounts against; set fairness_header to "" to disable.

--- a/release-notes.d/unreleased/380.md
+++ b/release-notes.d/unreleased/380.md
@@ -1,0 +1,7 @@
+---
+pr: 380
+url: https://github.com/llm-d/llm-d-async/pull/380
+author: LukeAVanDrie
+date: 2026-07-30
+---
+Merge policies stamp the tenant identity attribute (default "userid") into the x-llm-d-inference-fairness-id request header so gateway flow control can arbitrate fairness per tenant; set fairness_header to "" to disable.

--- a/test/integration/merge_policy_test.go
+++ b/test/integration/merge_policy_test.go
@@ -39,7 +39,7 @@ func TestRandomRobinPolicy_ConcurrentProducers(t *testing.T) {
 		},
 	}
 
-	policy := randomrobin.NewRandomRobinPolicy("test")
+	policy := randomrobin.NewRandomRobinPolicy("test", randomrobin.Config{})
 	dispatch := policy.MergeRequestChannels(channels, pools)
 	mergedChan := dispatch.Channels["test-pool"]
 

--- a/test/integration/redisimpl_test.go
+++ b/test/integration/redisimpl_test.go
@@ -77,7 +77,7 @@ func TestRedisImpl(t *testing.T) {
 			Workers: 1,
 		},
 	}
-	dispatch := randomrobin.NewRandomRobinPolicy("test").MergeRequestChannels(flow.RequestChannels(), pools)
+	dispatch := randomrobin.NewRandomRobinPolicy("test", randomrobin.Config{}).MergeRequestChannels(flow.RequestChannels(), pools)
 	mergedChannel := dispatch.Channels["default"]
 
 	select {


### PR DESCRIPTION
## What does this PR do?

Both merge policies (`random-robin`, `tier-priority`) now stamp the tenant attribute the `redis-quota` gate already keys on (default `userid`, from message metadata) into the router's fairness header `x-llm-d-inference-fairness-id`, so the gateway's flow control can arbitrate fairness between tenants after dispatch.

- New policy parameters `fairness_header` / `fairness_attribute`; explicit `fairness_header: ""` disables stamping (a pointer distinguishes absent from empty in config).
- The header is stamped only when the attribute is present, non-empty, and a legal HTTP header value, and a caller-supplied header with the same name under any letter case takes precedence (HTTP header names are case-insensitive; stamping anyway would leave two case variants with nondeterministic wire order).
- Stamping is best effort and never costs a request. Metadata is caller-supplied and never previously reached the wire, so an identity `net/http` refuses to write (a control character) skips the stamp rather than failing the whole dispatch as a non-retryable `UNKNOWN` error.
- The stamping logic lives in one place — the new internal package `pkg/async/mergepolicy/internal/fairness` — instead of being duplicated per policy, and both constructors now take a `Config` struct rather than 4–5 positional strings, so their parameters cannot be transposed and can grow without breaking the signature again.

## Why is this change needed?

Tenant isolation currently ends at dispatch: quotas are enforced upstream, but all of the processor's traffic at a given priority arrives at the gateway as one flow, so one tenant's burst delays every other tenant's requests behind it — the gateway's fairness policies receive no identity to arbitrate on. One header, written by the processor from an attribute both sides already carry, extends isolation past dispatch with no new mechanism on either side. Part of the async-side changes from the feedback-based dispatch control proposal (#379); independently useful and dependency-free.

Deployments whose messages carry no `userid` metadata keep today's behavior exactly. Where the attribute is present, note that stamping is on by default, so its value now reaches the gateway and may be recorded in access logs — the README recommends an opaque tenant ID over personally identifying values, and `fairness_header: ""` opts out entirely.

## How was this tested?

- [x] Unit tests added/updated — stamping behavior is covered once, in the new `internal/fairness` package (stamped identity, configured vs. defaulted attribute, absent and empty attribute, explicit disable, caller precedence including case variants, invalid header value skipped); each policy keeps two tests pinning only that it wires the stamper into its dispatch path and resolves its plugin parameters
- [x] Integration/e2e tests added/updated — existing integration suites updated for the new `Config` constructors and passing
- [x] Manual testing performed — `make ci` green and `go test -race ./pkg/async/mergepolicy/...` clean; verified end-to-end that a `userid` containing CRLF now dispatches successfully with no fairness header stamped, where before the guard it produced a permanent `invalid header field value` failure

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable) — README merge-policy parameters plus a note on the access-log implication, and the release-note fragment `release-notes.d/unreleased/380.md`

## Related Issues

Related to #379 (feedback-based dispatch control proposal).

## Release note

```release-note
Merge policies stamp the tenant identity attribute (default "userid") into the x-llm-d-inference-fairness-id request header so gateway flow control can arbitrate fairness per tenant; set fairness_header to "" to disable.
```
