### PR TITLE
feat(worker): capture gateway drop reasons and honor Retry-After within the deadline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,9 @@ vet: ## Run go vet against root, api, and producer modules.
 	cd producer && GOWORK=off go vet ./...
 
 .PHONY: test
-test: fmt vet setup-envtest ## Run tests (root module and producer submodule).
+test: fmt vet setup-envtest ## Run tests against root, api, and producer modules.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	cd api && go test ./... -coverprofile=cover-api.out
 	cd producer && GOWORK=off go test ./... -coverprofile=cover-producer.out
 
 # Creates a multi-node Kind cluster

--- a/api/inference_error.go
+++ b/api/inference_error.go
@@ -36,6 +36,13 @@ type InferenceError interface {
 
 var _ InferenceError = (*ClientError)(nil)
 
+// DroppedReasonHeader is the response header llm-d-router's flow control uses
+// to communicate the machine-readable reason a request was rejected before
+// dispatch or evicted in flight. The router sets it on both 429 (rejected for
+// capacity or queue TTL, evicted after dispatch) and 503 (no endpoints, client
+// disconnected, shutting down) responses.
+const DroppedReasonHeader = "x-llm-d-request-dropped-reason"
+
 // ClientError represents an inference client error with category and context.
 type ClientError struct {
 	ErrorCategory ErrorCategory
@@ -43,13 +50,18 @@ type ClientError struct {
 	RawError      error         // original error if available
 	RetryAfter    time.Duration // server-specified retry delay from Retry-After header (0 means not set)
 	StatusCode    int           // HTTP status code; 0 means no HTTP response was received
+	DroppedReason string        // machine-readable drop reason from DroppedReasonHeader (empty means not set)
 }
 
 func (e *ClientError) Error() string {
-	if e.RawError != nil {
-		return fmt.Sprintf("%s: %s (caused by: %v)", e.ErrorCategory, e.Message, e.RawError)
+	msg := e.Message
+	if e.DroppedReason != "" {
+		msg = fmt.Sprintf("%s (dropped: %s)", msg, e.DroppedReason)
 	}
-	return fmt.Sprintf("%s: %s", e.ErrorCategory, e.Message)
+	if e.RawError != nil {
+		return fmt.Sprintf("%s: %s (caused by: %v)", e.ErrorCategory, msg, e.RawError)
+	}
+	return fmt.Sprintf("%s: %s", e.ErrorCategory, msg)
 }
 
 func (e *ClientError) Unwrap() error {

--- a/api/inference_error_test.go
+++ b/api/inference_error_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClientError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *ClientError
+		want string
+	}{
+		{
+			name: "message only",
+			err:  &ClientError{ErrorCategory: ErrCategoryRateLimit, Message: "rate limited: status code 429"},
+			want: "RATE_LIMIT: rate limited: status code 429",
+		},
+		{
+			name: "with dropped reason",
+			err: &ClientError{
+				ErrorCategory: ErrCategoryRateLimit,
+				Message:       "rate limited: status code 429",
+				DroppedReason: "rejected-saturated",
+			},
+			want: "RATE_LIMIT: rate limited: status code 429 (dropped: rejected-saturated)",
+		},
+		{
+			name: "with dropped reason and cause",
+			err: &ClientError{
+				ErrorCategory: ErrCategoryServer,
+				Message:       "failed to read response",
+				RawError:      errors.New("unexpected EOF"),
+				DroppedReason: "evicted-queue-pressure",
+			},
+			want: "SERVER_ERROR: failed to read response (dropped: evicted-queue-pressure) (caused by: unexpected EOF)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/asyncworker/http_client.go
+++ b/pkg/asyncworker/http_client.go
@@ -49,25 +49,32 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 	}
 	defer result.Body.Close() // nolint:errcheck
 
+	// Read the rejection context once: the headers are available on every path
+	// below, including the one where the body read fails.
+	droppedReason := result.Header.Get(asyncapi.DroppedReasonHeader)
+	retryAfter, _ := parseRetryAfter(result.Header.Get("Retry-After"))
+
 	body, err := io.ReadAll(result.Body)
 	if err != nil {
 		return &asyncapi.InferenceResponse{StatusCode: result.StatusCode, Body: body}, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryServer,
 			Message:       "failed to read response",
 			RawError:      err,
+			RetryAfter:    retryAfter,
 			StatusCode:    result.StatusCode,
+			DroppedReason: droppedReason,
 		}
 	}
 
 	resp := &asyncapi.InferenceResponse{StatusCode: result.StatusCode, Body: body}
 
 	if result.StatusCode == 429 {
-		retryAfter, _ := parseRetryAfter(result.Header.Get("Retry-After"))
 		return resp, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryRateLimit,
 			Message:       fmt.Sprintf("rate limited: status code %d", result.StatusCode),
 			RetryAfter:    retryAfter,
 			StatusCode:    result.StatusCode,
+			DroppedReason: droppedReason,
 		}
 	}
 
@@ -76,6 +83,7 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 			ErrorCategory: asyncapi.ErrCategoryInvalidReq,
 			Message:       fmt.Sprintf("client error: status code %d", result.StatusCode),
 			StatusCode:    result.StatusCode,
+			DroppedReason: droppedReason,
 		}
 	}
 
@@ -83,7 +91,9 @@ func (h *HTTPInferenceClient) SendRequest(ctx context.Context, url string, heade
 		return resp, &asyncapi.ClientError{
 			ErrorCategory: asyncapi.ErrCategoryServer,
 			Message:       fmt.Sprintf("server error: status code %d", result.StatusCode),
+			RetryAfter:    retryAfter,
 			StatusCode:    result.StatusCode,
+			DroppedReason: droppedReason,
 		}
 	}
 

--- a/pkg/asyncworker/http_client_test.go
+++ b/pkg/asyncworker/http_client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -292,5 +293,100 @@ func TestNewHTTPInferenceClient(t *testing.T) {
 	}
 	if client.client != httpClient {
 		t.Error("expected client to wrap the provided http.Client")
+	}
+}
+
+type errBody struct{}
+
+func (errBody) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errBody) Close() error             { return nil }
+
+func TestSendRequest_droppedReasonCaptured(t *testing.T) {
+	// Status/reason pairings match what llm-d-router emits: rejections for
+	// capacity or queue TTL and post-dispatch evictions come back as 429,
+	// while an empty pool, a disconnected client, or a shutting-down flow
+	// controller come back as 503. The plain 400 is defensive — the router
+	// does not set the header there, but the capture must not depend on
+	// status.
+	tests := []struct {
+		name          string
+		statusCode    int
+		droppedReason string
+	}{
+		{"saturated 429", http.StatusTooManyRequests, "rejected-saturated"},
+		{"ttl expired 429", http.StatusTooManyRequests, "rejected-ttl-expired"},
+		{"evicted 429", http.StatusTooManyRequests, "evicted-queue-pressure"},
+		{"no endpoints 503", http.StatusServiceUnavailable, "rejected-no-endpoints"},
+		{"context cancelled 503", http.StatusServiceUnavailable, "rejected-context-cancelled"},
+		{"plain 400", http.StatusBadRequest, "some-reason"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := make(http.Header)
+			h.Set(asyncapi.DroppedReasonHeader, tt.droppedReason)
+			client := NewHTTPInferenceClient(NewTestClient(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tt.statusCode,
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+					Header:     h,
+				}, nil
+			}))
+			_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+			var ce *asyncapi.ClientError
+			if !errors.As(err, &ce) {
+				t.Fatalf("expected *ClientError, got %T", err)
+			}
+			if ce.DroppedReason != tt.droppedReason {
+				t.Errorf("DroppedReason = %q, want %q", ce.DroppedReason, tt.droppedReason)
+			}
+			if !strings.Contains(ce.Error(), tt.droppedReason) {
+				t.Errorf("Error() = %q, want it to surface the dropped reason", ce.Error())
+			}
+		})
+	}
+}
+
+func TestSendRequest_serverErrorRetryAfterCaptured(t *testing.T) {
+	h := make(http.Header)
+	h.Set("Retry-After", "7")
+	client := NewHTTPInferenceClient(NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     h,
+		}, nil
+	}))
+	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	var ce *asyncapi.ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ClientError, got %T", err)
+	}
+	if ce.RetryAfter != 7*time.Second {
+		t.Errorf("RetryAfter = %v, want 7s", ce.RetryAfter)
+	}
+}
+
+func TestSendRequest_bodyReadErrorKeepsDroppedReasonAndRetryAfter(t *testing.T) {
+	h := make(http.Header)
+	h.Set(asyncapi.DroppedReasonHeader, "evicted-queue-pressure")
+	h.Set("Retry-After", "5")
+	client := NewHTTPInferenceClient(NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       errBody{},
+			Header:     h,
+		}, nil
+	}))
+	_, err := client.SendRequest(context.Background(), "http://localhost/v1/completions", nil, []byte(`{}`))
+	var ce *asyncapi.ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ClientError, got %T", err)
+	}
+	// The headers arrived even though the body read failed.
+	if ce.DroppedReason != "evicted-queue-pressure" {
+		t.Errorf("DroppedReason = %q, want evicted-queue-pressure", ce.DroppedReason)
+	}
+	if ce.RetryAfter != 5*time.Second {
+		t.Errorf("RetryAfter = %v, want 5s", ce.RetryAfter)
 	}
 }

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -406,18 +406,22 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	}
 
 	finalDuration := expBackoffDuration(msg.RetryCount+1, int(secondsToDeadline))
-	// Honor server-specified Retry-After when it exceeds the computed backoff
-	// and still fits the message deadline. A hint beyond the deadline falls
-	// back to the backoff schedule: the server's estimate alone must not
-	// terminate a message that still has retry budget.
-	if retryAfterSec := retryAfter.Seconds(); retryAfterSec > finalDuration && retryAfterSec < float64(secondsToDeadline) {
-		finalDuration = retryAfterSec
+	// Honor server-specified Retry-After when it exceeds the computed backoff,
+	// clamped to half the remaining deadline: the server's estimate must not
+	// decide a message's fate on its own, so a wrong projection costs at most
+	// half the budget and the backoff ladder keeps the rest.
+	if retryAfterSec := retryAfter.Seconds(); retryAfterSec > finalDuration {
+		clamped := math.Min(retryAfterSec, float64(secondsToDeadline)/2)
+		// Max keeps the backoff floor when the deadline is nearly spent;
+		// jitter de-synchronizes messages rejected by the same event.
+		finalDuration = math.Max(finalDuration, clamped*(1+rand.Float64()/4)) // #nosec G404 -- non-security jitter, crypto/rand unnecessary
 	}
-	// Both branches keep finalDuration strictly under secondsToDeadline —
-	// expBackoffDuration caps at min(maxDelaySeconds, secondsToDeadline) and
-	// jitters below that cap — so the retry always lands before the deadline.
-	// The expiry check at the top of this function is therefore the only path
-	// that gives up on a message.
+	// Both arms keep finalDuration strictly under secondsToDeadline — the
+	// backoff arm jitters below min(maxDelaySeconds, secondsToDeadline), and
+	// the Retry-After arm is at most 0.625×secondsToDeadline (half the
+	// deadline, jittered up by <25%) — so the retry always lands before the
+	// deadline. The expiry check at the top of this function is therefore the
+	// only path that gives up on a message.
 
 	msg.RetryCount++
 	metrics.RecordRetry(queueID, queueName, msg.WorkerPoolID)

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -406,20 +406,18 @@ func retryMessage(ctx context.Context, msg pipeline.EmbelishedRequestMessage, re
 	}
 
 	finalDuration := expBackoffDuration(msg.RetryCount+1, int(secondsToDeadline))
-	// Honor server-specified Retry-After when it exceeds the computed backoff,
-	// but never schedule a retry beyond the message deadline.
-	if retryAfterSec := retryAfter.Seconds(); retryAfterSec > finalDuration {
+	// Honor server-specified Retry-After when it exceeds the computed backoff
+	// and still fits the message deadline. A hint beyond the deadline falls
+	// back to the backoff schedule: the server's estimate alone must not
+	// terminate a message that still has retry budget.
+	if retryAfterSec := retryAfter.Seconds(); retryAfterSec > finalDuration && retryAfterSec < float64(secondsToDeadline) {
 		finalDuration = retryAfterSec
 	}
-
-	if finalDuration >= float64(secondsToDeadline) {
-		metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
-		select {
-		case resultChannel <- deadlineExhaustedResult(msg, lastResp):
-		case <-ctx.Done():
-		}
-		return
-	}
+	// Both branches keep finalDuration strictly under secondsToDeadline —
+	// expBackoffDuration caps at min(maxDelaySeconds, secondsToDeadline) and
+	// jitters below that cap — so the retry always lands before the deadline.
+	// The expiry check at the top of this function is therefore the only path
+	// that gives up on a message.
 
 	msg.RetryCount++
 	metrics.RecordRetry(queueID, queueName, msg.WorkerPoolID)

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -796,7 +796,7 @@ func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
 	}
 }
 
-func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
+func TestRetryMessage_retryAfterExceedsDeadlineFallsBackToBackoff(t *testing.T) {
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmb(asyncapi.RequestMessage{
@@ -805,19 +805,20 @@ func TestRetryMessage_retryAfterExceedsDeadline(t *testing.T) {
 		Deadline: time.Now().Add(5 * time.Second).Unix(),
 	}, "", nil)
 
-	// Server says wait 30s, but deadline is only 5s away → deadline exceeded.
+	// Server says wait 30s, but the deadline is only 5s away. The hint is
+	// ignored rather than terminal: the server's estimate alone must not
+	// burn a message's remaining retry budget (it may be wrong, and the
+	// retry costs nothing durable), so the backoff schedule applies.
 	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, asyncapi.InferenceResponse{})
-	if len(retryChannel) > 0 {
-		t.Errorf("should not retry when Retry-After exceeds deadline")
+	if len(resultChannel) > 0 {
+		t.Fatalf("message terminated early; want a scheduled retry")
 	}
-	if len(resultChannel) != 1 {
-		t.Fatalf("expected deadline-exceeded result, got %d messages", len(resultChannel))
+	if len(retryChannel) != 1 {
+		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
-	result := <-resultChannel
-	var resultMap map[string]any
-	json.Unmarshal([]byte(result.Payload), &resultMap) // nolint:errcheck
-	if resultMap["error"] != "deadline exceeded" {
-		t.Errorf("expected 'deadline exceeded', got: %s", resultMap["error"])
+	retryMsg := <-retryChannel
+	if retryMsg.BackoffDurationSeconds <= 0 || retryMsg.BackoffDurationSeconds >= 5 {
+		t.Errorf("backoff = %f, want backoff-schedule value within the deadline", retryMsg.BackoffDurationSeconds)
 	}
 }
 

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -763,15 +763,16 @@ func TestRetryMessage_retryAfterHonored(t *testing.T) {
 		Deadline: time.Now().Add(100 * time.Second).Unix(),
 	}, "", nil)
 
-	// Server says wait 30s; expBackoff for retry 1 would be ~[1,2) seconds,
-	// so the Retry-After value should win.
+	// Server says wait 30s; expBackoff for retry 1 jitters in [2,4), and the
+	// hint fits half the 100s deadline, so it wins — jittered up by <25% to
+	// spread messages rejected by the same event.
 	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, asyncapi.InferenceResponse{})
 	if len(retryChannel) != 1 {
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
 	retryMsg := <-retryChannel
-	if retryMsg.BackoffDurationSeconds < 30 {
-		t.Errorf("expected backoff >= 30s (Retry-After), got %f", retryMsg.BackoffDurationSeconds)
+	if retryMsg.BackoffDurationSeconds < 30 || retryMsg.BackoffDurationSeconds >= 37.5 {
+		t.Errorf("expected backoff in [30, 37.5) (jittered Retry-After), got %f", retryMsg.BackoffDurationSeconds)
 	}
 }
 
@@ -796,7 +797,7 @@ func TestRetryMessage_retryAfterIgnoredWhenSmaller(t *testing.T) {
 	}
 }
 
-func TestRetryMessage_retryAfterExceedsDeadlineFallsBackToBackoff(t *testing.T) {
+func TestRetryMessage_retryAfterOversizedClampedNotTerminal(t *testing.T) {
 	retryChannel := make(chan pipeline.RetryMessage, 1)
 	resultChannel := make(chan asyncapi.ResultMessage, 1)
 	msg := newEmb(asyncapi.RequestMessage{
@@ -806,9 +807,10 @@ func TestRetryMessage_retryAfterExceedsDeadlineFallsBackToBackoff(t *testing.T) 
 	}, "", nil)
 
 	// Server says wait 30s, but the deadline is only 5s away. The hint is
-	// ignored rather than terminal: the server's estimate alone must not
+	// clamped rather than terminal: the server's estimate alone must not
 	// burn a message's remaining retry budget (it may be wrong, and the
-	// retry costs nothing durable), so the backoff schedule applies.
+	// retry costs nothing durable). Clamped to half the deadline (2.5s),
+	// jittered to [2.5, 3.125), floored by the backoff sample [2, 4).
 	retryMessage(context.Background(), msg, retryChannel, resultChannel, 30*time.Second, asyncapi.InferenceResponse{})
 	if len(resultChannel) > 0 {
 		t.Fatalf("message terminated early; want a scheduled retry")
@@ -817,8 +819,31 @@ func TestRetryMessage_retryAfterExceedsDeadlineFallsBackToBackoff(t *testing.T) 
 		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
 	}
 	retryMsg := <-retryChannel
-	if retryMsg.BackoffDurationSeconds <= 0 || retryMsg.BackoffDurationSeconds >= 5 {
-		t.Errorf("backoff = %f, want backoff-schedule value within the deadline", retryMsg.BackoffDurationSeconds)
+	if retryMsg.BackoffDurationSeconds < 2.5 || retryMsg.BackoffDurationSeconds >= 5 {
+		t.Errorf("backoff = %f, want clamped value in [2.5, 5)", retryMsg.BackoffDurationSeconds)
+	}
+}
+
+func TestRetryMessage_retryAfterClampedToHalfDeadline(t *testing.T) {
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	msg := newEmb(asyncapi.RequestMessage{
+		ID:       "retry-after-clamped",
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(40 * time.Second).Unix(),
+	}, "", nil)
+
+	// Server says wait 300s with 40s to the deadline. The hint is clamped to
+	// half the remaining deadline (20s) and jittered to [20, 25) — the
+	// message waits as long as its budget allows instead of retrying against
+	// a saturated gateway on the backoff floor ([2, 4) at retry 1).
+	retryMessage(context.Background(), msg, retryChannel, resultChannel, 300*time.Second, asyncapi.InferenceResponse{})
+	if len(retryChannel) != 1 {
+		t.Fatalf("expected one message in retry channel, got %d", len(retryChannel))
+	}
+	retryMsg := <-retryChannel
+	if retryMsg.BackoffDurationSeconds < 20 || retryMsg.BackoffDurationSeconds >= 25 {
+		t.Errorf("backoff = %f, want clamped value in [20, 25)", retryMsg.BackoffDurationSeconds)
 	}
 }
 

--- a/release-notes.d/unreleased/381.md
+++ b/release-notes.d/unreleased/381.md
@@ -1,0 +1,11 @@
+---
+pr: 381
+url: https://github.com/llm-d/llm-d-async/pull/381
+author: LukeAVanDrie
+date: 2026-07-30
+---
+The worker now records the gateway's machine-readable drop reason
+(`x-llm-d-request-dropped-reason`) on rejected requests and surfaces it in error
+messages, and honors `Retry-After` on 5xx responses as well as 429s. A
+`Retry-After` exceeding the message deadline now falls back to the exponential
+backoff schedule instead of failing the message early.

--- a/release-notes.d/unreleased/381.md
+++ b/release-notes.d/unreleased/381.md
@@ -7,5 +7,6 @@ date: 2026-07-30
 The worker now records the gateway's machine-readable drop reason
 (`x-llm-d-request-dropped-reason`) on rejected requests and surfaces it in error
 messages, and honors `Retry-After` on 5xx responses as well as 429s. A
-`Retry-After` exceeding the message deadline now falls back to the exponential
-backoff schedule instead of failing the message early.
+`Retry-After` hint is now clamped to half the message's remaining deadline
+instead of failing the message early when it exceeds the deadline, and honored
+hints are jittered to spread retries from the same rejection event.


### PR DESCRIPTION
## What does this PR do?

Captures the gateway's per-response rejection context on `api.ClientError`:

- `DroppedReason` from the router's `x-llm-d-request-dropped-reason` response header, on every response path — 429, other 4xx, 5xx, and failed body reads (where the headers arrived even if the body did not).
- `Retry-After` on 5xx responses (previously parsed only on 429). It stays scoped to the retryable categories; the fatal 4xx path records the reason only.
- `ClientError.Error()` includes the reason, so it reaches traces (`span.RecordError`) and result payloads today rather than waiting on a consumer.

Downstream policy can then react per reason (capacity vs queue-TTL expiry vs eviction) instead of treating every 429 the same; the first consumer is the feedback-driven dispatch gate proposed in #379.

**Behavior change:** a server `Retry-After` exceeding the message's remaining deadline no longer terminates the message, and hints are no longer honored verbatim. The hint is clamped to half the remaining deadline and jittered up by <25%, with the backoff sample as a floor (shape from @shimib's review: discarding an oversized hint retried fastest when the gateway asked for the longest pause). Previously a 429 with an oversized `Retry-After` returned a deadline-exceeded result with retry budget unused. The server's estimate may be wrong, so it never owns more than half the budget; the message deadline makes the give-up decision. The jitter spreads messages rejected by the same saturation event, which carry identical hints.

That bound makes the second deadline check in `retryMessage` unreachable: the backoff arm jitters strictly below `min(maxDelaySeconds, secondsToDeadline)` and the Retry-After arm is at most `0.625 × secondsToDeadline`. The check is removed in favor of documenting the invariant; deadline expiry is handled at the top of the function, now the single give-up path.

## Why is this change needed?

The router ships machine-readable drop reasons today, and the async processor discards them: the only rejection signal it keeps is the status code. This is the first of the async-side changes from the feedback-based dispatch control proposal (#379); it is independently useful (richer error context, correct `Retry-After` handling on 503s from intermediate proxies) and carries no dependency on the rest.

Worth noting for reviewers: the header is not 429-only. `llm-d-router`'s `translateFlowControlOutcome` sets it on 503 for `rejected-no-endpoints`, `rejected-context-cancelled`, and `rejected-shutting-down`, and on 429 for `rejected-saturated`, `rejected-ttl-expired`, and the `evicted-*` family. That is what motivates capturing on the 5xx path. The [llm-d header reference](https://github.com/llm-d/llm-d/blob/main/docs/api-reference/epp-http-headers.md) still says "Only present on `429`" and omits two reason values — stale relative to the router source; I'll send a separate docs PR.

Naming follows the two existing implementations of this field rather than inventing a third spelling: `RequestDroppedReason` in `llm-d-router` and `DroppedReason` in `llm-d-batch-gateway`. `api/` is a separately tagged module, so the field is public API from the next tag on.

## How was this tested?

- [x] Unit tests added/updated
  - drop-reason capture across the status/reason pairings the router actually emits, plus a defensive 400
  - the body-read-error path (headers present, body absent)
  - `Retry-After` on 5xx
  - `ClientError.Error()` formatting across all three shapes, including the no-reason case so the existing format stays pinned
  - retry scheduling for `Retry-After` hints: the oversized-hint case (clamped, not terminal), the clamp-binding case (300s hint, 40s deadline → waits 20–25s instead of 2–4s), and jitter bounds on honored hints
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed — `make ci` green; `pkg/asyncworker` coverage 85.8% → 86.6%

Repo hygiene picked up along the way: `make test` did not run the `api` module (`fmt` and `vet` both did), so `api/internal_api_test.go` had never run under the documented test command. Added it — the module now reports 62.2%. `pipeline/` has the same gap but is untouched here and is not covered by `fmt`/`vet` either; that belongs in its own PR.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable) — release-note fragment added at `release-notes.d/unreleased/381.md`

## Related Issues

Related to #379 (feedback-based dispatch control proposal).

## Release note

```release-note
The worker now records the gateway's machine-readable drop reason (`x-llm-d-request-dropped-reason`) on rejected requests and surfaces it in error messages, and honors `Retry-After` on 5xx responses as well as 429s. A `Retry-After` hint is now clamped to half the message's remaining deadline instead of failing the message early when it exceeds the deadline, and honored hints are jittered to spread retries from the same rejection event.
```