### PR TITLE
refactor: update helm config to new format

### DIFF
--- a/charts/llm-d-async/templates/NOTES.txt
+++ b/charts/llm-d-async/templates/NOTES.txt
@@ -1,0 +1,24 @@
+llm-d-async {{ .Chart.AppVersion }} has been installed as {{ include "llm-d-async.fullname" . }}.
+
+Transport: {{ include "llm-d-async.transport" . }}
+
+The processor is configured through the unified transport surface
+(--transport / --transport-config); no deprecated CLI flags are emitted.
+{{- if include "llm-d-async.usingDeprecatedTransport" . }}
+
+WARNING: deprecated chart values in use.
+  You configured the transport with the deprecated per-backend values
+  (ap.redis.enabled / ap.gcpPubSub.enabled / ap.messageQueueImpl and the
+  per-backend ap.redis.* / ap.gcpPubSub.* request/queue fields, ap.otel.redisTracing).
+  They still work — the chart translates them into the transport config — but
+  will be removed in a future release. Migrate to the unified surface:
+
+    ap:
+      transport: {{ include "llm-d-async.transport" . }}
+      transportConfig:
+        # transport-specific JSON document; see the chart README and the
+        # "Transport Configuration" section of the project README.
+
+  Redis/Valkey credentials stay in ap.redis.url / ap.redis.secretName (injected
+  as REDIS_URL); leave "url" out of transportConfig to use them.
+{{- end }}

--- a/charts/llm-d-async/templates/NOTES.txt
+++ b/charts/llm-d-async/templates/NOTES.txt
@@ -18,7 +18,20 @@ WARNING: deprecated chart values in use.
       transportConfig:
         # transport-specific JSON document; see the chart README and the
         # "Transport Configuration" section of the project README.
+{{- end }}
+{{- if include "llm-d-async.usingDeprecatedRedisConn" . }}
 
-  Redis/Valkey credentials stay in ap.redis.url / ap.redis.secretName (injected
-  as REDIS_URL); leave "url" out of transportConfig to use them.
+WARNING: deprecated Redis connection values in use.
+  ap.redis.url / ap.redis.secretName are deprecated. Provide the Redis/Valkey
+  connection on the transport surface instead — the chart injects it as REDIS_URL
+  and keeps it out of the pod args:
+
+    ap:
+      transportConfig:
+        urlSecret:
+          name: <existing-secret>   # reference a Secret, OR
+          key: url
+        # or have the chart create the Secret from a literal URL:
+        # urlSecret:
+        #   url: redis://...
 {{- end }}

--- a/charts/llm-d-async/templates/_helpers.tpl
+++ b/charts/llm-d-async/templates/_helpers.tpl
@@ -83,7 +83,9 @@ per-backend values so existing values files keep working.
 */}}
 {{- define "llm-d-async.transportConfig" -}}
 {{- if .Values.ap.transport -}}
-{{- .Values.ap.transportConfig | toJson -}}
+{{- /* urlSecret is a chart-only directive (it wires REDIS_URL from a Secret);
+       strip it so it is never passed to the processor or rendered into args. */ -}}
+{{- omit .Values.ap.transportConfig "urlSecret" | toJson -}}
 {{- else -}}
 {{- include "llm-d-async.legacyTransportConfig" . -}}
 {{- end -}}
@@ -150,7 +152,9 @@ If redis.url is set, the chart creates a Secret named <fullname>-redis.
 Otherwise, use the user-provided redis.secretName.
 */}}
 {{- define "llm-d-async.redisSecretName" -}}
-{{- if .Values.ap.redis.url -}}
+{{- if and .Values.ap.transport (dig "urlSecret" "name" "" (.Values.ap.transportConfig | default dict)) -}}
+{{- dig "urlSecret" "name" "" (.Values.ap.transportConfig | default dict) -}}
+{{- else if .Values.ap.redis.url -}}
 {{- printf "%s-redis" (include "llm-d-async.fullname" .) -}}
 {{- else -}}
 {{- .Values.ap.redis.secretName -}}
@@ -162,7 +166,9 @@ Resolve the Redis secret key.
 When the chart creates the Secret, the key is always "url".
 */}}
 {{- define "llm-d-async.redisSecretKey" -}}
-{{- if .Values.ap.redis.url -}}
+{{- if and .Values.ap.transport (dig "urlSecret" "name" "" (.Values.ap.transportConfig | default dict)) -}}
+{{- dig "urlSecret" "key" "url" (.Values.ap.transportConfig | default dict) -}}
+{{- else if .Values.ap.redis.url -}}
 url
 {{- else -}}
 {{- .Values.ap.redis.secretKey -}}

--- a/charts/llm-d-async/templates/_helpers.tpl
+++ b/charts/llm-d-async/templates/_helpers.tpl
@@ -58,15 +58,90 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Render gate params as JSON with all values as strings.
-The gate params parser expects map[string]string, so numeric values must be quoted.
+Effective transport type. Prefers the new ap.transport; otherwise derives it from
+the deprecated ap.redis.enabled / ap.gcpPubSub.enabled / ap.messageQueueImpl values.
+Renders empty when no backend is selected.
 */}}
-{{- define "llm-d-async.gateParamsJson" -}}
-{{- $out := dict -}}
-{{- range $k, $v := .Values.ap.redis.gateParams -}}
-{{- $_ := set $out $k ($v | toString) -}}
+{{- define "llm-d-async.transport" -}}
+{{- if .Values.ap.transport -}}
+{{- .Values.ap.transport -}}
+{{- else if .Values.ap.redis.enabled -}}
+{{- if eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset" -}}
+redis-sortedset
+{{- else -}}
+redis-pubsub
 {{- end -}}
-{{- $out | toJson -}}
+{{- else if .Values.ap.gcpPubSub.enabled -}}
+gcp-pubsub
+{{- end -}}
+{{- end }}
+
+{{/*
+Transport config JSON document passed via --transport-config. On the new surface
+it is ap.transportConfig verbatim; otherwise it is synthesized from the deprecated
+per-backend values so existing values files keep working.
+*/}}
+{{- define "llm-d-async.transportConfig" -}}
+{{- if .Values.ap.transport -}}
+{{- .Values.ap.transportConfig | toJson -}}
+{{- else -}}
+{{- include "llm-d-async.legacyTransportConfig" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Synthesize a transport config JSON document from the deprecated per-backend chart
+values (ap.redis.* / ap.gcpPubSub.* / ap.otel.redisTracing). The Redis "url" is
+deliberately left unset so the injected REDIS_URL env var supplies it.
+*/}}
+{{- define "llm-d-async.legacyTransportConfig" -}}
+{{- $ap := .Values.ap -}}
+{{- $transport := include "llm-d-async.transport" . -}}
+{{- $cfg := dict -}}
+{{- if eq $transport "redis-pubsub" -}}
+{{- if and $ap.otel.redisTracing $ap.otel.endpoint -}}{{- $_ := set $cfg "enable_tracing" true -}}{{- end -}}
+{{- if $ap.redis.queuesConfig -}}
+{{- $_ := set $cfg "queues" $ap.redis.queuesConfig -}}
+{{- else -}}
+{{- $_ := set $cfg "queues" (list (dict "queue_name" "request-queue" "igw_base_url" $ap.igwBaseURL "request_path_url" $ap.redis.requestPathURL)) -}}
+{{- end -}}
+{{- else if eq $transport "redis-sortedset" -}}
+{{- $_ := set $cfg "result_queue_name" ($ap.redis.resultQueueName | default "result-list") -}}
+{{- $_ := set $cfg "poll_interval_ms" (int ($ap.redis.pollIntervalMs | default 1000)) -}}
+{{- $_ := set $cfg "batch_size" (int ($ap.redis.batchSize | default 10)) -}}
+{{- if and $ap.otel.redisTracing $ap.otel.endpoint -}}{{- $_ := set $cfg "enable_tracing" true -}}{{- end -}}
+{{- if $ap.redis.queuesConfig -}}
+{{- $_ := set $cfg "queues" $ap.redis.queuesConfig -}}
+{{- else -}}
+{{- $q := dict "queue_name" ($ap.redis.requestQueueName | default "request-sortedset") "igw_base_url" $ap.igwBaseURL "request_path_url" $ap.redis.requestPathURL -}}
+{{- if $ap.redis.gateType -}}
+{{- $_ := set $q "gate_type" $ap.redis.gateType -}}
+{{- $gp := dict -}}
+{{- range $k, $v := $ap.redis.gateParams -}}{{- $_ := set $gp $k ($v | toString) -}}{{- end -}}
+{{- $_ := set $q "gate_params" $gp -}}
+{{- end -}}
+{{- $_ := set $cfg "queues" (list $q) -}}
+{{- end -}}
+{{- else if eq $transport "gcp-pubsub" -}}
+{{- $_ := set $cfg "project_id" $ap.gcpPubSub.projectId -}}
+{{- $_ := set $cfg "result_topic_id" $ap.gcpPubSub.resultTopicId -}}
+{{- if $ap.gcpPubSub.topicsConfig -}}
+{{- $_ := set $cfg "topics" $ap.gcpPubSub.topicsConfig -}}
+{{- else -}}
+{{- $_ := set $cfg "topics" (list (dict "subscriber_id" $ap.gcpPubSub.requestSubscriberId "igw_base_url" $ap.igwBaseURL "request_path_url" $ap.gcpPubSub.requestPathURL)) -}}
+{{- end -}}
+{{- end -}}
+{{- $cfg | toJson -}}
+{{- end }}
+
+{{/*
+Report whether any deprecated per-backend transport value is in use. Drives the
+migration warning in NOTES.txt.
+*/}}
+{{- define "llm-d-async.usingDeprecatedTransport" -}}
+{{- if and (not .Values.ap.transport) (or .Values.ap.redis.enabled .Values.ap.gcpPubSub.enabled) -}}
+true
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/llm-d-async/templates/_helpers.tpl
+++ b/charts/llm-d-async/templates/_helpers.tpl
@@ -147,13 +147,27 @@ true
 {{- end }}
 
 {{/*
+Report whether the deprecated ap.redis.* connection inputs are in use. On the new
+surface the Redis connection belongs in ap.transportConfig.urlSecret; ap.redis.url
+and ap.redis.secretName are retained for backwards compatibility only.
+*/}}
+{{- define "llm-d-async.usingDeprecatedRedisConn" -}}
+{{- if or .Values.ap.redis.url .Values.ap.redis.secretName -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve the Redis secret name.
 If redis.url is set, the chart creates a Secret named <fullname>-redis.
 Otherwise, use the user-provided redis.secretName.
 */}}
 {{- define "llm-d-async.redisSecretName" -}}
-{{- if and .Values.ap.transport (dig "urlSecret" "name" "" (.Values.ap.transportConfig | default dict)) -}}
-{{- dig "urlSecret" "name" "" (.Values.ap.transportConfig | default dict) -}}
+{{- $ts := .Values.ap.transportConfig | default dict -}}
+{{- if and .Values.ap.transport (dig "urlSecret" "url" "" $ts) -}}
+{{- printf "%s-redis" (include "llm-d-async.fullname" .) -}}
+{{- else if and .Values.ap.transport (dig "urlSecret" "name" "" $ts) -}}
+{{- dig "urlSecret" "name" "" $ts -}}
 {{- else if .Values.ap.redis.url -}}
 {{- printf "%s-redis" (include "llm-d-async.fullname" .) -}}
 {{- else -}}
@@ -166,8 +180,11 @@ Resolve the Redis secret key.
 When the chart creates the Secret, the key is always "url".
 */}}
 {{- define "llm-d-async.redisSecretKey" -}}
-{{- if and .Values.ap.transport (dig "urlSecret" "name" "" (.Values.ap.transportConfig | default dict)) -}}
-{{- dig "urlSecret" "key" "url" (.Values.ap.transportConfig | default dict) -}}
+{{- $ts := .Values.ap.transportConfig | default dict -}}
+{{- if and .Values.ap.transport (dig "urlSecret" "url" "" $ts) -}}
+url
+{{- else if and .Values.ap.transport (dig "urlSecret" "name" "" $ts) -}}
+{{- dig "urlSecret" "key" "url" $ts -}}
 {{- else if .Values.ap.redis.url -}}
 url
 {{- else -}}

--- a/charts/llm-d-async/templates/_helpers.tpl
+++ b/charts/llm-d-async/templates/_helpers.tpl
@@ -149,10 +149,16 @@ true
 {{/*
 Report whether the deprecated ap.redis.* connection inputs are in use. On the new
 surface the Redis connection belongs in ap.transportConfig.urlSecret; ap.redis.url
-and ap.redis.secretName are retained for backwards compatibility only.
+and ap.redis.secretName are retained for backwards compatibility only. Only warn
+when the effective transport is Redis and the connection actually comes from
+ap.redis.* (i.e. the new urlSecret surface is not configured), so the migration
+notice never fires for a non-Redis backend or when urlSecret already supersedes it.
 */}}
 {{- define "llm-d-async.usingDeprecatedRedisConn" -}}
-{{- if or .Values.ap.redis.url .Values.ap.redis.secretName -}}
+{{- $transport := include "llm-d-async.transport" . -}}
+{{- $ts := .Values.ap.transportConfig | default dict -}}
+{{- $hasUrlSecret := or (dig "urlSecret" "url" "" $ts) (dig "urlSecret" "name" "" $ts) -}}
+{{- if and (hasPrefix "redis" $transport) (not $hasUrlSecret) (or .Values.ap.redis.url .Values.ap.redis.secretName) -}}
 true
 {{- end -}}
 {{- end }}
@@ -184,7 +190,7 @@ When the chart creates the Secret, the key is always "url".
 {{- if and .Values.ap.transport (dig "urlSecret" "url" "" $ts) -}}
 url
 {{- else if and .Values.ap.transport (dig "urlSecret" "name" "" $ts) -}}
-{{- dig "urlSecret" "key" "url" $ts -}}
+{{- dig "urlSecret" "key" "url" $ts | default "url" -}}
 {{- else if .Values.ap.redis.url -}}
 url
 {{- else -}}

--- a/charts/llm-d-async/templates/ap-configmap.yaml
+++ b/charts/llm-d-async/templates/ap-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
+{{- if or .Values.ap.workerPools .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,9 +9,6 @@ metadata:
 data:
   {{- if .Values.ap.workerPools }}
   worker-pools.json: {{ .Values.ap.workerPools | toJson | quote }}
-  {{- end }}
-  {{- if .Values.ap.gcpPubSub.topicsConfig }}
-  pubsub-topics.json: {{ .Values.ap.gcpPubSub.topicsConfig | toJson | quote }}
   {{- end }}
   {{- if .Values.ap.transformConfig }}
   transform-config.json: {{ .Values.ap.transformConfig | toJson | quote }}

--- a/charts/llm-d-async/templates/ap-deployments.yaml
+++ b/charts/llm-d-async/templates/ap-deployments.yaml
@@ -1,6 +1,19 @@
 {{- /* ---- Fail-fast configuration validation ----
        Turn common misconfigurations into clear install-time errors instead of
        runtime crash-loops or silently dropped requests. */ -}}
+{{- if not (include "llm-d-async.transport" .) }}
+{{- fail "No transport configured: set ap.transport (redis-pubsub|redis-sortedset|gcp-pubsub) with ap.transportConfig, or enable a backend via ap.redis.enabled / ap.gcpPubSub.enabled (deprecated)." }}
+{{- end }}
+{{- if .Values.ap.transport }}
+{{- /* New transport surface. */ -}}
+{{- if not .Values.ap.transportConfig }}
+{{- fail "ap.transport is set but ap.transportConfig is empty: provide the transport configuration document (see the README 'Transport Configuration' section)." }}
+{{- end }}
+{{- if and (hasPrefix "redis" .Values.ap.transport) (not (hasKey .Values.ap.transportConfig "url")) (not (include "llm-d-async.redisSecretName" .)) }}
+{{- fail "redis transport has no connection: set url in ap.transportConfig, or set ap.redis.url / ap.redis.secretName to inject REDIS_URL." }}
+{{- end }}
+{{- else }}
+{{- /* Deprecated per-backend surface. */ -}}
 {{- if .Values.ap.redis.enabled }}
 {{- if and (not .Values.ap.redis.url) (not .Values.ap.redis.secretName) }}
 {{- fail "ap.redis is enabled but no connection is configured: set ap.redis.url, or set ap.redis.secretName/ap.redis.secretKey to reference an existing Secret." }}
@@ -15,6 +28,10 @@
 {{- fail "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-queue igw_base_url entries via ap.redis.queuesConfig." }}
 {{- else if and .Values.ap.gcpPubSub.enabled (not .Values.ap.gcpPubSub.topicsConfig) }}
 {{- fail "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-topic igw_base_url entries via ap.gcpPubSub.topicsConfig." }}
+{{- end }}
+{{- end }}
+{{- if and .Values.ap.redis.enabled (eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset") .Values.ap.redis.queuesConfig .Values.ap.redis.gateType }}
+{{- fail "Cannot set both queuesConfig and gateType. Use queuesConfig with per-queue gate_type instead." }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1
@@ -43,69 +60,13 @@ spec:
         # Must match the binary produced by the Dockerfile (ENTRYPOINT /llm-d-async).
         - /llm-d-async
         args:
-          {{- if .Values.ap.redis.enabled }}
-          {{- if eq (.Values.ap.messageQueueImpl | default "redis-pubsub") "redis-sortedset" }}
-          - --message-queue-impl=redis-sortedset
-          {{- if and .Values.ap.redis.queuesConfig .Values.ap.redis.gateType }}
-          {{- fail "Cannot set both queuesConfig and gateType. Use queuesConfig with per-queue gate_type instead." }}
-          {{- end }}
-          {{- if .Values.ap.redis.queuesConfig }}
-          - --redis.ss.queues-config
-          - {{ .Values.ap.redis.queuesConfig | toJson | quote }}
-          {{- else }}
-          - --redis.ss.igw-base-url={{ .Values.ap.igwBaseURL }}
-          - --redis.ss.request-path-url
-          - "{{ .Values.ap.redis.requestPathURL }}"
-          - --redis.ss.request-queue-name
-          - "{{ .Values.ap.redis.requestQueueName | default "request-sortedset" }}"
-          {{- if .Values.ap.redis.gateType }}
-          - --redis.ss.gate-type={{ .Values.ap.redis.gateType }}
-          - --redis.ss.gate-params={{ include "llm-d-async.gateParamsJson" . }}
-          {{- end }}
-          {{- end }}
-          - --redis.ss.result-queue-name
-          - "{{ .Values.ap.redis.resultQueueName | default "result-list" }}"
-          - --redis.ss.poll-interval-ms
-          - "{{ .Values.ap.redis.pollIntervalMs | default 1000 }}"
-          - --redis.ss.batch-size
-          - "{{ .Values.ap.redis.batchSize | default 10 }}"
-          {{- else }}
-          - --message-queue-impl=redis-pubsub
-          {{- if .Values.ap.redis.queuesConfig }}
-          - --redis.queues-config
-          - {{ .Values.ap.redis.queuesConfig | toJson | quote }}
-          {{- else }}
-          - --redis.igw-base-url={{ .Values.ap.igwBaseURL }}
-          - --redis.request-path-url
-          - "{{ .Values.ap.redis.requestPathURL }}"
-          {{- end }}
-          {{- end }}
-          {{- else if .Values.ap.gcpPubSub.enabled }}
-          {{- /* Honor an explicit gcp-pubsub* messageQueueImpl; otherwise auto-select
-                 gcp-pubsub-gated when any topic declares a gate_type (per-topic gates
-                 only take effect in gated mode). */}}
-          {{- $mqImpl := "gcp-pubsub" }}
-          {{- if and .Values.ap.messageQueueImpl (hasPrefix "gcp-pubsub" .Values.ap.messageQueueImpl) }}
-          {{- $mqImpl = .Values.ap.messageQueueImpl }}
-          {{- else }}
-          {{- range .Values.ap.gcpPubSub.topicsConfig }}
-          {{- if .gate_type }}{{- $mqImpl = "gcp-pubsub-gated" }}{{- end }}
-          {{- end }}
-          {{- end }}
-          - --message-queue-impl={{ $mqImpl }}
-          {{- if .Values.ap.gcpPubSub.projectId }}
-          - --pubsub.project-id={{ .Values.ap.gcpPubSub.projectId }}
-          {{- end }}
-          - --pubsub.result-topic-id={{ .Values.ap.gcpPubSub.resultTopicId }}
-          {{- if .Values.ap.gcpPubSub.topicsConfig }}
-          - --pubsub.topics-config-file=/etc/llm-d-async/config/pubsub-topics.json
-          {{- else }}
-          - --pubsub.igw-base-url={{ .Values.ap.igwBaseURL }}
-          - --pubsub.request-subscriber-id={{ .Values.ap.gcpPubSub.requestSubscriberId }}
-          - --pubsub.request-path-url
-          - "{{ .Values.ap.gcpPubSub.requestPathURL }}"
-          {{- end }}
-          {{- end }}
+          {{- /* Unified transport surface. On the deprecated per-backend values the
+                 config is synthesized from them (see _helpers.tpl), so the processor
+                 never receives the retired --message-queue-impl / --redis.* / --pubsub.*
+                 flags regardless of which values the operator sets. */}}
+          - --transport={{ include "llm-d-async.transport" . }}
+          - --transport-config
+          - {{ include "llm-d-async.transportConfig" . | quote }}
           {{- if .Values.ap.prometheusURL }}
           - --prometheus-url={{ .Values.ap.prometheusURL }}
           {{- end }}
@@ -119,16 +80,13 @@ spec:
           - --transform-config-file=/etc/llm-d-async/config/transform-config.json
           {{- end }}
           {{- if .Values.ap.requestMergePolicyConfig }}
-          - --request-merge-policy-config=/etc/llm-d-async/config/request-merge-policy.json
+          - --request-merge-policy-config-file=/etc/llm-d-async/config/request-merge-policy.json
           {{- end }}
           - --concurrency={{ .Values.ap.concurrency | default 64 }}
           - --drain-timeout={{ .Values.ap.drainTimeout | default "2m" }}
           - --health-port={{ .Values.ap.health.port | default 8081 }}
           - --metrics-endpoint-auth={{ .Values.ap.metrics.secure }}
           - --metrics-port={{ .Values.ap.metrics.port | default 9090 }}
-          {{- if and .Values.ap.otel.redisTracing .Values.ap.otel.endpoint }}
-          - --redis-tracing=true
-          {{- end }}
           {{- if .Values.ap.tls.insecureSkipVerify }}
           - --tls-insecure-skip-verify=true
           {{- end }}
@@ -166,7 +124,7 @@ spec:
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: "k8s.namespace.name=$(NAMESPACE),k8s.pod.name=$(POD_NAME),service.version={{ .Chart.AppVersion }}"
           {{- end }}
-          {{- if .Values.ap.redis.enabled }}
+          {{- if and (hasPrefix "redis" (include "llm-d-async.transport" .)) (include "llm-d-async.redisSecretName" .) }}
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:
@@ -213,9 +171,9 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig .Values.ap.tls.secretName }}
+        {{- if or .Values.ap.workerPools .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig .Values.ap.tls.secretName }}
         volumeMounts:
-          {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
+          {{- if or .Values.ap.workerPools .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
           - name: ap-config
             mountPath: /etc/llm-d-async/config
             readOnly: true
@@ -228,9 +186,9 @@ spec:
         {{- end }}
       serviceAccountName: {{ include "llm-d-async.fullname" . }}
       terminationGracePeriodSeconds: 130
-      {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig .Values.ap.tls.secretName }}
+      {{- if or .Values.ap.workerPools .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig .Values.ap.tls.secretName }}
       volumes:
-        {{- if or .Values.ap.workerPools .Values.ap.gcpPubSub.topicsConfig .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
+        {{- if or .Values.ap.workerPools .Values.ap.transformConfig .Values.ap.requestMergePolicyConfig }}
         - name: ap-config
           configMap:
             name: {{ include "llm-d-async.fullname" . }}-config

--- a/charts/llm-d-async/templates/ap-deployments.yaml
+++ b/charts/llm-d-async/templates/ap-deployments.yaml
@@ -10,7 +10,7 @@
 {{- fail "ap.transport is set but ap.transportConfig is empty: provide the transport configuration document (see the README 'Transport Configuration' section)." }}
 {{- end }}
 {{- if and (hasPrefix "redis" .Values.ap.transport) (not (hasKey .Values.ap.transportConfig "url")) (not (include "llm-d-async.redisSecretName" .)) }}
-{{- fail "redis transport has no connection: set url in ap.transportConfig, or set ap.redis.url / ap.redis.secretName to inject REDIS_URL." }}
+{{- fail "redis transport has no connection: set url or urlSecret ({name,key}) in ap.transportConfig, or (legacy) ap.redis.url / ap.redis.secretName. urlSecret/secretName reference an existing Secret injected as REDIS_URL." }}
 {{- end }}
 {{- else }}
 {{- /* Deprecated per-backend surface. */ -}}

--- a/charts/llm-d-async/templates/ap-deployments.yaml
+++ b/charts/llm-d-async/templates/ap-deployments.yaml
@@ -10,7 +10,7 @@
 {{- fail "ap.transport is set but ap.transportConfig is empty: provide the transport configuration document (see the README 'Transport Configuration' section)." }}
 {{- end }}
 {{- if and (hasPrefix "redis" .Values.ap.transport) (not (hasKey .Values.ap.transportConfig "url")) (not (include "llm-d-async.redisSecretName" .)) }}
-{{- fail "redis transport has no connection: set url or urlSecret ({name,key}) in ap.transportConfig, or (legacy) ap.redis.url / ap.redis.secretName. urlSecret/secretName reference an existing Secret injected as REDIS_URL." }}
+{{- fail "redis transport has no connection: set ap.transportConfig.urlSecret.url (chart creates a Secret) or ap.transportConfig.urlSecret.name/key (reference an existing Secret), or an inline url in ap.transportConfig (dev only). The deprecated ap.redis.url / ap.redis.secretName still work. The resolved Secret is injected as REDIS_URL." }}
 {{- end }}
 {{- else }}
 {{- /* Deprecated per-backend surface. */ -}}

--- a/charts/llm-d-async/templates/redis-secret.yaml
+++ b/charts/llm-d-async/templates/redis-secret.yaml
@@ -1,11 +1,13 @@
 {{- /* Create the connection Secret when a literal URL is supplied, either on the
        new surface (ap.transportConfig.urlSecret.url) or via the deprecated
        ap.redis.url. A referenced Secret (urlSecret.name / redis.secretName) is
-       not created here. */ -}}
+       not created here. Only emit it when the effective transport is Redis so a
+       non-Redis backend (e.g. gcp-pubsub) never stores an unused Redis URL. */ -}}
+{{- $transport := include "llm-d-async.transport" . -}}
 {{- $newURL := "" -}}
 {{- if .Values.ap.transport -}}{{- $newURL = dig "urlSecret" "url" "" (.Values.ap.transportConfig | default dict) -}}{{- end -}}
 {{- $url := $newURL | default .Values.ap.redis.url -}}
-{{- if $url }}
+{{- if and (hasPrefix "redis" $transport) $url }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/llm-d-async/templates/redis-secret.yaml
+++ b/charts/llm-d-async/templates/redis-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ap.redis.enabled .Values.ap.redis.url }}
+{{- if .Values.ap.redis.url }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/llm-d-async/templates/redis-secret.yaml
+++ b/charts/llm-d-async/templates/redis-secret.yaml
@@ -1,4 +1,11 @@
-{{- if .Values.ap.redis.url }}
+{{- /* Create the connection Secret when a literal URL is supplied, either on the
+       new surface (ap.transportConfig.urlSecret.url) or via the deprecated
+       ap.redis.url. A referenced Secret (urlSecret.name / redis.secretName) is
+       not created here. */ -}}
+{{- $newURL := "" -}}
+{{- if .Values.ap.transport -}}{{- $newURL = dig "urlSecret" "url" "" (.Values.ap.transportConfig | default dict) -}}{{- end -}}
+{{- $url := $newURL | default .Values.ap.redis.url -}}
+{{- if $url }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +15,5 @@ metadata:
     {{- include "llm-d-async.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  url: {{ .Values.ap.redis.url | quote }}
+  url: {{ $url | quote }}
 {{- end }}

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -213,6 +213,41 @@ tests:
                 key: url
           any: true
 
+  - it: should inject REDIS_URL from transportConfig.urlSecret and strip it from the config
+    set:
+      ap.redis.secretName: ""
+      ap.transportConfig.urlSecret.name: my-redis
+      ap.transportConfig.urlSecret.key: conn
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-redis
+                key: conn
+          any: true
+      # urlSecret is a chart directive; it must not leak into --transport-config
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: urlSecret
+
+  - it: should default urlSecret key to url when omitted
+    set:
+      ap.redis.secretName: ""
+      ap.transportConfig.urlSecret.name: my-redis
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-redis
+                key: url
+          any: true
+
   - it: should not inject REDIS_URL for a gcp-pubsub transport
     set:
       ap.redis.secretName: ""

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -248,6 +248,22 @@ tests:
                 key: url
           any: true
 
+  - it: should default urlSecret key to url when explicitly empty
+    set:
+      ap.redis.secretName: ""
+      ap.transportConfig.urlSecret.name: my-redis
+      ap.transportConfig.urlSecret.key: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-redis
+                key: url
+          any: true
+
   - it: should inject REDIS_URL from the chart-created Secret when urlSecret.url is set
     set:
       ap.redis.secretName: ""

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -248,6 +248,25 @@ tests:
                 key: url
           any: true
 
+  - it: should inject REDIS_URL from the chart-created Secret when urlSecret.url is set
+    set:
+      ap.redis.secretName: ""
+      ap.transportConfig.urlSecret.url: "redis://inline-secret:6379"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-llm-d-async-redis
+                key: url
+          any: true
+      # the literal URL must not leak into --transport-config args
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: inline-secret
+
   - it: should not inject REDIS_URL for a gcp-pubsub transport
     set:
       ap.redis.secretName: ""

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -1,14 +1,16 @@
 suite: deployment
 templates:
   - templates/ap-deployments.yaml
-# Suite-level defaults satisfy the chart's fail-fast validation (igwBaseURL,
-# a Redis connection, and a Pub/Sub projectId) so positive tests render.
-# Individual tests override these to exercise the validation guards.
+# Suite-level defaults use the recommended transport surface (ap.transport +
+# ap.transportConfig) and a Redis connection Secret so REDIS_URL is injected.
+# Individual tests override these to exercise other backends and the guards.
 set:
-  ap.redis.enabled: true
+  ap.transport: redis-pubsub
+  ap.transportConfig:
+    queues:
+      - queue_name: request-queue
+        igw_base_url: "http://igw:80"
   ap.redis.secretName: "redis-creds"
-  ap.igwBaseURL: "http://igw:80"
-  ap.gcpPubSub.projectId: "test-project"
 tests:
   - it: should render a Deployment
     asserts:
@@ -134,30 +136,99 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --metrics-port=8080
 
-  - it: should configure redis-pubsub by default when redis enabled
+  # --- Transport surface (ap.transport + ap.transportConfig) ---------------
+  - it: should select the configured transport
     asserts:
       - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport=redis-pubsub
+
+  - it: should pass the transport config document as an inline arg
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport-config
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"queue_name":"request-queue"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"igw_base_url":"http://igw:80"'
+
+  - it: should not emit any deprecated per-backend flags
+    asserts:
+      - notContains:
           path: spec.template.spec.containers[0].args
           content: --message-queue-impl=redis-pubsub
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redis.igw-base-url=http://igw:80
 
-  - it: should configure redis-sortedset when specified
+  - it: should select redis-sortedset
     set:
-      ap.messageQueueImpl: redis-sortedset
+      ap.transport: redis-sortedset
+      ap.transportConfig:
+        poll_interval_ms: 500
+        queues:
+          - queue_name: request-sortedset
+            igw_base_url: "http://igw:80"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=redis-sortedset
+          content: --transport=redis-sortedset
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"poll_interval_ms":500'
 
-  - it: should configure GCP Pub/Sub when enabled
+  - it: should select gcp-pubsub and pass its config
     set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.requestSubscriberId: "test-sub"
-      ap.gcpPubSub.resultTopicId: "test-topic"
+      ap.redis.secretName: ""
+      ap.transport: gcp-pubsub
+      ap.transportConfig:
+        project_id: my-project
+        result_topic_id: results
+        topics:
+          - subscriber_id: sub-1
+            igw_base_url: "http://igw:80"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=gcp-pubsub
+          content: --transport=gcp-pubsub
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"project_id":"my-project"'
+
+  - it: should inject REDIS_URL from the created Secret when redis.url is set
+    set:
+      ap.redis.secretName: ""
+      ap.redis.url: "redis://redis-master.redis.svc:6379"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-llm-d-async-redis
+                key: url
+          any: true
+
+  - it: should not inject REDIS_URL for a gcp-pubsub transport
+    set:
+      ap.redis.secretName: ""
+      ap.transport: gcp-pubsub
+      ap.transportConfig:
+        project_id: my-project
+        result_topic_id: results
+        topics:
+          - subscriber_id: sub-1
+            igw_base_url: "http://igw:80"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+          any: true
 
   - it: should default the image to the published repo with the appVersion tag
     asserts:
@@ -173,69 +244,18 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/llm-d/llm-d-async:v1.2.3
 
-  - it: should render --pubsub.project-id when projectId is set
+  - it: should not require a Secret when url is inline in transportConfig
     set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.projectId: "my-project"
-      ap.gcpPubSub.requestSubscriberId: "test-sub"
-      ap.gcpPubSub.resultTopicId: "test-topic"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --pubsub.project-id=my-project
-
-  - it: should fail when gcp-pubsub is enabled without a projectId
-    set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.projectId: ""
-      ap.gcpPubSub.requestSubscriberId: "test-sub"
-      ap.gcpPubSub.resultTopicId: "test-topic"
-    asserts:
-      - failedTemplate:
-          errorMessage: "ap.gcpPubSub is enabled but ap.gcpPubSub.projectId is empty: the GCP Pub/Sub backend requires a project ID (the process panics on startup without it)."
-
-  - it: should fail when redis is enabled with no url and no secretName
-    set:
-      ap.redis.enabled: true
-      ap.redis.url: ""
       ap.redis.secretName: ""
-    asserts:
-      - failedTemplate:
-          errorMessage: "ap.redis is enabled but no connection is configured: set ap.redis.url, or set ap.redis.secretName/ap.redis.secretKey to reference an existing Secret."
-
-  - it: should fail when igwBaseURL is empty in single-queue redis mode
-    set:
-      ap.redis.enabled: true
-      ap.igwBaseURL: ""
-    asserts:
-      - failedTemplate:
-          errorMessage: "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-queue igw_base_url entries via ap.redis.queuesConfig."
-
-  - it: should fail when igwBaseURL is empty in single-topic gcp-pubsub mode
-    set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.igwBaseURL: ""
-      ap.gcpPubSub.resultTopicId: "test-topic"
-    asserts:
-      - failedTemplate:
-          errorMessage: "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-topic igw_base_url entries via ap.gcpPubSub.topicsConfig."
-
-  - it: should not require igwBaseURL when redis queuesConfig is set
-    set:
-      ap.redis.enabled: true
-      ap.messageQueueImpl: "redis-sortedset"
-      ap.igwBaseURL: ""
-      ap.redis.queuesConfig:
-        - queue_name: "queue-1"
-          igw_base_url: "http://igw-1:80"
-          request_path_url: "/v1/completions"
+      ap.transportConfig:
+        url: "redis://inline:6379"
+        queues:
+          - queue_name: request-queue
+            igw_base_url: "http://igw:80"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --redis.ss.queues-config
+          content: --transport=redis-pubsub
 
   - it: should inject OTel env vars when endpoint is set
     set:
@@ -279,22 +299,12 @@ tests:
             secret:
               secretName: my-tls-secret
 
-  - it: should not mount TLS volume when secretName is empty
+  - it: should not mount any volume by default
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].volumeMounts
       - isNull:
           path: spec.template.spec.volumes
-
-  - it: should fail when queuesConfig and gateType are both set
-    set:
-      ap.messageQueueImpl: redis-sortedset
-      ap.redis.gateType: prometheus-saturation
-      ap.redis.queuesConfig:
-        - queue_name: q1
-    asserts:
-      - failedTemplate:
-          errorMessage: "Cannot set both queuesConfig and gateType. Use queuesConfig with per-queue gate_type instead."
 
   - it: should mount config volume and pass pool-config-file when workerPools are set
     set:
@@ -317,81 +327,6 @@ tests:
             name: ap-config
             configMap:
               name: RELEASE-NAME-llm-d-async-config
-
-  - it: should mount config volume and pass pubsub.topics-config-file when GCP PubSub topicsConfig is set
-    set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.resultTopicId: "test-result-topic"
-      ap.gcpPubSub.topicsConfig:
-        - subscriber_id: "sub-1"
-          igw_base_url: "http://igw:80"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --pubsub.topics-config-file=/etc/llm-d-async/config/pubsub-topics.json
-      - contains:
-          path: spec.template.spec.containers[0].volumeMounts
-          content:
-            name: ap-config
-            mountPath: /etc/llm-d-async/config
-            readOnly: true
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: ap-config
-            configMap:
-              name: RELEASE-NAME-llm-d-async-config
-
-  - it: should auto-select gcp-pubsub-gated when a topic declares a gate_type
-    set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.resultTopicId: "test-result-topic"
-      ap.gcpPubSub.topicsConfig:
-        - subscriber_id: "sub-1"
-          igw_base_url: "http://igw:80"
-          gate_type: "redis-quota"
-          gate_params:
-            address: "redis:6379"
-            attribute: "team"
-            mode: "concurrency"
-            limit: "5"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=gcp-pubsub-gated
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=gcp-pubsub
-
-  - it: should keep plain gcp-pubsub when no topic declares a gate_type
-    set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.resultTopicId: "test-result-topic"
-      ap.gcpPubSub.topicsConfig:
-        - subscriber_id: "sub-1"
-          igw_base_url: "http://igw:80"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=gcp-pubsub
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=gcp-pubsub-gated
-
-  - it: should honor an explicit gcp-pubsub-gated messageQueueImpl override
-    set:
-      ap.redis.enabled: false
-      ap.gcpPubSub.enabled: true
-      ap.gcpPubSub.requestSubscriberId: "test-sub"
-      ap.gcpPubSub.resultTopicId: "test-topic"
-      ap.messageQueueImpl: "gcp-pubsub-gated"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --message-queue-impl=gcp-pubsub-gated
 
   - it: should pass transform-config-file and mount the config when transformConfig is set
     set:
@@ -441,3 +376,15 @@ tests:
           value: Exists
       - notExists:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values
+
+  - it: should pass the renamed request-merge-policy-config-file flag
+    set:
+      ap.requestMergePolicyConfig:
+        type: random-robin
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --request-merge-policy-config-file=/etc/llm-d-async/config/request-merge-policy.json
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --request-merge-policy-config=/etc/llm-d-async/config/request-merge-policy.json

--- a/charts/llm-d-async/tests/deprecated_transport_test.yaml
+++ b/charts/llm-d-async/tests/deprecated_transport_test.yaml
@@ -1,0 +1,193 @@
+suite: deprecated transport values (backwards compatibility)
+# The deprecated per-backend selectors (ap.redis.enabled / ap.gcpPubSub.enabled /
+# ap.messageQueueImpl and the ap.redis.* / ap.gcpPubSub.* request fields,
+# ap.otel.redisTracing) still work: the chart translates them into the unified
+# --transport / --transport-config surface and never emits the retired flags.
+templates:
+  - templates/ap-deployments.yaml
+tests:
+  - it: redis.enabled defaults to the redis-pubsub transport
+    set:
+      ap.redis.enabled: true
+      ap.redis.secretName: "redis-creds"
+      ap.igwBaseURL: "http://igw:80"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport=redis-pubsub
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"queue_name":"request-queue"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"igw_base_url":"http://igw:80"'
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=redis-pubsub
+
+  - it: messageQueueImpl redis-sortedset selects the sorted-set transport
+    set:
+      ap.redis.enabled: true
+      ap.messageQueueImpl: redis-sortedset
+      ap.redis.secretName: "redis-creds"
+      ap.igwBaseURL: "http://igw:80"
+      ap.redis.resultQueueName: "result-list"
+      ap.redis.pollIntervalMs: 500
+      ap.redis.batchSize: 20
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport=redis-sortedset
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"queue_name":"request-sortedset"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"poll_interval_ms":500'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"batch_size":20'
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=redis-sortedset
+
+  - it: single-queue sorted-set gate is translated into the queue entry
+    set:
+      ap.redis.enabled: true
+      ap.messageQueueImpl: redis-sortedset
+      ap.redis.secretName: "redis-creds"
+      ap.igwBaseURL: "http://igw:80"
+      ap.redis.gateType: prometheus-saturation
+      ap.redis.gateParams:
+        pool: p1
+        threshold: 0.7
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"gate_type":"prometheus-saturation"'
+      # gate_params values are rendered as strings for the params parser.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"threshold":"0.7"'
+
+  - it: redisTracing is translated into enable_tracing
+    set:
+      ap.redis.enabled: true
+      ap.messageQueueImpl: redis-sortedset
+      ap.redis.secretName: "redis-creds"
+      ap.igwBaseURL: "http://igw:80"
+      ap.otel.endpoint: "http://otel:4317"
+      ap.otel.redisTracing: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"enable_tracing":true'
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redis-tracing=true
+
+  - it: redis queuesConfig is passed through as the queues array
+    set:
+      ap.redis.enabled: true
+      ap.messageQueueImpl: redis-sortedset
+      ap.redis.secretName: "redis-creds"
+      ap.igwBaseURL: ""
+      ap.redis.queuesConfig:
+        - queue_name: "queue-1"
+          igw_base_url: "http://igw-1:80"
+          request_path_url: "/v1/completions"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport=redis-sortedset
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"queue_name":"queue-1"'
+
+  - it: gcpPubSub.enabled with a topics gate maps to gcp-pubsub (no more gated impl)
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.projectId: "test-project"
+      ap.gcpPubSub.resultTopicId: "test-result-topic"
+      ap.gcpPubSub.topicsConfig:
+        - subscriber_id: "sub-1"
+          igw_base_url: "http://igw:80"
+          gate_type: "redis-quota"
+          gate_params:
+            address: "redis:6379"
+            limit: "5"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport=gcp-pubsub
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '"gate_type":"redis-quota"'
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub-gated
+
+  - it: deprecated gcp-pubsub-gated messageQueueImpl maps to gcp-pubsub
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.projectId: "test-project"
+      ap.gcpPubSub.resultTopicId: "test-topic"
+      ap.gcpPubSub.requestSubscriberId: "test-sub"
+      ap.igwBaseURL: "http://igw:80"
+      ap.messageQueueImpl: "gcp-pubsub-gated"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --transport=gcp-pubsub
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --message-queue-impl=gcp-pubsub-gated
+
+  # Deprecated-path fail-fast guards are preserved.
+  - it: should fail when redis is enabled with no url and no secretName
+    set:
+      ap.redis.enabled: true
+      ap.redis.url: ""
+      ap.redis.secretName: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.redis is enabled but no connection is configured: set ap.redis.url, or set ap.redis.secretName/ap.redis.secretKey to reference an existing Secret."
+
+  - it: should fail when gcp-pubsub is enabled without a projectId
+    set:
+      ap.redis.enabled: false
+      ap.gcpPubSub.enabled: true
+      ap.gcpPubSub.projectId: ""
+      ap.gcpPubSub.requestSubscriberId: "test-sub"
+      ap.gcpPubSub.resultTopicId: "test-topic"
+      ap.igwBaseURL: "http://igw:80"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.gcpPubSub is enabled but ap.gcpPubSub.projectId is empty: the GCP Pub/Sub backend requires a project ID (the process panics on startup without it)."
+
+  - it: should fail when igwBaseURL is empty in single-queue redis mode
+    set:
+      ap.redis.enabled: true
+      ap.redis.secretName: "redis-creds"
+      ap.igwBaseURL: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.igwBaseURL is required: set it to your inference gateway base URL, or provide per-queue igw_base_url entries via ap.redis.queuesConfig."
+
+  - it: should fail when queuesConfig and gateType are both set
+    set:
+      ap.redis.enabled: true
+      ap.redis.secretName: "redis-creds"
+      ap.messageQueueImpl: redis-sortedset
+      ap.redis.gateType: prometheus-saturation
+      ap.redis.queuesConfig:
+        - queue_name: q1
+          igw_base_url: "http://igw:80"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Cannot set both queuesConfig and gateType. Use queuesConfig with per-queue gate_type instead."

--- a/charts/llm-d-async/tests/observability_test.yaml
+++ b/charts/llm-d-async/tests/observability_test.yaml
@@ -1,4 +1,13 @@
 suite: observability
+# A minimal transport is required for the chart to render (the Deployment
+# fail-fasts otherwise); these suites assert on the monitoring templates only.
+set:
+  ap.transport: redis-pubsub
+  ap.transportConfig:
+    queues:
+      - queue_name: request-queue
+        igw_base_url: "http://igw:80"
+  ap.redis.secretName: "redis-creds"
 tests:
   # -- PodMonitor --
   - it: should not render PodMonitor by default

--- a/charts/llm-d-async/tests/redis_secret_test.yaml
+++ b/charts/llm-d-async/tests/redis_secret_test.yaml
@@ -48,3 +48,15 @@ tests:
       - equal:
           path: stringData.url
           value: "redis://legacy:6379"
+
+  - it: does not create a Redis Secret for a non-Redis transport
+    set:
+      ap.transport: gcp-pubsub
+      ap.transportConfig:
+        urlSecret:
+          url: "redis://created:6379"
+        project_id: my-project
+        result_topic_id: results
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/llm-d-async/tests/redis_secret_test.yaml
+++ b/charts/llm-d-async/tests/redis_secret_test.yaml
@@ -1,0 +1,50 @@
+suite: redis connection secret
+templates:
+  - templates/redis-secret.yaml
+tests:
+  - it: creates the Secret from transportConfig.urlSecret.url (new surface)
+    set:
+      ap.transport: redis-sortedset
+      ap.transportConfig:
+        urlSecret:
+          url: "redis://created:6379"
+        queues:
+          - queue_name: q
+            igw_base_url: "http://igw:80"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-llm-d-async-redis
+      - equal:
+          path: stringData.url
+          value: "redis://created:6379"
+
+  - it: does not create a Secret when urlSecret references an existing one
+    set:
+      ap.transport: redis-sortedset
+      ap.transportConfig:
+        urlSecret:
+          name: my-existing
+        queues:
+          - queue_name: q
+            igw_base_url: "http://igw:80"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still creates the Secret from the deprecated ap.redis.url
+    set:
+      ap.transport: redis-sortedset
+      ap.transportConfig:
+        queues:
+          - queue_name: q
+            igw_base_url: "http://igw:80"
+      ap.redis.url: "redis://legacy:6379"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.url
+          value: "redis://legacy:6379"

--- a/charts/llm-d-async/tests/validation_test.yaml
+++ b/charts/llm-d-async/tests/validation_test.yaml
@@ -25,4 +25,4 @@ tests:
             igw_base_url: "http://igw:80"
     asserts:
       - failedTemplate:
-          errorMessage: "redis transport has no connection: set url in ap.transportConfig, or set ap.redis.url / ap.redis.secretName to inject REDIS_URL."
+          errorMessage: "redis transport has no connection: set url or urlSecret ({name,key}) in ap.transportConfig, or (legacy) ap.redis.url / ap.redis.secretName. urlSecret/secretName reference an existing Secret injected as REDIS_URL."

--- a/charts/llm-d-async/tests/validation_test.yaml
+++ b/charts/llm-d-async/tests/validation_test.yaml
@@ -25,4 +25,4 @@ tests:
             igw_base_url: "http://igw:80"
     asserts:
       - failedTemplate:
-          errorMessage: "redis transport has no connection: set url or urlSecret ({name,key}) in ap.transportConfig, or (legacy) ap.redis.url / ap.redis.secretName. urlSecret/secretName reference an existing Secret injected as REDIS_URL."
+          errorMessage: "redis transport has no connection: set ap.transportConfig.urlSecret.url (chart creates a Secret) or ap.transportConfig.urlSecret.name/key (reference an existing Secret), or an inline url in ap.transportConfig (dev only). The deprecated ap.redis.url / ap.redis.secretName still work. The resolved Secret is injected as REDIS_URL."

--- a/charts/llm-d-async/tests/validation_test.yaml
+++ b/charts/llm-d-async/tests/validation_test.yaml
@@ -1,0 +1,28 @@
+suite: transport validation
+# Self-contained (no suite-level defaults) so each test starts from an empty
+# transport configuration and exercises one fail-fast guard.
+templates:
+  - templates/ap-deployments.yaml
+tests:
+  - it: should fail when no transport is configured at all
+    asserts:
+      - failedTemplate:
+          errorMessage: "No transport configured: set ap.transport (redis-pubsub|redis-sortedset|gcp-pubsub) with ap.transportConfig, or enable a backend via ap.redis.enabled / ap.gcpPubSub.enabled (deprecated)."
+
+  - it: should fail when transport is set without a transportConfig
+    set:
+      ap.transport: redis-pubsub
+    asserts:
+      - failedTemplate:
+          errorMessage: "ap.transport is set but ap.transportConfig is empty: provide the transport configuration document (see the README 'Transport Configuration' section)."
+
+  - it: should fail when a redis transport has no connection
+    set:
+      ap.transport: redis-pubsub
+      ap.transportConfig:
+        queues:
+          - queue_name: request-queue
+            igw_base_url: "http://igw:80"
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis transport has no connection: set url in ap.transportConfig, or set ap.redis.url / ap.redis.secretName to inject REDIS_URL."

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -70,7 +70,7 @@ ap:
   #         providers: ["whisper"]
   transformConfig: {}
   # Request merge policy configuration. When set, rendered to a config file and passed
-  # via --request-merge-policy-config.
+  # via --request-merge-policy-config-file.
   requestMergePolicyConfig: {}
   otel:
     # OTLP gRPC endpoint for trace collection. Examples:
@@ -113,13 +113,46 @@ ap:
     enabled: true
     port: 9090
     secure: false
-  # Message queue implementation. Supported: "redis-sortedset", "redis-pubsub",
-  # "gcp-pubsub", "gcp-pubsub-gated". Leave empty to auto-select: redis-pubsub by
-  # default, and for GCP Pub/Sub "gcp-pubsub-gated" when any gcpPubSub.topicsConfig
-  # entry declares a gate_type (per-topic gates only take effect in gated mode),
-  # otherwise "gcp-pubsub".
+  # --- Transport configuration (recommended) --------------------------------
+  # Select the message-queue backend and configure it with a single JSON document,
+  # mirroring the processor's --transport / --transport-config flags. When set,
+  # ap.transport takes precedence over the deprecated per-backend values below
+  # (ap.messageQueueImpl, ap.redis.* / ap.gcpPubSub.* request/queue fields,
+  # ap.otel.redisTracing).
+  #
+  # transport: one of redis-pubsub, redis-sortedset, gcp-pubsub.
+  # transportConfig: the transport-specific document. See the project README
+  #   "Transport Configuration" section for the schema. For the Redis transports
+  #   leave "url" unset and provide credentials via ap.redis.url / ap.redis.secretName
+  #   (injected as REDIS_URL) -- an explicit "url" here is rendered into the pod args.
+  # Example (redis-sortedset):
+  #   transport: redis-sortedset
+  #   transportConfig:
+  #     result_queue_name: result-list
+  #     poll_interval_ms: 1000
+  #     batch_size: 10
+  #     queues:
+  #       - queue_name: request-sortedset
+  #         request_path_url: /v1/completions
+  #         igw_base_url: http://igw:80
+  #         gate_type: prometheus-budget
+  #         gate_params:
+  #           pool: my-pool
+  #           max_concurrency: "100"
+  #           baseline: "0.05"
+  transport: ""
+  transportConfig: {}
+
+  # DEPRECATED: prefer ap.transport + ap.transportConfig above. Retained so
+  # existing values keep working -- the chart translates them into the transport
+  # config and the install notes print a migration warning. Message queue
+  # implementation. Supported: "redis-sortedset", "redis-pubsub", "gcp-pubsub",
+  # "gcp-pubsub-gated" ("gcp-pubsub-gated" is treated as "gcp-pubsub"; a per-topic
+  # gate_type now gates natively). Empty selects redis-pubsub.
   messageQueueImpl: ""
   gcpPubSub:
+    # DEPRECATED selector: prefer ap.transport: gcp-pubsub with ap.transportConfig.
+    # The request/topic fields below are translated into the transport config.
     enabled: false
     # GCP project ID for the Pub/Sub client. Required for the gcp-pubsub backends:
     # the process panics on startup ("projectID string is empty") if unset.
@@ -148,6 +181,10 @@ ap:
     certKey: ""
     keyKey: ""
   redis:
+    # DEPRECATED selector: prefer ap.transport: redis-pubsub|redis-sortedset with
+    # ap.transportConfig. The request/queue fields below are translated into the
+    # transport config; the connection fields (url/secretName/secretKey) still apply
+    # on the new surface and are injected as REDIS_URL.
     enabled: false
     # Compatible with any Redis-protocol server including Valkey.
     # All redis.* fields work unchanged when pointed at a Valkey endpoint.

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -123,12 +123,14 @@ ap:
   # transport: one of redis-pubsub, redis-sortedset, gcp-pubsub.
   # transportConfig: the transport-specific document. See the project README
   #   "Transport Configuration" section for the schema.
-  #   Redis/Valkey connection: DO NOT put a credentialed "url" here -- inline values
-  #   are rendered into the pod args (visible via `kubectl get pod` / `helm get values`).
-  #   Instead reference an existing Secret with transportConfig.urlSecret; the chart
-  #   injects it as the REDIS_URL env var and leaves "url" out of the args. urlSecret
-  #   is a chart-only directive and is stripped before the config reaches the processor.
-  #   (An inline "url" and the legacy ap.redis.url / ap.redis.secretName still work.)
+  #   Redis/Valkey connection: DO NOT put a credentialed "url" directly in
+  #   transportConfig -- inline values are rendered into the pod args (visible via
+  #   `kubectl get pod` / `helm get values`). Use transportConfig.urlSecret instead;
+  #   the chart injects it as the REDIS_URL env var and keeps it out of the args.
+  #   urlSecret is a chart-only directive, stripped before the config reaches the
+  #   processor. Two forms:
+  #     urlSecret: {name: <secret>, key: url}  # reference an existing Secret
+  #     urlSecret: {url: "redis://..."}        # chart creates the Secret for you
   # Example (redis-sortedset):
   #   transport: redis-sortedset
   #   transportConfig:
@@ -188,10 +190,10 @@ ap:
     certKey: ""
     keyKey: ""
   redis:
-    # DEPRECATED selector: prefer ap.transport: redis-pubsub|redis-sortedset with
-    # ap.transportConfig. The request/queue fields below are translated into the
-    # transport config; the connection fields (url/secretName/secretKey) still apply
-    # on the new surface and are injected as REDIS_URL.
+    # DEPRECATED (whole block): prefer ap.transport + ap.transportConfig. The
+    # request/queue fields are translated into the transport config; the connection
+    # fields (url/secretName/secretKey) are superseded by ap.transportConfig.urlSecret.
+    # All still work for backwards compatibility and emit a migration warning.
     enabled: false
     # Compatible with any Redis-protocol server including Valkey.
     # All redis.* fields work unchanged when pointed at a Valkey endpoint.

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -122,12 +122,19 @@ ap:
   #
   # transport: one of redis-pubsub, redis-sortedset, gcp-pubsub.
   # transportConfig: the transport-specific document. See the project README
-  #   "Transport Configuration" section for the schema. For the Redis transports
-  #   leave "url" unset and provide credentials via ap.redis.url / ap.redis.secretName
-  #   (injected as REDIS_URL) -- an explicit "url" here is rendered into the pod args.
+  #   "Transport Configuration" section for the schema.
+  #   Redis/Valkey connection: DO NOT put a credentialed "url" here -- inline values
+  #   are rendered into the pod args (visible via `kubectl get pod` / `helm get values`).
+  #   Instead reference an existing Secret with transportConfig.urlSecret; the chart
+  #   injects it as the REDIS_URL env var and leaves "url" out of the args. urlSecret
+  #   is a chart-only directive and is stripped before the config reaches the processor.
+  #   (An inline "url" and the legacy ap.redis.url / ap.redis.secretName still work.)
   # Example (redis-sortedset):
   #   transport: redis-sortedset
   #   transportConfig:
+  #     urlSecret:
+  #       name: my-redis-secret   # existing Secret holding the connection URL
+  #       key: url                # key within that Secret (default: url)
   #     result_queue_name: result-list
   #     poll_interval_ms: 1000
   #     batch_size: 10

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -164,7 +164,11 @@ helm install llm-d-async ${ASYNC_REPO}/charts/llm-d-async/ \
 
 The values file (`docs/guides/e2e-deploy/llm-d-async-values.yaml`) configures:
 - Image: `ghcr.io/llm-d/llm-d-async:938cd44`
-- Queue: `redis-sortedset` transport, `redis.url` set directly (chart creates the Secret and injects it as `REDIS_URL`), configured via `transport` / `transportConfig`
+- Queue: `redis-sortedset` transport, configured via `transport` / `transportConfig`.
+  Connection: `transportConfig.urlSecret.url` — the chart creates a Secret from the URL and
+  injects it as `REDIS_URL` (kept out of the pod args). This dev Redis is unauthenticated;
+  for a **credentialed or production** Redis, reference an existing Secret instead with
+  `ap.transportConfig.urlSecret: {name: <secret>, key: url}`
 - Gate: `prometheus-budget` with pool=`optimized-baseline`, max_concurrency=100, baseline=0.05 (per-queue).
   `max_concurrency` is a **per ready pod** capacity — see [Size `max_concurrency` for your pool](#size-max_concurrency-for-your-pool)
   before reusing this value on your own model

--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -164,7 +164,7 @@ helm install llm-d-async ${ASYNC_REPO}/charts/llm-d-async/ \
 
 The values file (`docs/guides/e2e-deploy/llm-d-async-values.yaml`) configures:
 - Image: `ghcr.io/llm-d/llm-d-async:938cd44`
-- Queue: Redis sorted-set with `redis.url` set directly (chart creates the Secret), configured via `queuesConfig`
+- Queue: `redis-sortedset` transport, `redis.url` set directly (chart creates the Secret and injects it as `REDIS_URL`), configured via `transport` / `transportConfig`
 - Gate: `prometheus-budget` with pool=`optimized-baseline`, max_concurrency=100, baseline=0.05 (per-queue).
   `max_concurrency` is a **per ready pod** capacity — see [Size `max_concurrency` for your pool](#size-max_concurrency-for-your-pool)
   before reusing this value on your own model

--- a/docs/guides/e2e-deploy/llm-d-async-values.yaml
+++ b/docs/guides/e2e-deploy/llm-d-async-values.yaml
@@ -13,11 +13,14 @@ ap:
   # JSON document (see the project README "Transport Configuration" section).
   transport: redis-sortedset
   transportConfig:
+    # Connection: this dev Redis is unauthenticated, so the chart creates a Secret
+    # from the URL below and injects it as REDIS_URL (kept out of the pod args).
+    # For an existing Secret use urlSecret: {name: <secret>, key: url} instead.
+    urlSecret:
+      url: "redis://redis-master.redis.svc.cluster.local:6379"
     result_queue_name: "result-list"
     poll_interval_ms: 1000
     batch_size: 10
-    # "url" is intentionally omitted -- the chart injects REDIS_URL from the
-    # Secret it creates for ap.redis.url below.
     queues:
       - queue_name: "request-sortedset"
         request_path_url: "/v1/completions"
@@ -35,9 +38,6 @@ ap:
           # "Size max_concurrency for your pool" section of the guide.
           max_concurrency: "100"
           baseline: "0.05"
-  redis:
-    # Connection only: the chart creates the Secret and injects it as REDIS_URL.
-    url: "redis://redis-master.redis.svc.cluster.local:6379"
   podMonitor:
     enabled: true
     interval: "15s"

--- a/docs/guides/e2e-deploy/llm-d-async-values.yaml
+++ b/docs/guides/e2e-deploy/llm-d-async-values.yaml
@@ -3,21 +3,22 @@ ap:
     repository: ghcr.io/llm-d/llm-d-async
     tag: "938cd44"
   imagePullPolicy: Always
-  igwBaseURL: "http://llm-d-inference-gateway-istio:80"
-  messageQueueImpl: "redis-sortedset"
   concurrency: 4
   prometheusURL: "http://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090"
   metrics:
     enabled: true
     port: 9090
     secure: false
-  redis:
-    enabled: true
-    url: "redis://redis-master.redis.svc.cluster.local:6379"
-    resultQueueName: "result-list"
-    pollIntervalMs: 1000
-    batchSize: 10
-    queuesConfig:
+  # Unified transport surface: select the backend and configure it with a single
+  # JSON document (see the project README "Transport Configuration" section).
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "result-list"
+    poll_interval_ms: 1000
+    batch_size: 10
+    # "url" is intentionally omitted -- the chart injects REDIS_URL from the
+    # Secret it creates for ap.redis.url below.
+    queues:
       - queue_name: "request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://llm-d-inference-gateway-istio:80"
@@ -34,6 +35,9 @@ ap:
           # "Size max_concurrency for your pool" section of the guide.
           max_concurrency: "100"
           baseline: "0.05"
+  redis:
+    # Connection only: the chart creates the Secret and injects it as REDIS_URL.
+    url: "redis://redis-master.redis.svc.cluster.local:6379"
   podMonitor:
     enabled: true
     interval: "15s"

--- a/pkg/redis/options_test.go
+++ b/pkg/redis/options_test.go
@@ -1,0 +1,55 @@
+package redis
+
+import "testing"
+
+// TestREDIS_URL_IsDefaultNotOverride guards the regression where REDIS_URL
+// overwrote an explicit url from the transport config on every load. It must be
+// a fallback default: an explicit url wins, and REDIS_URL only fills an empty one.
+func TestREDIS_URL_IsDefaultNotOverride(t *testing.T) {
+	const explicit = `{"url":"redis://from-config:6379","queues":[{"queue_name":"q","igw_base_url":"http://gw"}]}`
+	const noURL = `{"queues":[{"queue_name":"q","igw_base_url":"http://gw"}]}`
+
+	t.Run("pubsub explicit url wins over REDIS_URL", func(t *testing.T) {
+		t.Setenv("REDIS_URL", "redis://from-env:6379")
+		cfg, err := LoadPubSubConfig([]byte(explicit))
+		if err != nil {
+			t.Fatalf("LoadPubSubConfig: %v", err)
+		}
+		if cfg.URL != "redis://from-config:6379" {
+			t.Errorf("URL = %q, want the explicit config value (env must not override)", cfg.URL)
+		}
+	})
+
+	t.Run("pubsub REDIS_URL fills empty url", func(t *testing.T) {
+		t.Setenv("REDIS_URL", "redis://from-env:6379")
+		cfg, err := LoadPubSubConfig([]byte(noURL))
+		if err != nil {
+			t.Fatalf("LoadPubSubConfig: %v", err)
+		}
+		if cfg.URL != "redis://from-env:6379" {
+			t.Errorf("URL = %q, want the REDIS_URL fallback", cfg.URL)
+		}
+	})
+
+	t.Run("sortedset explicit url wins over REDIS_URL", func(t *testing.T) {
+		t.Setenv("REDIS_URL", "redis://from-env:6379")
+		cfg, err := LoadSortedSetConfig([]byte(explicit))
+		if err != nil {
+			t.Fatalf("LoadSortedSetConfig: %v", err)
+		}
+		if cfg.URL != "redis://from-config:6379" {
+			t.Errorf("URL = %q, want the explicit config value (env must not override)", cfg.URL)
+		}
+	})
+
+	t.Run("sortedset REDIS_URL fills empty url", func(t *testing.T) {
+		t.Setenv("REDIS_URL", "redis://from-env:6379")
+		cfg, err := LoadSortedSetConfig([]byte(noURL))
+		if err != nil {
+			t.Fatalf("LoadSortedSetConfig: %v", err)
+		}
+		if cfg.URL != "redis://from-env:6379" {
+			t.Errorf("URL = %q, want the REDIS_URL fallback", cfg.URL)
+		}
+	})
+}

--- a/release-notes.d/unreleased/388.md
+++ b/release-notes.d/unreleased/388.md
@@ -1,0 +1,22 @@
+---
+pr: 388
+url: https://github.com/llm-d/llm-d-async/pull/388
+author: evacchi
+date: 2026-08-03
+---
+Breaking: The Helm chart now configures the processor through the unified transport
+surface. Select the backend with `ap.transport`
+(`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it with a
+single `ap.transportConfig` document (mirroring `--transport` /
+`--transport-config`). Redis/Valkey credentials still come from `ap.redis.url`
+or `ap.redis.secretName` (injected as `REDIS_URL`); leave `url` out of
+`ap.transportConfig` to use them.
+
+The deprecated per-backend values (`ap.messageQueueImpl`, the `ap.redis.*` /
+`ap.gcpPubSub.*` request/queue fields, and `ap.otel.redisTracing`) still work —
+the chart translates them into the transport config — and the install notes
+print a migration warning when they are used. Either way the chart now emits
+only `--transport` / `--transport-config`, so a default install no longer logs
+per-flag deprecation warnings from the processor.
+
+Deprecation Window: 2 versions from now.

--- a/release-notes.d/unreleased/388.md
+++ b/release-notes.d/unreleased/388.md
@@ -8,14 +8,16 @@ Breaking: The Helm chart now configures the processor through the unified transp
 surface. Select the backend with `ap.transport`
 (`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it with a
 single `ap.transportConfig` document (mirroring `--transport` /
-`--transport-config`). For the Redis transports, reference the connection
-Secret from the new surface via `ap.transportConfig.urlSecret` (`{name, key}`):
-the chart injects it as `REDIS_URL` and strips it from the config so the URL is
-never rendered into the pod args. The legacy `ap.redis.url` / `ap.redis.secretName`
-inputs still work as an alternative.
+`--transport-config`). For the Redis transports, the connection now lives on the
+transport surface via `ap.transportConfig.urlSecret`: set `{url: "redis://..."}`
+to have the chart create the Secret, or `{name, key}` to reference an existing
+one. Either way the chart injects it as `REDIS_URL` and strips `urlSecret` from
+the config, so the URL is never rendered into the pod args.
 
-The deprecated per-backend values (`ap.messageQueueImpl`, the `ap.redis.*` /
-`ap.gcpPubSub.*` request/queue fields, and `ap.otel.redisTracing`) still work —
+The whole deprecated `ap.redis` block is superseded (`ap.redis.enabled`,
+`ap.redis.url` / `ap.redis.secretName`, and the per-backend request/queue
+fields), along with `ap.messageQueueImpl`, the `ap.gcpPubSub.*` request/queue
+fields, and `ap.otel.redisTracing`. They still work —
 the chart translates them into the transport config — and the install notes
 print a migration warning when they are used. Either way the chart now emits
 only `--transport` / `--transport-config`, so a default install no longer logs

--- a/release-notes.d/unreleased/388.md
+++ b/release-notes.d/unreleased/388.md
@@ -8,9 +8,11 @@ Breaking: The Helm chart now configures the processor through the unified transp
 surface. Select the backend with `ap.transport`
 (`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it with a
 single `ap.transportConfig` document (mirroring `--transport` /
-`--transport-config`). Redis/Valkey credentials still come from `ap.redis.url`
-or `ap.redis.secretName` (injected as `REDIS_URL`); leave `url` out of
-`ap.transportConfig` to use them.
+`--transport-config`). For the Redis transports, reference the connection
+Secret from the new surface via `ap.transportConfig.urlSecret` (`{name, key}`):
+the chart injects it as `REDIS_URL` and strips it from the config so the URL is
+never rendered into the pod args. The legacy `ap.redis.url` / `ap.redis.secretName`
+inputs still work as an alternative.
 
 The deprecated per-backend values (`ap.messageQueueImpl`, the `ap.redis.*` /
 `ap.gcpPubSub.*` request/queue fields, and `ap.otel.redisTracing`) still work —

--- a/test/e2e/helm/benchmark-pool-gate.yaml
+++ b/test/e2e/helm/benchmark-pool-gate.yaml
@@ -1,9 +1,17 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "benchmark-pool-gate-result-list"
+    poll_interval_ms: 50
+    batch_size: 64
+    queues:
+      - queue_name: "benchmark-pool-gate-request-sortedset"
+        worker_pool_id: "benchmark-pool"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   workerPools:
     - id: "benchmark-pool"
       workers: 64
@@ -15,15 +23,6 @@ ap:
     port: 9090
     secure: false
   redis:
-    enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "benchmark-pool-gate-result-list"
-    pollIntervalMs: 50
-    batchSize: 64
-    queuesConfig:
-      - queue_name: "benchmark-pool-gate-request-sortedset"
-        worker_pool_id: "benchmark-pool"
-        request_path_url: "/v1/completions"
-        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/benchmark.yaml
+++ b/test/e2e/helm/benchmark.yaml
@@ -1,21 +1,14 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 64
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "benchmark-result-list"
-    pollIntervalMs: 50
-    batchSize: 64
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "benchmark-result-list"
+    poll_interval_ms: 50
+    batch_size: 64
+    queues:
       - queue_name: "benchmark-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
@@ -29,5 +22,11 @@ ap:
             - gate_type: "local-max-concurrency"
               gate_params:
                 limit: 40
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/budget.yaml
+++ b/test/e2e/helm/budget.yaml
@@ -1,21 +1,14 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "budget-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "budget-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "budget-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
@@ -24,5 +17,11 @@ ap:
           pool: "e2e-pool"
           max_concurrency: "1"
           baseline: "0.05"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/composite.yaml
+++ b/test/e2e/helm/composite.yaml
@@ -1,26 +1,25 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "composite-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "composite-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "composite-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
         gate_type: "composite"
         gate_params:
           gates: '[{"gate_type":"prometheus-saturation","gate_params":{"pool":"e2e-pool","threshold":"0.8"}},{"gate_type":"redis-quota","gate_params":{"address":"redis.e2e-integration.svc.cluster.local:6379","attribute":"userid","mode":"concurrency","limit":"1","prefix":"test-composite-quota:"}}]'
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/endpoint-scrape.yaml
+++ b/test/e2e/helm/endpoint-scrape.yaml
@@ -1,19 +1,13 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
   concurrency: 1
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "endpoint-scrape-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "endpoint-scrape-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "endpoint-scrape-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
@@ -23,5 +17,11 @@ ap:
           metric: "vllm:num_requests_waiting"
           max_count_per_pod: "5"
           fallback: "1.0"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/integration.yaml
+++ b/test/e2e/helm/integration.yaml
@@ -1,7 +1,5 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusCacheTTL: "0s"
   otel:
@@ -10,19 +8,20 @@ ap:
     sampler: "always_on"
     samplerArg: "1.0"
     redisTracing: false
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "integration-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
+      - queue_name: "integration-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   metrics:
     enabled: true
     port: 9090
     secure: false
   redis:
-    enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "integration-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
-      - queue_name: "integration-request-sortedset"
-        request_path_url: "/v1/completions"
-        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/mt-merge.yaml
+++ b/test/e2e/helm/mt-merge.yaml
@@ -5,8 +5,6 @@
 # overflow) and the tier-priority merge policy dispatches lanes in strict order.
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusCacheTTL: "0s"
   metrics:
@@ -20,13 +18,12 @@ ap:
   workerPools:
     - id: "default"
       workers: 1          # single worker -> dispatch order == merge-policy lane order
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "mt-merge-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "mt-merge-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "mt-merge-hi-sortedset"
         worker_pool_id: "default"
         request_path_url: "/v1/completions"
@@ -53,5 +50,7 @@ ap:
           mode: "concurrency"
           gating_mode: "classifying"
           limit: "1"
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/multitenant.yaml
+++ b/test/e2e/helm/multitenant.yaml
@@ -13,21 +13,18 @@
 # prometheus-query.yaml overlay uses.
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
   metrics:
     enabled: true
     port: 9090
     secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "mt-default-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "mt-default-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       # premium: highest priority — no queue quota, no pool saturation gate.
       - queue_name: "mt-premium-request-sortedset"
         worker_pool_id: "premium"
@@ -74,5 +71,7 @@ ap:
       gate_params:
         gate: |
           {"gate_type":"prometheus-query","gate_params":{"query":"clamp(1 - inference_extension_flow_control_pool_saturation{inference_pool=\"e2e-pool\"}/0.5, 0, 1)","fallback":"1"}}
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/prometheus-query.yaml
+++ b/test/e2e/helm/prometheus-query.yaml
@@ -1,25 +1,26 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "query-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
+      - queue_name: "query-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "prometheus-query"
+        gate_params:
+          query: "1 - inference_extension_flow_control_pool_saturation{inference_pool=\"e2e-pool\"}"
+          fallback: "0.0"
   metrics:
     enabled: true
     port: 9090
     secure: false
   redis:
-    enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "query-request-sortedset"
-    resultQueueName: "query-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    gateType: "prometheus-query"
-    gateParams:
-      query: "1 - inference_extension_flow_control_pool_saturation{inference_pool=\"e2e-pool\"}"
-      fallback: "0.0"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/quota.yaml
+++ b/test/e2e/helm/quota.yaml
@@ -1,20 +1,13 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "quota-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "quota-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "quota-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
@@ -24,5 +17,11 @@ ap:
           attribute: "userid"
           mode: "concurrency"
           limit: "1"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/redis-gate.yaml
+++ b/test/e2e/helm/redis-gate.yaml
@@ -1,25 +1,24 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "redis-gate-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "redis-gate-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "redis-gate-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
         gate_type: "redis"
         gate_params:
           address: "redis.e2e-integration.svc.cluster.local:6379"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/saturation.yaml
+++ b/test/e2e/helm/saturation.yaml
@@ -1,21 +1,14 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
-  metrics:
-    enabled: true
-    port: 9090
-    secure: false
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "saturation-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "saturation-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "saturation-request-sortedset"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
@@ -23,5 +16,11 @@ ap:
         gate_params:
           pool: "e2e-pool"
           threshold: "0.7"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/short-drain.yaml
+++ b/test/e2e/helm/short-drain.yaml
@@ -1,7 +1,5 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   concurrency: 1
   drainTimeout: "5s"
   otel:
@@ -10,19 +8,20 @@ ap:
     sampler: "always_on"
     samplerArg: "1.0"
     redisTracing: false
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "short-drain-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
+      - queue_name: "short-drain-request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   metrics:
     enabled: true
     port: 9090
     secure: false
   redis:
-    enabled: true
     url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "short-drain-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
-      - queue_name: "short-drain-request-sortedset"
-        request_path_url: "/v1/completions"
-        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/helm/tier-priority.yaml
+++ b/test/e2e/helm/tier-priority.yaml
@@ -1,7 +1,5 @@
 ap:
   imagePullPolicy: Never
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://envoy.e2e-integration.svc.cluster.local:8081"
   prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
   prometheusCacheTTL: "0s"
   metrics:
@@ -20,18 +18,19 @@ ap:
         saturation_gate: "prometheus-saturation"
         saturation_gate_params: '{"pool":"e2e-pool","threshold":"0.8"}'
         tier_label: "tier"
-  redis:
-    enabled: true
-    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
-    resultQueueName: "tier-priority-result-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transport: redis-sortedset
+  transportConfig:
+    result_queue_name: "tier-priority-result-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       - queue_name: "tier-priority-interactive"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
       - queue_name: "tier-priority-async"
         request_path_url: "/v1/completions"
         igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  redis:
+    url: "redis://redis.e2e-integration.svc.cluster.local:6379"
   modelServerMonitor:
     enabled: false

--- a/test/e2e/yaml/llm-d-async-composite.yaml
+++ b/test/e2e/yaml/llm-d-async-composite.yaml
@@ -21,10 +21,8 @@ spec:
         image: ${AP_IMAGE}
         imagePullPolicy: IfNotPresent
         args:
-        - --message-queue-impl=redis-sortedset
-        - --redis.url=redis://redis.e2e-test.svc.cluster.local:6379
-        - --redis.ss.queues-config=[{"queue_name":"composite-request-sortedset","igw_base_url":"http://igw-mock.e2e-test.svc.cluster.local:80","request_path_url":"/v1/completions","gate_type":"composite","gate_params":{"gates":"[{\"gate_type\":\"prometheus-saturation\",\"gate_params\":{\"pool\":\"e2e-pool\",\"threshold\":\"0.8\"}},{\"gate_type\":\"redis-quota\",\"gate_params\":{\"address\":\"redis.e2e-test.svc.cluster.local:6379\",\"attribute\":\"userid\",\"mode\":\"concurrency\",\"limit\":\"1\",\"prefix\":\"test-composite-quota:\"}}]"}}]
+        - --transport=redis-sortedset
+        - --transport-config={"url":"redis://redis.e2e-test.svc.cluster.local:6379","poll_interval_ms":500,"queues":[{"queue_name":"composite-request-sortedset","igw_base_url":"http://igw-mock.e2e-test.svc.cluster.local:80","request_path_url":"/v1/completions","gate_type":"composite","gate_params":{"gates":"[{\"gate_type\":\"prometheus-saturation\",\"gate_params\":{\"pool\":\"e2e-pool\",\"threshold\":\"0.8\"}},{\"gate_type\":\"redis-quota\",\"gate_params\":{\"address\":\"redis.e2e-test.svc.cluster.local:6379\",\"attribute\":\"userid\",\"mode\":\"concurrency\",\"limit\":\"1\",\"prefix\":\"test-composite-quota:\"}}]"}}]}
         - --prometheus-url=http://prom-mock.e2e-test.svc.cluster.local:9090
         - --prometheus-cache-ttl=0s
-        - --redis.ss.poll-interval-ms=500
         - --metrics-endpoint-auth=false

--- a/test/e2e/yaml/llm-d-async-quota.yaml
+++ b/test/e2e/yaml/llm-d-async-quota.yaml
@@ -21,7 +21,6 @@ spec:
         image: ${AP_IMAGE}
         imagePullPolicy: IfNotPresent
         args:
-        - --message-queue-impl=redis-sortedset
-        - --redis.url=redis://redis.e2e-test.svc.cluster.local:6379
-        - --redis.ss.queues-config=[{"queue_name":"quota-request-sortedset","igw_base_url":"http://igw-mock.e2e-test.svc.cluster.local:80","request_path_url":"/v1/completions","gate_type":"redis-quota","gate_params":{"address":"redis.e2e-test.svc.cluster.local:6379","attribute":"userid","mode":"concurrency","limit":"1"}}]
+        - --transport=redis-sortedset
+        - --transport-config={"url":"redis://redis.e2e-test.svc.cluster.local:6379","queues":[{"queue_name":"quota-request-sortedset","igw_base_url":"http://igw-mock.e2e-test.svc.cluster.local:80","request_path_url":"/v1/completions","gate_type":"redis-quota","gate_params":{"address":"redis.e2e-test.svc.cluster.local:6379","attribute":"userid","mode":"concurrency","limit":"1"}}]}
         - --metrics-endpoint-auth=false


### PR DESCRIPTION
## What does this PR do?

Updates helm charts and docs to follow the config changes in #378. Stacked, pending merge there, and also cross-testing on llm-d-batch-gateway. Relevant commit is just 2b579b0

## Why is this change needed?

#378 harmonizes configuration style for llm-d-async, this propagates the change to the Helm charts. The old Helm format still works, and also the old flags work for the time being. In v+2 we will remove the deprecated formats.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Follow up to #378, closes https://github.com/llm-d/llm-d-async/issues/284

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
Breaking: The Helm chart now configures the processor through the unified transport
surface. Select the backend with `ap.transport`
(`redis-pubsub` | `redis-sortedset` | `gcp-pubsub`) and configure it with a
single `ap.transportConfig` document (mirroring `--transport` /
`--transport-config`). Redis/Valkey credentials still come from `ap.redis.url`
or `ap.redis.secretName` (injected as `REDIS_URL`); leave `url` out of
`ap.transportConfig` to use them.

The deprecated per-backend values (`ap.messageQueueImpl`, the `ap.redis.*` /
`ap.gcpPubSub.*` request/queue fields, and `ap.otel.redisTracing`) still work —
the chart translates them into the transport config — and the install notes
print a migration warning when they are used. Either way the chart now emits
only `--transport` / `--transport-config`, so a default install no longer logs
per-flag deprecation warnings from the processor.

Deprecation Window: 2 versions from now.
```
