### PR TITLE
Add async_gate_decisions_total metrics to worker pool gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ The Async Processor exposes Prometheus metrics under the `llm_d_async` subsystem
 | `llm_d_async_async_queue_residence_time_millis` | Histogram | Time in milliseconds a message spent buffered in-process, from broker ingestion until a worker pulled it for processing. Measures the async delay introduced by the system (queue time). Always registered. |
 | `llm_d_async_async_dispatch_budget` | Gauge | Current dispatch budget [0.0–1.0] returned by the queue's gate; the fraction of system capacity available for new requests (0.0 = gate fully closed). Useful for diagnosing why throughput is throttled. |
 | `llm_d_async_async_pool_worker_limit` | Gauge | Configured worker concurrency limit for a pool (carries only the `pool_name` label). Compare against `llm_d_async_async_inflight_requests` to compute worker utilization. |
-| `llm_d_async_async_gate_decisions_total` | Counter | Count of gate decisions that prevented dispatch, by `reason`: `gate_closed` (no dispatch budget), `quota_exhausted` (per-attribute quota overflow), `dropped` (gate permanently rejected the request), `error` (gate evaluation failed). `quota_exhausted`, `dropped` and `error` count individual messages refused after being dequeued. `gate_closed` counts those plus every dequeue round in which the budget shrank the batch to zero — the way budget-based gates (`prometheus-budget`/`-saturation`/`-query`) shed work *before* a message is dequeued — so its rate reflects throttled dispatch opportunities, not messages. All four `reason` series are created at 0 when a queue starts, so a query returns 0 rather than an empty vector. |
+| `llm_d_async_async_gate_decisions_total` | Counter | Count of gate decisions that prevented dispatch, by `reason`: `gate_closed` (no dispatch budget), `quota_exhausted` (per-attribute quota overflow), `dropped` (gate permanently rejected the request), `error` (gate evaluation failed). `quota_exhausted`, `dropped` and `error` count individual messages refused after being dequeued. `gate_closed` counts those plus every dequeue round in which the budget shrank the batch to zero — the way budget-based gates (`prometheus-budget`/`-saturation`/`-query`) shed work *before* a message is dequeued — so its rate reflects throttled dispatch opportunities, not messages. All four `reason` series are created at 0 when a queue or gated worker pool starts, so a query returns 0 rather than an empty vector. |
 | `llm_d_async_async_gate_metric_value` | Gauge | Raw metric value a metric-based gate (`prometheus-saturation`/`-budget`/`-query`) last read — the number compared against the threshold below. For the saturation gate this is `1 - saturation`. |
 | `llm_d_async_async_gate_metric_threshold` | Gauge | Threshold the value above is compared against. The gate closes when `value <= threshold`, which is what drives `async_dispatch_budget` to 0. |
 
@@ -645,7 +645,8 @@ InferencePool a gate happens to query — that is what `inference_pool` is for. 
 per-queue series therefore carries the same `queue_id`/`queue_name`/`pool_name`
 triple and joins on it, including the two gate gauges. A **pool-level** gate (one
 configured on a worker pool rather than a queue) has no single queue, so its gauges
-carry an empty `queue_id` and `queue_name` and are keyed by `pool_name` alone.
+and `async_gate_decisions_total` counter carry an empty `queue_id` and `queue_name`
+and are keyed by `pool_name` alone.
 
 **Example PromQL queries:**
 

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -117,6 +117,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 
 					var verdict pipeline.Verdict
 					var err error
+					var waitRecorded bool
 					for {
 						if emitCancelledResultIfNeeded(requestCtx, logger, retryChannel, resultChannel, msg, &nextCancellationCheck) {
 							return
@@ -139,6 +140,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 								}
 								return
 							}
+							metrics.RecordGateDecision(metrics.ReasonError, "", "", msg.WorkerPoolID)
 							select {
 							case resultChannel <- asyncapi.NewErrorResult(msg.PublicRequest, msg.InternalRouting, asyncapi.ErrCodeGateError, fmt.Sprintf("Pool gating error: %s", err.Error())):
 							case <-requestCtx.Done():
@@ -151,6 +153,7 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						}
 
 						if verdict.Action == pipeline.ActionDrop {
+							metrics.RecordGateDecision(metrics.ReasonDropped, "", "", msg.WorkerPoolID)
 							var resultMsg asyncapi.ResultMessage
 							if verdict.Result != nil {
 								resultMsg = *verdict.Result
@@ -165,6 +168,11 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						}
 
 						if verdict.Action == pipeline.ActionRefuse {
+							reason := metrics.ReasonGateClosed
+							if msg.GetClassification() == asyncapi.ClassificationOverflow {
+								reason = metrics.ReasonQuotaExhausted
+							}
+							metrics.RecordGateDecision(reason, "", "", msg.WorkerPoolID)
 							select {
 							case retryChannel <- pipeline.RetryMessage{
 								EmbelishedRequestMessage: msg,
@@ -177,6 +185,14 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 
 						// ActionWait: park/wait and retry in-memory
 						if verdict.Action == pipeline.ActionWait {
+							if !waitRecorded {
+								reason := metrics.ReasonGateClosed
+								if msg.GetClassification() == asyncapi.ClassificationOverflow {
+									reason = metrics.ReasonQuotaExhausted
+								}
+								metrics.RecordGateDecision(reason, "", "", msg.WorkerPoolID)
+								waitRecorded = true
+							}
 							select {
 							case <-gateCtx.Done():
 								if requestCtx.Err() != nil && !errors.Is(requestCtx.Err(), context.DeadlineExceeded) {

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -2545,3 +2545,223 @@ func TestWorker_QueueGateAndPoolGateRace(t *testing.T) {
 		t.Errorf("expected pool release to be called exactly once, got %d", poolReleaseCalled)
 	}
 }
+
+type mockDecisionPoolGate struct {
+	verdict pipeline.Verdict
+	err     error
+}
+
+func (g *mockDecisionPoolGate) Budget(ctx context.Context) float64 { return 1.0 }
+
+func (g *mockDecisionPoolGate) Apply(ctx context.Context, _ *asyncapi.InternalRequest, _ *[]pipeline.GateReleaseFunc) (pipeline.Verdict, error) {
+	return g.verdict, g.err
+}
+
+func gateDecisionCountForPool(poolID, reason string) float64 {
+	c, err := metrics.GateDecisions.GetMetricWithLabelValues("", "", poolID, reason)
+	if err != nil {
+		return 0
+	}
+	return testutil.ToFloat64(c)
+}
+
+func TestWorker_PoolGateDecisionsMetrics(t *testing.T) {
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Header: make(http.Header)}, nil
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+
+	t.Run("dropped decision", func(t *testing.T) {
+		poolID := "pool-test-dropped"
+		metrics.InitGateDecisions("", "", poolID)
+		requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+		retryChannel := make(chan pipeline.RetryMessage, 1)
+		resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		gate := &mockDecisionPoolGate{verdict: pipeline.Drop(nil)}
+		go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+		msg := newEmb(asyncapi.RequestMessage{
+			ID:       "req-dropped",
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(30 * time.Second).Unix(),
+			Payload:  map[string]any{"model": "test"},
+		}, "http://localhost:30800/v1/completions", nil)
+		msg.WorkerPoolID = poolID
+		requestChannel <- msg
+
+		select {
+		case <-resultChannel:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for dropped result")
+		}
+
+		if got := gateDecisionCountForPool(poolID, metrics.ReasonDropped); got != 1 {
+			t.Errorf("GateDecisions[dropped] = %v, want 1", got)
+		}
+		for _, reason := range []string{metrics.ReasonGateClosed, metrics.ReasonQuotaExhausted, metrics.ReasonError} {
+			if got := gateDecisionCountForPool(poolID, reason); got != 0 {
+				t.Errorf("GateDecisions[%s] = %v, want 0", reason, got)
+			}
+		}
+	})
+
+	t.Run("refuse decision - gate_closed", func(t *testing.T) {
+		poolID := "pool-test-refused-closed"
+		metrics.InitGateDecisions("", "", poolID)
+		requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+		retryChannel := make(chan pipeline.RetryMessage, 1)
+		resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		gate := &mockDecisionPoolGate{verdict: pipeline.Refuse()}
+		go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+		msg := newEmb(asyncapi.RequestMessage{
+			ID:       "req-closed",
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(30 * time.Second).Unix(),
+			Payload:  map[string]any{"model": "test"},
+		}, "http://localhost:30800/v1/completions", nil)
+		msg.WorkerPoolID = poolID
+		requestChannel <- msg
+
+		select {
+		case <-retryChannel:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for retry message")
+		}
+
+		if got := gateDecisionCountForPool(poolID, metrics.ReasonGateClosed); got != 1 {
+			t.Errorf("GateDecisions[gate_closed] = %v, want 1", got)
+		}
+		for _, reason := range []string{metrics.ReasonDropped, metrics.ReasonQuotaExhausted, metrics.ReasonError} {
+			if got := gateDecisionCountForPool(poolID, reason); got != 0 {
+				t.Errorf("GateDecisions[%s] = %v, want 0", reason, got)
+			}
+		}
+	})
+
+	t.Run("refuse decision - quota_exhausted", func(t *testing.T) {
+		poolID := "pool-test-refused-quota"
+		metrics.InitGateDecisions("", "", poolID)
+		requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+		retryChannel := make(chan pipeline.RetryMessage, 1)
+		resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		gate := &mockDecisionPoolGate{verdict: pipeline.Refuse()}
+		go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+		ir := asyncapi.NewInternalRequest(
+			asyncapi.InternalRouting{RequestQueueName: "test-queue"},
+			&asyncapi.RequestMessage{
+				ID:       "req-quota",
+				Created:  time.Now().Unix(),
+				Deadline: time.Now().Add(30 * time.Second).Unix(),
+				Payload:  map[string]any{"model": "test"},
+			},
+		)
+		ir.SetClassification(asyncapi.ClassificationOverflow)
+
+		requestChannel <- pipeline.EmbelishedRequestMessage{
+			InternalRequest: ir,
+			RequestURL:      "http://localhost:30800/v1/completions",
+			WorkerPoolID:    poolID,
+		}
+
+		select {
+		case <-retryChannel:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for retry message")
+		}
+
+		if got := gateDecisionCountForPool(poolID, metrics.ReasonQuotaExhausted); got != 1 {
+			t.Errorf("GateDecisions[quota_exhausted] = %v, want 1", got)
+		}
+		for _, reason := range []string{metrics.ReasonGateClosed, metrics.ReasonDropped, metrics.ReasonError} {
+			if got := gateDecisionCountForPool(poolID, reason); got != 0 {
+				t.Errorf("GateDecisions[%s] = %v, want 0", reason, got)
+			}
+		}
+	})
+
+	t.Run("error decision", func(t *testing.T) {
+		poolID := "pool-test-error"
+		metrics.InitGateDecisions("", "", poolID)
+		requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+		retryChannel := make(chan pipeline.RetryMessage, 1)
+		resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		gate := &mockDecisionPoolGate{err: fmt.Errorf("gate failure")}
+		go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+		msg := newEmb(asyncapi.RequestMessage{
+			ID:       "req-error",
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(30 * time.Second).Unix(),
+			Payload:  map[string]any{"model": "test"},
+		}, "http://localhost:30800/v1/completions", nil)
+		msg.WorkerPoolID = poolID
+		requestChannel <- msg
+
+		select {
+		case <-resultChannel:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for error result")
+		}
+
+		if got := gateDecisionCountForPool(poolID, metrics.ReasonError); got != 1 {
+			t.Errorf("GateDecisions[error] = %v, want 1", got)
+		}
+		for _, reason := range []string{metrics.ReasonGateClosed, metrics.ReasonQuotaExhausted, metrics.ReasonDropped} {
+			if got := gateDecisionCountForPool(poolID, reason); got != 0 {
+				t.Errorf("GateDecisions[%s] = %v, want 0", reason, got)
+			}
+		}
+	})
+
+	t.Run("wait decision - counts once per message", func(t *testing.T) {
+		poolID := "pool-test-wait"
+		metrics.InitGateDecisions("", "", poolID)
+		requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+		retryChannel := make(chan pipeline.RetryMessage, 1)
+		resultChannel := make(chan asyncapi.ResultMessage, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		gate := &mockDecisionPoolGate{verdict: pipeline.Wait()}
+		go WorkerWithGate(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil, gate)
+
+		msg := newEmb(asyncapi.RequestMessage{
+			ID:       "req-wait",
+			Created:  time.Now().Unix(),
+			Deadline: time.Now().Add(30 * time.Second).Unix(),
+			Payload:  map[string]any{"model": "test"},
+		}, "http://localhost:30800/v1/completions", nil)
+		msg.WorkerPoolID = poolID
+		requestChannel <- msg
+
+		time.Sleep(250 * time.Millisecond)
+
+		if got := gateDecisionCountForPool(poolID, metrics.ReasonGateClosed); got != 1 {
+			t.Errorf("GateDecisions[gate_closed] = %v, want 1 after multiple wait intervals", got)
+		}
+		for _, reason := range []string{metrics.ReasonQuotaExhausted, metrics.ReasonDropped, metrics.ReasonError} {
+			if got := gateDecisionCountForPool(poolID, reason); got != 0 {
+				t.Errorf("GateDecisions[%s] = %v, want 0", reason, got)
+			}
+		}
+	})
+}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -150,6 +150,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 				os.Exit(1)
 			}
 			poolGates[poolID] = gate
+			metrics.InitGateDecisions("", "", poolID)
 			setupLog.Info("Created pool gate", "poolID", poolID, "gateType", pool.GateType, "gateParams", pool.GateParams)
 		}
 	}

--- a/release-notes.d/unreleased/add-pool-gate-decisions-metrics.md
+++ b/release-notes.d/unreleased/add-pool-gate-decisions-metrics.md
@@ -1,0 +1,7 @@
+---
+pr: 385
+url: https://github.com/llm-d/llm-d-async/pull/385
+author: jtechapps
+date: 2026-07-31
+---
+The `llm_d_async_async_gate_decisions_total` counter now records decisions (`gate_closed`, `quota_exhausted`, `dropped`, and `error`) for worker pool-level gates in addition to queue-level gates. Because `pool_name` identifies the worker pool on both queue-level and pool-level series, queries aggregating `sum by (pool_name)` across `async_gate_decisions_total` will now include decisions made at the pool gate in addition to the queue gate.


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

Previously, async_gate_decisions_total (via metrics.RecordGateDecision)
and series initialization (via metrics.InitGateDecisions) were only
included in queue-level gates (Pub/Sub and Redis sorted set consumers).
Worker pool-level gates did not record gate decision reasons or pre-create
zero-valued series in Prometheus.
This change:
* pkg/asyncworker/worker.go:
  - Calls metrics.RecordGateDecision(...) across all worker pool gate
    verdicts (error, dropped, gate_closed, and quota_exhausted for
    ClassificationOverflow messages).
  - Hoists a waitRecorded boolean outside the gating loop so requests parked
    in ActionWait record gate_closed exactly once per message instead of on
    every 50ms poll tick.
* pkg/server/runner.go:
  - Calls metrics.InitGateDecisions("", "", poolID) during pool gate
    construction (if pool.GateType != "") so gated worker pools pre-create
    all four reason series at 0 on startup without polluting gateless pools.
* README.md:
  - Updates the llm_d_async_async_gate_decisions_total table description
    and pool-level paragraph to document that both pool-level gate gauges
    and async_gate_decisions_total are keyed by pool_name alone with empty
    queue_id/queue_name labels.
* pkg/asyncworker/worker_test.go:
  - Adds TestWorker_PoolGateDecisionsMetrics with subtests for dropped,
    gate_closed, quota_exhausted, error, and wait_decision_-_counts_once_per_message.
* release-notes.d/unreleased/add-pool-gate-decisions-metrics.md:
  - Adds release note fragment for PR #385.

Intentionally did not include `async_dispatch_budget` metric because `gate.Budget()` has not effect for worker pool gates. This will only be applicable after https://github.com/llm-d/llm-d-async/issues/304, https://github.com/llm-d/llm-d-async/issues/141

## Why is this change needed?

Fixes: #384 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
NONE
```
