### PR TITLE
feat(chart): support pod affinity (ap.affinity) for the llm-d-async chart

### DIFF
--- a/charts/llm-d-async/templates/ap-deployments.yaml
+++ b/charts/llm-d-async/templates/ap-deployments.yaml
@@ -241,3 +241,7 @@ spec:
             secretName: {{ .Values.ap.tls.secretName }}
         {{- end }}
       {{- end }}
+      {{- with .Values.ap.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -417,3 +417,23 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --transform-config-file=/etc/llm-d-async/config/transform-config.json
+
+  - it: should not render affinity by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.affinity
+
+  - it: should render affinity when set
+    set:
+      ap.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: In
+                    values: ["true"]
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: node-role.kubernetes.io/infra

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -431,9 +431,13 @@ tests:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: node-role.kubernetes.io/infra
-                    operator: In
-                    values: ["true"]
+                    operator: Exists
     asserts:
       - equal:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: node-role.kubernetes.io/infra
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator
+          value: Exists
+      - notExists:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -5,6 +5,18 @@ ap:
   # For multi-queue/multi-topic setups, set per-entry igw_base_url in
   # redis.queuesConfig / gcpPubSub.topicsConfig instead of this global value.
   igwBaseURL: ""
+  # affinity defines optional pod affinity/anti-affinity/nodeAffinity rules
+  # for the Async Processor deployment, e.g. to pin the dispatcher onto
+  # non-GPU infra nodes:
+  #   affinity:
+  #     nodeAffinity:
+  #       requiredDuringSchedulingIgnoredDuringExecution:
+  #         nodeSelectorTerms:
+  #           - matchExpressions:
+  #               - key: node-role.kubernetes.io/infra
+  #                 operator: In
+  #                 values: ["true"]
+  affinity: {}
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -14,8 +14,7 @@ ap:
   #         nodeSelectorTerms:
   #           - matchExpressions:
   #               - key: node-role.kubernetes.io/infra
-  #                 operator: In
-  #                 values: ["true"]
+  #                 operator: Exists
   affinity: {}
   securityContext:
     allowPrivilegeEscalation: false

--- a/release-notes.d/unreleased/383.md
+++ b/release-notes.d/unreleased/383.md
@@ -1,0 +1,7 @@
+---
+pr: 383
+url: https://github.com/llm-d/llm-d-async/pull/383
+author: todayim
+date: 2026-08-01
+---
+The llm-d-async chart now supports `ap.affinity`, rendered into the async-processor Deployment's pod spec. This lets operators pin async-processor pods onto designated nodes (e.g. infra/CPU node pools via `nodeAffinity`) without wrapping or forking the chart. Unset by default; rendering is unchanged when the value is empty.


### PR DESCRIPTION
## Summary

Add optional `ap.affinity` to the `async-processor` Helm chart so the dispatcher Deployment's pod spec can carry affinity rules.

## Motivation

In production clusters the Async Processor (dispatcher for async batch inference) typically belongs on CPU/infra nodes, while GPU nodes are either tainted or too valuable to host a small control-plane-ish workload. Without chart-level affinity support, operators have to post-patch the rendered Deployment (or fork the chart) just to keep the pod off GPU pools. A first-class `affinity` value keeps such clusters on the stock chart.

## Changes

- `templates/ap-deployments.yaml`: render `.Values.ap.affinity` into the Deployment's pod spec (`affinity` omitted entirely when unset — behavior is byte-identical for existing values)
- `values.yaml`: document `ap.affinity` (default `{}`) with a nodeAffinity example

## Testing

- `helm template` renders the affinity block correctly when set, and is unchanged when unset
- Deployed on Kubernetes 1.26 serving 3-model mixed vLLM/SGLang async batch traffic via `redis-sortedset` queues; dispatcher pinned to infra nodes throughout a 900-request mixed load run

## Checklist

- [x] Signed-off-by included (DCO)
- [x] No behavior change for existing releases (empty default + `with` guard)
