### PR TITLE
feat(ap): result TTLs, per-lane objective stamping, and deadline classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,11 @@ The merge policy is configured using the `--request-merge-policy-config-file` CL
 {
   "type": "tier-priority",
   "parameters": {
-    "priority_header": "x-gateway-priority"
+    "priority_header": "x-gateway-priority",
+    "lane_objectives": {
+      "reserved-interactive": "premium-latency",
+      "overflow-batch": "best-effort"
+    }
   }
 }
 ```
@@ -510,6 +514,8 @@ The merge policy is configured using the `--request-merge-policy-config-file` CL
    - **Parameters**:
      - `priority_header` (optional, string): The HTTP header name used to pass the priority value downstream to the inference scheduler. A name that is not a legal HTTP header name is rejected at startup. Default is `"x-gateway-priority"`.
      - `tier_label` (optional, string): The label name on `InternalRequest.Labels` used to look up the request's priority tier. Default is `"tier"`.
+     - `objective_header` (optional, string): The HTTP header name used to stamp the lane's InferenceObjective name. A name that is not a legal HTTP header name is rejected at startup. Default is `"x-llm-d-inference-objective"` (`api.ObjectiveHeader`).
+     - `lane_objectives` (optional, object): Maps lane keys (`"reserved-interactive"`, `"reserved-async"`, `"reserved-batch"`, `"overflow-interactive"`, `"overflow-async"`, `"overflow-batch"`) to InferenceObjective names. A request whose lane has an entry gets that objective stamped as `objective_header`, which overrides the queue-level `inference_objective`. Lanes without an entry fall back to the queue objective.
      - `fairness_header` / `fairness_attribute` (optional, string): Same as for `random-robin`.
 
 ## Request Body Transforms

--- a/api/api.go
+++ b/api/api.go
@@ -25,6 +25,11 @@ type Request interface {
 // attribute reach the gateway with whatever the caller sent.
 const FairnessIDHeader = "x-llm-d-inference-fairness-id"
 
+// ObjectiveHeader is the request header llm-d-router reads to resolve a
+// request's InferenceObjective. The tier-priority merge policy stamps it with
+// the per-lane objective when lane_objectives is configured.
+const ObjectiveHeader = "x-llm-d-inference-objective"
+
 // RequestMessage contains the caller-visible fields of a request. Metadata is
 // caller-supplied pass-through data (e.g. tracing IDs, user labels). The system
 // never writes Metadata, and reads it only where an opt-in feature is configured

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -19,15 +19,15 @@ import (
 func init() {
 	plugins.MustRegister("tier-priority", func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 		var params struct {
-			PriorityHeader string `json:"priority_header"`
-			TierLabel      string `json:"tier_label"`
+			PriorityHeader  string `json:"priority_header"`
+			TierLabel       string `json:"tier_label"`
+			ObjectiveHeader string `json:"objective_header"`
 			// LaneObjectives maps lane keys ("reserved-interactive",
 			// "overflow-batch", ...) to InferenceObjective names stamped as
 			// ObjectiveHeader, replacing the per-queue objective for lane
 			// granularity. The numeric priority header has no consumer in
 			// upstream gateways. Objectives are how priority reaches them.
-			ObjectiveHeader string            `json:"objective_header"`
-			LaneObjectives  map[string]string `json:"lane_objectives"`
+			LaneObjectives map[string]string `json:"lane_objectives"`
 			fairness.Params
 		}
 		if len(parameters) > 0 {
@@ -44,7 +44,7 @@ func init() {
 			return nil, fmt.Errorf("invalid tier-priority parameters: priority_header %q is not a legal HTTP header name", params.PriorityHeader)
 		}
 		if params.ObjectiveHeader == "" {
-			params.ObjectiveHeader = "x-llm-d-inference-objective"
+			params.ObjectiveHeader = api.ObjectiveHeader
 		}
 		if !httpguts.ValidHeaderFieldName(params.ObjectiveHeader) {
 			return nil, fmt.Errorf("invalid tier-priority parameters: objective_header %q is not a legal HTTP header name", params.ObjectiveHeader)
@@ -81,8 +81,7 @@ type Config struct {
 	// identity. Empty falls back to fairness.DefaultAttribute.
 	FairnessAttribute string
 	// ObjectiveHeader is the HTTP header stamped with the lane's
-	// InferenceObjective name. Empty falls back to
-	// "x-llm-d-inference-objective".
+	// InferenceObjective name. Empty falls back to api.ObjectiveHeader.
 	ObjectiveHeader string
 	// LaneObjectives maps lane keys ("reserved-interactive", "overflow-batch",
 	// ...) to InferenceObjective names. Lanes without an entry are not
@@ -99,7 +98,7 @@ func NewTierPriorityPolicy(name string, cfg Config) *TierPriorityPolicy {
 	}
 	objectiveHeader := cfg.ObjectiveHeader
 	if objectiveHeader == "" {
-		objectiveHeader = "x-llm-d-inference-objective"
+		objectiveHeader = api.ObjectiveHeader
 	}
 	return &TierPriorityPolicy{
 		name:            name,
@@ -370,6 +369,9 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 				headers := map[string]string{
 					"Content-Type": "application/json",
 				}
+				// Queue-level objective. For lanes configured in
+				// lane_objectives, the lane objective stamped below
+				// overrides it.
 				if chMeta.InferenceObjective != "" {
 					headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
 				}

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -21,6 +21,13 @@ func init() {
 		var params struct {
 			PriorityHeader string `json:"priority_header"`
 			TierLabel      string `json:"tier_label"`
+			// LaneObjectives maps lane keys ("reserved-interactive",
+			// "overflow-batch", ...) to InferenceObjective names stamped as
+			// ObjectiveHeader, replacing the per-queue objective for lane
+			// granularity. The numeric priority header has no consumer in
+			// upstream gateways. Objectives are how priority reaches them.
+			ObjectiveHeader string            `json:"objective_header"`
+			LaneObjectives  map[string]string `json:"lane_objectives"`
 			fairness.Params
 		}
 		if len(parameters) > 0 {
@@ -36,6 +43,12 @@ func init() {
 		if !httpguts.ValidHeaderFieldName(params.PriorityHeader) {
 			return nil, fmt.Errorf("invalid tier-priority parameters: priority_header %q is not a legal HTTP header name", params.PriorityHeader)
 		}
+		if params.ObjectiveHeader == "" {
+			params.ObjectiveHeader = "x-llm-d-inference-objective"
+		}
+		if !httpguts.ValidHeaderFieldName(params.ObjectiveHeader) {
+			return nil, fmt.Errorf("invalid tier-priority parameters: objective_header %q is not a legal HTTP header name", params.ObjectiveHeader)
+		}
 		fairnessHeader, err := params.ResolveHeader()
 		if err != nil {
 			return nil, fmt.Errorf("invalid tier-priority parameters: %w", err)
@@ -43,6 +56,8 @@ func init() {
 		return NewTierPriorityPolicy(name, Config{
 			PriorityHeader:    params.PriorityHeader,
 			TierLabel:         params.TierLabel,
+			ObjectiveHeader:   params.ObjectiveHeader,
+			LaneObjectives:    params.LaneObjectives,
 			FairnessHeader:    fairnessHeader,
 			FairnessAttribute: params.Attribute,
 		}), nil
@@ -65,6 +80,14 @@ type Config struct {
 	// FairnessAttribute is the message metadata attribute holding the tenant
 	// identity. Empty falls back to fairness.DefaultAttribute.
 	FairnessAttribute string
+	// ObjectiveHeader is the HTTP header stamped with the lane's
+	// InferenceObjective name. Empty falls back to
+	// "x-llm-d-inference-objective".
+	ObjectiveHeader string
+	// LaneObjectives maps lane keys ("reserved-interactive", "overflow-batch",
+	// ...) to InferenceObjective names. Lanes without an entry are not
+	// stamped. Nil disables objective stamping.
+	LaneObjectives map[string]string
 }
 
 // NewTierPriorityPolicy returns a merge policy that buckets requests into strict
@@ -74,11 +97,17 @@ func NewTierPriorityPolicy(name string, cfg Config) *TierPriorityPolicy {
 	if tierLabel == "" {
 		tierLabel = "tier"
 	}
+	objectiveHeader := cfg.ObjectiveHeader
+	if objectiveHeader == "" {
+		objectiveHeader = "x-llm-d-inference-objective"
+	}
 	return &TierPriorityPolicy{
-		name:           name,
-		priorityHeader: cfg.PriorityHeader,
-		tierLabel:      tierLabel,
-		fairness:       fairness.New(cfg.FairnessHeader, cfg.FairnessAttribute),
+		name:            name,
+		priorityHeader:  cfg.PriorityHeader,
+		tierLabel:       tierLabel,
+		objectiveHeader: objectiveHeader,
+		laneObjectives:  cfg.LaneObjectives,
+		fairness:        fairness.New(cfg.FairnessHeader, cfg.FairnessAttribute),
 	}
 }
 
@@ -86,10 +115,12 @@ var _ pipeline.RequestMergePolicy = (*TierPriorityPolicy)(nil)
 var _ plugins.Plugin = (*TierPriorityPolicy)(nil)
 
 type TierPriorityPolicy struct {
-	name           string
-	priorityHeader string
-	tierLabel      string
-	fairness       fairness.Stamper
+	name            string
+	priorityHeader  string
+	tierLabel       string
+	objectiveHeader string
+	laneObjectives  map[string]string
+	fairness        fairness.Stamper
 }
 
 func (p *TierPriorityPolicy) TypedName() plugins.TypedName {
@@ -195,6 +226,25 @@ func getPriorityIndex(ir *api.InternalRequest, tierLabel string) int {
 	}
 
 	return classPri*3 + tierPri
+}
+
+// laneKey names the (classification, tier) lane for objective mapping, e.g.
+// "reserved-interactive" or "overflow-batch".
+func laneKey(ir *api.InternalRequest, tierLabel string) string {
+	tier := string(api.TierBatch)
+	if ir.Labels != nil {
+		switch ir.Labels[tierLabel] {
+		case string(api.TierInteractive):
+			tier = string(api.TierInteractive)
+		case string(api.TierAsync):
+			tier = string(api.TierAsync)
+		}
+	}
+	class := "overflow"
+	if ir.GetClassification() == api.ClassificationReserved {
+		class = "reserved"
+	}
+	return class + "-" + tier
 }
 
 func (s *scheduler) Push(ir *api.InternalRequest, chMeta pipeline.RequestChannel) bool {
@@ -333,6 +383,11 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 				pri := getPriorityIndex(ir, tierLabel)
 				if priorityHeader != "" {
 					headers[priorityHeader] = strconv.Itoa(pri)
+				}
+				if len(p.laneObjectives) > 0 {
+					if objective, ok := p.laneObjectives[laneKey(ir, tierLabel)]; ok && objective != "" {
+						headers[p.objectiveHeader] = objective
+					}
 				}
 
 				erm := pipeline.EmbelishedRequestMessage{

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
@@ -292,3 +292,55 @@ func TestPerBucketLimitsNonBlocking(t *testing.T) {
 		t.Fatal("push to empty bucket blocked")
 	}
 }
+
+func TestTierPriorityStamping(t *testing.T) {
+	ch := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 4),
+		WorkerPoolID: "pool-s",
+		IGWBaseURL:   "http://gw",
+	}
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-s": {ID: "pool-s", Workers: 1},
+	}
+	policy := NewTierPriorityPolicy("test-stamping", Config{
+		PriorityHeader: "x-gateway-priority",
+		TierLabel:      "tier",
+		LaneObjectives: map[string]string{
+			"reserved-interactive": "interactive-reserved",
+			"overflow-interactive": "interactive-overflow",
+		},
+	})
+
+	mk := func(id, tier, class, team string) *api.InternalRequest {
+		ir := api.NewInternalRequest(api.InternalRouting{
+			Labels: map[string]string{"tier": tier, api.LabelClassification: class},
+		}, &api.RequestMessage{
+			ID: id, Created: 1, Deadline: 9999999999,
+			Metadata: map[string]string{"team": team},
+		})
+		return ir
+	}
+	ch.Channel <- mk("s-reserved", "interactive", string(api.ClassificationReserved), "team-a")
+	ch.Channel <- mk("s-overflow", "interactive", string(api.ClassificationOverflow), "team-b")
+	close(ch.Channel)
+
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch}, pools)
+	merged := dispatch.Channels["pool-s"]
+
+	expected := map[string]string{
+		"s-reserved": "interactive-reserved",
+		"s-overflow": "interactive-overflow",
+	}
+	deadline := time.After(3 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-merged:
+			want := expected[msg.PublicRequest.ReqID()]
+			if got := msg.HttpHeaders["x-llm-d-inference-objective"]; got != want {
+				t.Errorf("%s: objective header = %q, want %q", msg.PublicRequest.ReqID(), got, want)
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for stamped messages")
+		}
+	}
+}

--- a/pkg/asyncworker/worker.go
+++ b/pkg/asyncworker/worker.go
@@ -302,6 +302,20 @@ func WorkerWithGate(consumeCtx, requestCtx context.Context, characteristics pipe
 						return
 					}
 
+					// The send was aborted by the per-request deadline (not a
+					// process shutdown): surface DEADLINE_EXCEEDED so callers
+					// can distinguish a timed-out request from an inference
+					// failure. This happens whenever the deadline expires
+					// while the request is queued or executing downstream.
+					if errors.Is(reqCtx.Err(), context.DeadlineExceeded) {
+						metrics.RecordExceededDeadlineReq(queueID, queueName, msg.WorkerPoolID)
+						select {
+						case resultChannel <- asyncapi.NewDeadlineExceededResult(msg.PublicRequest, msg.InternalRouting):
+						case <-requestCtx.Done():
+						}
+						return
+					}
+
 					var inferenceErr asyncapi.InferenceError
 					if !errors.As(err, &inferenceErr) || inferenceErr.Category().Fatal() {
 						span.RecordError(err)

--- a/pkg/asyncworker/worker_test.go
+++ b/pkg/asyncworker/worker_test.go
@@ -2791,3 +2791,40 @@ func TestWorker_PoolGateDecisionsMetrics(t *testing.T) {
 		}
 	})
 }
+
+// A send aborted by the per-request deadline (message deadline in the past
+// relative to the send duration) must surface DEADLINE_EXCEEDED, not
+// INFERENCE_ERROR, so callers can distinguish timeout from failure.
+func TestDeadlineAbortedSendClassifiedAsDeadlineExceeded(t *testing.T) {
+	msgId := "deadline-mid-flight"
+	httpclient := NewTestClient(func(req *http.Request) (*http.Response, error) {
+		// Simulate an upstream that holds the request until the context dies.
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	inferenceClient := NewHTTPInferenceClient(httpclient)
+	requestChannel := make(chan pipeline.EmbelishedRequestMessage, 1)
+	retryChannel := make(chan pipeline.RetryMessage, 1)
+	resultChannel := make(chan asyncapi.ResultMessage, 1)
+	ctx := context.Background()
+
+	go Worker(ctx, ctx, pipeline.Characteristics{}, inferenceClient, requestChannel, retryChannel, resultChannel, defaultRequestTimeout, nil)
+
+	requestChannel <- newEmb(asyncapi.RequestMessage{
+		ID:       msgId,
+		Created:  time.Now().Unix(),
+		Deadline: time.Now().Add(1 * time.Second).Unix(),
+		Payload:  map[string]any{"model": "m", "prompt": "hi"},
+	}, "http://localhost:30800/v1/completions", map[string]string{})
+
+	select {
+	case r := <-resultChannel:
+		if r.ErrorCode != asyncapi.ErrCodeDeadlineExceeded {
+			t.Errorf("expected DEADLINE_EXCEEDED, got error code %q (message %q)", r.ErrorCode, r.ErrorMessage)
+		}
+	case <-retryChannel:
+		t.Error("deadline-aborted send should not be retried")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -21,9 +21,14 @@ import (
 
 // SortedSetQueueConfig defines a single queue entry in the sorted-set transport config.
 type SortedSetQueueConfig struct {
-	ID                 string `json:"id,omitempty"`
-	QueueName          string `json:"queue_name,omitempty"`
-	ResultQueueName    string `json:"result_queue_name,omitempty"`
+	ID              string `json:"id,omitempty"`
+	QueueName       string `json:"queue_name,omitempty"`
+	ResultQueueName string `json:"result_queue_name,omitempty"`
+	// ResultTTLSeconds, when > 0, sets an expiry on the result destination
+	// each time results are pushed. Used for per-request result keys
+	// (frontend enqueue mode) so unfetched results are cleaned up. Queues
+	// without it behave as before (no expiry).
+	ResultTTLSeconds   int64  `json:"result_ttl_seconds,omitempty"`
 	WorkerPoolID       string `json:"worker_pool_id"`
 	InferenceObjective string `json:"inference_objective"`
 	RequestPathURL     string `json:"request_path_url"`
@@ -651,14 +656,19 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 	logger := log.FromContext(ctx)
 	defaultQueue := r.defaultResultQueueName
 	queued := make(map[string][]string)
+	resultTTLs := make(map[string]time.Duration)
 	for _, result := range batch {
 		resultQueue := defaultQueue
-		if cfg, ok := r.configMap[result.Routing.QueueID]; ok && cfg.ResultQueueName != "" {
+		cfg, hasCfg := r.configMap[result.Routing.QueueID]
+		if hasCfg && cfg.ResultQueueName != "" {
 			resultQueue = cfg.ResultQueueName
 		} else if result.Routing.ResultQueueName != "" {
 			resultQueue = result.Routing.ResultQueueName
 		}
 		queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
+		if hasCfg && cfg.ResultTTLSeconds > 0 {
+			resultTTLs[resultQueue] = time.Duration(cfg.ResultTTLSeconds) * time.Second
+		}
 	}
 
 	if err := retryRedisOp(ctx, func(ctx context.Context) error {
@@ -666,6 +676,9 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 		for queue, msgs := range queued {
 			for _, msgStr := range msgs {
 				pipe.LPush(ctx, queue, msgStr)
+			}
+			if ttl, ok := resultTTLs[queue]; ok {
+				pipe.Expire(ctx, queue, ttl)
 			}
 		}
 		_, err := pipe.Exec(ctx)

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -401,8 +401,17 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		}
 		if deadline < currentTime {
 			logger.V(logutil.DEFAULT).Info("Deadline expired", "id", rview.ReqID())
+			metrics.RecordExceededDeadlineReq(queueID, queueName, poolName)
 			if err := r.cleanupRequestStateByIDAndToken(ctx, rview.ReqID(), ir.RequestToken); err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to cleanup expired request state", "id", rview.ReqID())
+			}
+			// Surface the expiry instead of dropping silently: without a
+			// result, a fetch cannot distinguish a request that timed out in
+			// the queue from one that never existed.
+			select {
+			case r.resultChannel <- api.NewDeadlineExceededResult(rview, ir.InternalRouting):
+			case <-ctx.Done():
+				return
 			}
 			continue
 		}

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -827,6 +827,59 @@ func TestSortedSetFlow_ResultBatch(t *testing.T) {
 	}
 }
 
+func TestSortedSetFlow_ResultTTL(t *testing.T) {
+	s, rdb, ctx, cancel := setupTest(t)
+	defer s.Close()
+	defer rdb.Close() // nolint:errcheck
+	defer cancel()
+
+	flow := &RedisSortedSetFlow{
+		defaultResultQueueName: "default-results",
+		rdb:                    rdb,
+		resultChannel:          make(chan api.ResultMessage, 4),
+		pollInterval:           50 * time.Millisecond,
+		batchSize:              10,
+		gate:                   noopGate(),
+		configMap: map[string]SortedSetQueueConfig{
+			"ttl-queue": {ID: "ttl-queue", ResultTTLSeconds: 60},
+			"no-ttl":    {ID: "no-ttl"},
+		},
+	}
+
+	go flow.resultWorker(ctx)
+
+	// Per-message result key routing from a queue with result_ttl_seconds:
+	// the destination key gets an expiry.
+	flow.resultChannel <- api.ResultMessage{
+		ID:      "ttl-1",
+		Payload: "data",
+		Routing: api.InternalRouting{QueueID: "ttl-queue", ResultQueueName: "results:req:ttl-1"},
+	}
+	// Same flow from a queue without TTL configured: no expiry (unchanged
+	// belt behavior).
+	flow.resultChannel <- api.ResultMessage{
+		ID:      "plain-1",
+		Payload: "data",
+		Routing: api.InternalRouting{QueueID: "no-ttl", ResultQueueName: "belt-results"},
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if n, _ := rdb.LLen(ctx, "results:req:ttl-1").Result(); n != 1 {
+		t.Fatalf("expected 1 result on per-request key, got %d", n)
+	}
+	ttl := s.TTL("results:req:ttl-1")
+	if ttl <= 0 || ttl > 60*time.Second {
+		t.Errorf("expected TTL in (0, 60s] on per-request key, got %v", ttl)
+	}
+
+	if n, _ := rdb.LLen(ctx, "belt-results").Result(); n != 1 {
+		t.Fatalf("expected 1 result on belt, got %d", n)
+	}
+	if ttl := s.TTL("belt-results"); ttl != 0 {
+		t.Errorf("expected no TTL on belt key, got %v", ttl)
+	}
+}
+
 func TestSortedSetFlow_ResultBatchMultiQueue(t *testing.T) {
 	s, rdb, ctx, cancel := setupTest(t)
 	defer s.Close()

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -249,9 +249,10 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
 			queueName: queue,
 		}},
-		pollInterval: 50 * time.Millisecond,
-		batchSize:    10,
-		gate:         noopGate(),
+		resultChannel: make(chan api.ResultMessage, 1),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
 	}
 
 	pastDeadline := time.Now().Unix() - 100
@@ -260,11 +261,24 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 
 	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
 
+	// The expiry is surfaced as a DEADLINE_EXCEEDED result rather than a
+	// silent drop, so fetch can distinguish a queue timeout from an unknown id.
+	select {
+	case result := <-flow.resultChannel:
+		if result.ID != "expired" {
+			t.Fatalf("Expected deadline result for %q, got %q", "expired", result.ID)
+		}
+		if result.ErrorCode != api.ErrCodeDeadlineExceeded {
+			t.Fatalf("Expected ErrorCode %q, got %q", api.ErrCodeDeadlineExceeded, result.ErrorCode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for deadline exceeded result")
+	}
+
 	select {
 	case msg := <-flow.requestChannels[0].channel.Channel:
 		t.Fatalf("Should not receive expired message: %s", msg.PublicRequest.ReqID())
-	case <-time.After(300 * time.Millisecond):
-		// Expected - message expired
+	default:
 	}
 
 	// Verify message was removed
@@ -288,9 +302,10 @@ func TestSortedSetFlow_ExpiredMessagesCleanupRequestState(t *testing.T) {
 			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
 			queueName: queue,
 		}},
-		pollInterval: 50 * time.Millisecond,
-		batchSize:    10,
-		gate:         noopGate(),
+		resultChannel: make(chan api.ResultMessage, 1),
+		pollInterval:  50 * time.Millisecond,
+		batchSize:     10,
+		gate:          noopGate(),
 	}
 
 	ir := api.NewInternalRequest(api.InternalRouting{RequestToken: token}, &api.RequestMessage{

--- a/release-notes.d/unreleased/394.md
+++ b/release-notes.d/unreleased/394.md
@@ -1,0 +1,12 @@
+---
+pr: 394
+url: https://github.com/llm-d/llm-d-async/pull/394
+author: BenjaminBraunDev
+date: 2026-08-07
+---
+AP-side support for OpenAI compatible serving through an external door
+(the llm-d-coordinator async-broker step): queue configs gain
+`result_ttl_seconds` so per-request result keys expire when never fetched,
+deadline aborted sends now classify as `DEADLINE_EXCEEDED`, and the
+tier-priority merge policy gains `lane_objectives` for per-lane objective
+stamping at dispatch.


### PR DESCRIPTION
#### What does this PR do?

Adds three AP-side changes that let llm-d-routers `async-broker` plugin serve requests through the broker:

- `result_ttl_seconds` on queue config: the result writer applies an expiry to the result destination on push, so per-request result keys clean themselves up when never fetched
- Per-lane objective and fairness stamping in the tier-priority merge policy, so every dispatch carries InferenceObjective and fairness headers the EPP understands
- DEADLINE_EXCEEDED classification wherever a deadline kills a request

And queues without the new settings behave exactly as today.

#### Why?

These are the broker-side prerequisites: fetchable per-request results need TTL cleanup, dispatches need priority headers the gateway understands, and deadline expiry needs to be distinguishable from generic failure. The serving door itself lives in llm-d-router as a coordinator pipeline step (async-broker), so this is the llm-d-async side of that design.

#### How was this tested?

Unit tests in each commit, make ci across all four modules, and end to end on a GKE cluster behind llm-d-router: TTLs observed on result keys, objective and fairness headers confirmed in EPP logs at dispatch, and mid-flight expiries surfacing as DEADLINE_EXCEEDED.

#### How to review

Non-test code is about 105 lines across three files (pkg/redis, pkg/async/mergepolicy/tierpriority, pkg/asyncworker).

#### Related Issues

Part of #308.

This PR carries the AP-side of the former implementation #392, which proposed a dedicated standalone frontend. The coordinator-based approach serves the same modes through the llm-d-router pipeline instead (llm-d/llm-d-router/pull/2325), so this is the alternative.

#### Release note
```release-note
Support result_ttl_seconds on queue config, stamp per-lane objective and fairness headers at dispatch, and classify deadline-aborted sends as DEADLINE_EXCEEDED.
```
