### PR TITLE
Add GCP PubSub e2e tests using emulator

### DIFF
--- a/charts/llm-d-async/templates/ap-deployments.yaml
+++ b/charts/llm-d-async/templates/ap-deployments.yaml
@@ -131,6 +131,9 @@ spec:
                 name: {{ include "llm-d-async.redisSecretName" . }}
                 key: {{ include "llm-d-async.redisSecretKey" . }}
           {{- end }}
+          {{- with .Values.ap.env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         name: llm-d-async
         ports:
           - name: metrics

--- a/charts/llm-d-async/tests/deployment_test.yaml
+++ b/charts/llm-d-async/tests/deployment_test.yaml
@@ -458,3 +458,23 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --request-merge-policy-config=/etc/llm-d-async/config/request-merge-policy.json
+
+  - it: should render extra env vars when ap.env is set
+    set:
+      ap.env:
+        - name: PUBSUB_EMULATOR_HOST
+          value: "pubsub-emulator:8085"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PUBSUB_EMULATOR_HOST
+            value: "pubsub-emulator:8085"
+
+  - it: should not render extra env vars when ap.env is empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PUBSUB_EMULATOR_HOST
+            value: "pubsub-emulator:8085"

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -51,6 +51,12 @@ ap:
   drainTimeout: "2m"
   prometheusURL: ""
   prometheusCacheTTL: ""
+  # Extra environment variables to inject into the processor container.
+  # Useful for passing backend-specific configuration like PUBSUB_EMULATOR_HOST.
+  # env:
+  #   - name: PUBSUB_EMULATOR_HOST
+  #     value: "pubsub-emulator:8085"
+  env: []
   # Named worker pools configuration. When specified, overrides the global concurrency option.
   # workerPools:
   #   - id: "default"

--- a/charts/llm-d-async/values.yaml
+++ b/charts/llm-d-async/values.yaml
@@ -53,6 +53,8 @@ ap:
   prometheusCacheTTL: ""
   # Extra environment variables to inject into the processor container.
   # Useful for passing backend-specific configuration like PUBSUB_EMULATOR_HOST.
+  # Note: Avoid setting NAMESPACE or POD_NAME here as it will override the downward
+  # API and break downstream $(NAMESPACE) / $(POD_NAME) OTel resource expansion.
   # env:
   #   - name: PUBSUB_EMULATOR_HOST
   #     value: "pubsub-emulator:8085"

--- a/release-notes.d/unreleased/395.md
+++ b/release-notes.d/unreleased/395.md
@@ -1,0 +1,7 @@
+---
+pr: 395
+url: https://github.com/llm-d/llm-d-async/pull/395
+author: jtechapps
+date: 2026-08-18
+---
+The `llm-d-async` Helm chart now supports `ap.env`, allowing operators to inject arbitrary environment variables into the async-processor container (such as `PUBSUB_EMULATOR_HOST` for local emulation or custom provider configurations).

--- a/test/e2e/e2e_benchmark_test.go
+++ b/test/e2e/e2e_benchmark_test.go
@@ -7,12 +7,14 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/llm-d/llm-d-async/api"
 )
 
@@ -56,6 +58,7 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		rdb.Del(ctx, benchmarkResultQueue)          //nolint:errcheck
 		rdb.Del(ctx, benchmarkPoolGateRequestQueue) //nolint:errcheck
 		rdb.Del(ctx, benchmarkPoolGateResultQueue)  //nolint:errcheck
+		recreatePubSubSubscription(ctx, pubsubClient, pubsubProjectID, pubsubBenchResultSub, pubsubBenchResultTopic)
 	})
 
 	ginkgo.It("measure clearing time and saturation under load with queue-level gate", func() {
@@ -226,6 +229,108 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 
 		// Verify basic correctness: result queue contains all processed messages
 		gomega.Expect(getResultCount(ctx, rdb, benchmarkPoolGateResultQueue)).To(gomega.Equal(int64(numRequests)))
+	})
+
+	ginkgo.It("measure clearing time and saturation under load with pub/sub transport and prometheus gate", func() {
+		// Build a prompt containing 1000 tokens by repeating a word 1000 times
+		prompt := strings.Repeat("word ", 1000)
+
+		numRequests := 5000
+		ginkgo.By(fmt.Sprintf("Bulk enqueuing %d inference requests (1000 input tokens, 500 output tokens) to pub/sub benchmark topic", numRequests))
+
+		msgs := make([]api.RequestMessage, numRequests)
+		now := time.Now().Unix()
+		for i := 0; i < numRequests; i++ {
+			msgs[i] = api.RequestMessage{
+				ID:       fmt.Sprintf("bench-pubsub-msg-%d", i),
+				Created:  now,
+				Deadline: now + 600, // 10 minutes deadline
+				Payload: map[string]any{
+					"model":      "test-model",
+					"prompt":     prompt,
+					"max_tokens": 500,
+				},
+			}
+		}
+
+		// Start background subscriber receiver before enqueuing to capture results as they arrive
+		var receivedCount atomic.Int64
+		recvCtx, recvCancel := context.WithCancel(ctx)
+		defer recvCancel()
+
+		go func() {
+			sub := pubsubClient.Subscriber(pubsubBenchResultSub)
+			sub.ReceiveSettings.MaxOutstandingMessages = 500
+			sub.ReceiveSettings.NumGoroutines = 8
+
+			_ = sub.Receive(recvCtx, func(rctx context.Context, msg *pubsub.Message) {
+				msg.Ack()
+				if receivedCount.Add(1) >= int64(numRequests) {
+					recvCancel()
+				}
+			})
+		}()
+
+		// Enqueue all messages concurrently via PubSub publisher
+		enqueuePubSubMessages(ctx, pubsubClient, pubsubBenchRequestTopic, msgs...)
+
+		ginkgo.By("Starting performance monitoring loop for pub/sub with prometheus gate")
+		var saturationMetrics []float64
+		monitorCtx, monitorCancel := context.WithCancel(ctx)
+		var monitorWg sync.WaitGroup
+		monitorWg.Add(1)
+
+		// Start a goroutine to poll Prometheus for saturation metrics during the benchmark run
+		go func() {
+			defer monitorWg.Done()
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-monitorCtx.Done():
+					return
+				case <-ticker.C:
+					// Send probe requests to drive flow control admission logic in EPP
+					sendProbeRequest(envoyURL)
+					satVal := queryProm(promURL, `inference_extension_flow_control_pool_saturation{inference_pool="e2e-pool"}`)
+					if !math.IsNaN(satVal) {
+						saturationMetrics = append(saturationMetrics, satVal)
+					}
+				}
+			}
+		}()
+
+		startTime := time.Now()
+
+		ginkgo.By("Waiting for all messages to be processed by pub/sub with prometheus gate")
+		gomega.Eventually(func() int64 {
+			return receivedCount.Load()
+		}, 10*time.Minute, 1*time.Second).Should(gomega.Equal(int64(numRequests)))
+
+		elapsedTime := time.Since(startTime)
+		monitorCancel()
+		monitorWg.Wait()
+
+		// Calculate average saturation
+		var avgSaturation float64
+		if len(saturationMetrics) > 0 {
+			var sum float64
+			for _, v := range saturationMetrics {
+				sum += v
+			}
+			avgSaturation = sum / float64(len(saturationMetrics))
+		}
+
+		ginkgo.GinkgoWriter.Printf("\n================ PUB/SUB PROMETHEUS GATE BENCHMARK RESULTS ================\n")
+		ginkgo.GinkgoWriter.Printf("Total Requests: %d\n", numRequests)
+		ginkgo.GinkgoWriter.Printf("Total Queue Clearing Time: %s\n", elapsedTime)
+		ginkgo.GinkgoWriter.Printf("Average Saturation Level: %.4f\n", avgSaturation)
+		ginkgo.GinkgoWriter.Printf("Saturation Metric Points Collected: %v\n", saturationMetrics)
+		ginkgo.GinkgoWriter.Printf("===========================================================================\n\n")
+
+		// Verify basic correctness: all messages were processed and received
+		gomega.Expect(receivedCount.Load()).To(gomega.Equal(int64(numRequests)))
 	})
 })
 

--- a/test/e2e/e2e_benchmark_test.go
+++ b/test/e2e/e2e_benchmark_test.go
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		// Wait for the result queue length to match the enqueued requests count
 		gomega.Eventually(func() int64 {
 			return getResultCount(ctx, rdb, benchmarkResultQueue)
-		}, 10*time.Minute, 5*time.Second).Should(gomega.Equal(int64(numRequests)))
+		}, 5*time.Minute, 5*time.Second).Should(gomega.Equal(int64(numRequests)))
 
 		elapsedTime := time.Since(startTime)
 		monitorCancel()
@@ -142,8 +142,9 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		ginkgo.GinkgoWriter.Printf("Saturation Metric Points Collected: %v\n", saturationMetrics)
 		ginkgo.GinkgoWriter.Printf("===================================================\n\n")
 
-		// Verify basic correctness: result queue contains all processed messages
+		// Verify basic correctness: result queue contains all processed messages and gate was exercised
 		gomega.Expect(getResultCount(ctx, rdb, benchmarkResultQueue)).To(gomega.Equal(int64(numRequests)))
+		gomega.Expect(saturationMetrics).ToNot(gomega.BeEmpty())
 	})
 
 	ginkgo.It("measure clearing time and saturation under load with pool-level gate", func() {
@@ -204,7 +205,7 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		// Wait for the result queue length to match the enqueued requests count
 		gomega.Eventually(func() int64 {
 			return getResultCount(ctx, rdb, benchmarkPoolGateResultQueue)
-		}, 10*time.Minute, 5*time.Second).Should(gomega.Equal(int64(numRequests)))
+		}, 5*time.Minute, 5*time.Second).Should(gomega.Equal(int64(numRequests)))
 
 		elapsedTime := time.Since(startTime)
 		monitorCancel()
@@ -227,8 +228,9 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		ginkgo.GinkgoWriter.Printf("Saturation Metric Points Collected: %v\n", saturationMetrics)
 		ginkgo.GinkgoWriter.Printf("====================================================================\n\n")
 
-		// Verify basic correctness: result queue contains all processed messages
+		// Verify basic correctness: result queue contains all processed messages and gate was exercised
 		gomega.Expect(getResultCount(ctx, rdb, benchmarkPoolGateResultQueue)).To(gomega.Equal(int64(numRequests)))
+		gomega.Expect(saturationMetrics).ToNot(gomega.BeEmpty())
 	})
 
 	ginkgo.It("measure clearing time and saturation under load with pub/sub transport and prometheus gate", func() {
@@ -306,7 +308,7 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		ginkgo.By("Waiting for all messages to be processed by pub/sub with prometheus gate")
 		gomega.Eventually(func() int64 {
 			return receivedCount.Load()
-		}, 10*time.Minute, 1*time.Second).Should(gomega.Equal(int64(numRequests)))
+		}, 5*time.Minute, 1*time.Second).Should(gomega.Equal(int64(numRequests)))
 
 		elapsedTime := time.Since(startTime)
 		monitorCancel()
@@ -329,8 +331,9 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		ginkgo.GinkgoWriter.Printf("Saturation Metric Points Collected: %v\n", saturationMetrics)
 		ginkgo.GinkgoWriter.Printf("===========================================================================\n\n")
 
-		// Verify basic correctness: all messages were processed and received
+		// Verify basic correctness: all messages were processed and received and gate was exercised
 		gomega.Expect(receivedCount.Load()).To(gomega.Equal(int64(numRequests)))
+		gomega.Expect(saturationMetrics).ToNot(gomega.BeEmpty())
 	})
 })
 

--- a/test/e2e/e2e_pubsub_test.go
+++ b/test/e2e/e2e_pubsub_test.go
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("GCP PubSub Integration", func() {
 		}
 	})
 
-	ginkgo.It("preserves caller attributes and metadata via GCP PubSub", func() {
+	ginkgo.It("accepts messages carrying caller attributes via GCP PubSub", func() {
 		msg := makeRequestMessage("pubsub-attr-1", 5*time.Minute)
 		msg.Metadata = map[string]string{
 			"custom-key": "custom-value",

--- a/test/e2e/e2e_pubsub_test.go
+++ b/test/e2e/e2e_pubsub_test.go
@@ -16,7 +16,7 @@ var _ = ginkgo.Describe("GCP PubSub Integration", func() {
 		ctx = context.Background()
 		setSimWaitingRequests(simAdminURL, 0)
 		setEnvoyFaultAbort(envoyAdminURL, 0)
-		drainPubSubResults(ctx, pubsubClient, pubsubResultSub)
+		recreatePubSubSubscription(ctx, pubsubClient, pubsubProjectID, pubsubResultSub, pubsubResultTopic)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe("GCP PubSub Integration", func() {
 		gomega.Expect(result.ID).To(gomega.Equal("pubsub-e2e-1"))
 	})
 
-	ginkgo.It("collects a batch of messages via GCP PubSub", func() {
+	ginkgo.It("processes multiple messages via GCP PubSub", func() {
 		msg1 := makeRequestMessage("pubsub-batch-1", 5*time.Minute)
 		msg2 := makeRequestMessage("pubsub-batch-2", 5*time.Minute)
 		msg3 := makeRequestMessage("pubsub-batch-3", 5*time.Minute)
@@ -59,6 +59,22 @@ var _ = ginkgo.Describe("GCP PubSub Integration", func() {
 		for _, id := range ids {
 			gomega.Expect(collected).To(gomega.HaveKey(id))
 		}
+	})
+
+	ginkgo.It("preserves caller attributes and metadata via GCP PubSub", func() {
+		msg := makeRequestMessage("pubsub-attr-1", 5*time.Minute)
+		msg.Metadata = map[string]string{
+			"custom-key": "custom-value",
+		}
+		enqueuePubSubMessage(ctx, pubsubClient, pubsubRequestTopic, msg)
+
+		var result *api.ResultMessage
+		gomega.Eventually(func() *api.ResultMessage {
+			result = popPubSubResult(ctx, pubsubClient, pubsubResultSub)
+			return result
+		}, 60*time.Second, 1*time.Second).ShouldNot(gomega.BeNil())
+
+		gomega.Expect(result.ID).To(gomega.Equal("pubsub-attr-1"))
 	})
 
 	ginkgo.It("retries on 5xx from the inference backend via GCP PubSub", func() {

--- a/test/e2e/e2e_pubsub_test.go
+++ b/test/e2e/e2e_pubsub_test.go
@@ -16,6 +16,7 @@ var _ = ginkgo.Describe("GCP PubSub Integration", func() {
 		ctx = context.Background()
 		setSimWaitingRequests(simAdminURL, 0)
 		setEnvoyFaultAbort(envoyAdminURL, 0)
+		drainPubSubResults(ctx, pubsubClient, pubsubResultSub)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/test/e2e/e2e_pubsub_test.go
+++ b/test/e2e/e2e_pubsub_test.go
@@ -1,0 +1,86 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	"github.com/llm-d/llm-d-async/api"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("GCP PubSub Integration", func() {
+	var ctx context.Context
+
+	ginkgo.BeforeEach(func() {
+		ctx = context.Background()
+		setSimWaitingRequests(simAdminURL, 0)
+		setEnvoyFaultAbort(envoyAdminURL, 0)
+	})
+
+	ginkgo.AfterEach(func() {
+		setEnvoyFaultAbort(envoyAdminURL, 0)
+		setEnvoyFaultDelay(envoyAdminURL, 0)
+	})
+
+	ginkgo.It("processes a message end-to-end via GCP PubSub", func() {
+		msg := makeRequestMessage("pubsub-e2e-1", 5*time.Minute)
+		enqueuePubSubMessage(ctx, pubsubClient, pubsubRequestTopic, msg)
+
+		var result *api.ResultMessage
+		gomega.Eventually(func() *api.ResultMessage {
+			result = popPubSubResult(ctx, pubsubClient, pubsubResultSub)
+			return result
+		}, 60*time.Second, 1*time.Second).ShouldNot(gomega.BeNil())
+
+		gomega.Expect(result.ID).To(gomega.Equal("pubsub-e2e-1"))
+	})
+
+	ginkgo.It("collects a batch of messages via GCP PubSub", func() {
+		msg1 := makeRequestMessage("pubsub-batch-1", 5*time.Minute)
+		msg2 := makeRequestMessage("pubsub-batch-2", 5*time.Minute)
+		msg3 := makeRequestMessage("pubsub-batch-3", 5*time.Minute)
+		enqueuePubSubMessages(ctx, pubsubClient, pubsubRequestTopic, msg1, msg2, msg3)
+
+		ids := []string{"pubsub-batch-1", "pubsub-batch-2", "pubsub-batch-3"}
+
+		collected := make(map[string]bool)
+		for i := 0; i < len(ids); i++ {
+			var result *api.ResultMessage
+			gomega.Eventually(func() *api.ResultMessage {
+				result = popPubSubResult(ctx, pubsubClient, pubsubResultSub)
+				return result
+			}, 60*time.Second, 1*time.Second).ShouldNot(gomega.BeNil())
+
+			collected[result.ID] = true
+		}
+
+		for _, id := range ids {
+			gomega.Expect(collected).To(gomega.HaveKey(id))
+		}
+	})
+
+	ginkgo.It("retries on 5xx from the inference backend via GCP PubSub", func() {
+		// Enable 100% fault injection so the first attempt fails with 503.
+		setEnvoyFaultAbort(envoyAdminURL, 100)
+
+		msg := makeRequestMessage("pubsub-retry-msg", 5*time.Minute)
+		enqueuePubSubMessage(ctx, pubsubClient, pubsubRequestTopic, msg)
+
+		// Message should not be delivered while faults are active.
+		gomega.Consistently(func() *api.ResultMessage {
+			return popPubSubResult(ctx, pubsubClient, pubsubResultSub)
+		}, 5*time.Second, 1*time.Second).Should(gomega.BeNil())
+
+		// Disable fault injection so retries succeed.
+		setEnvoyFaultAbort(envoyAdminURL, 0)
+
+		var result *api.ResultMessage
+		gomega.Eventually(func() *api.ResultMessage {
+			result = popPubSubResult(ctx, pubsubClient, pubsubResultSub)
+			return result
+		}, 120*time.Second, 1*time.Second).ShouldNot(gomega.BeNil())
+
+		gomega.Expect(result.ID).To(gomega.Equal("pubsub-retry-msg"))
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,7 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
@@ -33,6 +37,7 @@ const (
 
 	// Manifests
 	redisManifest      = "./yaml/redis.yaml"
+	pubsubManifest     = "./yaml/pubsub.yaml"
 	simManifest        = "./yaml/sim.yaml"
 	eppManifest        = "./yaml/epp.yaml"
 	eppConfigNoFC      = "./yaml/epp-config-no-fc.yaml"
@@ -49,6 +54,7 @@ const (
 
 var (
 	redisPort      string = env.GetEnvString("E2E_INTEGRATION_REDIS_PORT", "30480", ginkgo.GinkgoLogr)
+	pubsubPort     string = env.GetEnvString("E2E_INTEGRATION_PUBSUB_PORT", "30485", ginkgo.GinkgoLogr)
 	promPort       string = env.GetEnvString("E2E_INTEGRATION_PROM_PORT", "30491", ginkgo.GinkgoLogr)
 	simPort        string = env.GetEnvString("E2E_INTEGRATION_SIM_PORT", "30490", ginkgo.GinkgoLogr)
 	envoyPort      string = env.GetEnvString("E2E_INTEGRATION_ENVOY_PORT", "30492", ginkgo.GinkgoLogr)
@@ -60,6 +66,7 @@ var (
 	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
 	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
 	redisImage       = env.GetEnvString("REDIS_IMAGE", "valkey/valkey:8-alpine", ginkgo.GinkgoLogr)
+	pubsubImage      = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators", ginkgo.GinkgoLogr)
 	gaieRoot         = os.Getenv("GAIE_ROOT")
 	simRoot          = os.Getenv("SIM_ROOT")
 
@@ -70,6 +77,7 @@ var (
 	kindKubeconfig string
 
 	rdb           *redis.Client
+	pubsubClient  *pubsub.Client
 	promURL       string
 	simAdminURL   string
 	envoyURL      string
@@ -95,6 +103,9 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
+	if pubsubClient != nil {
+		pubsubClient.Close() //nolint:errcheck
+	}
 	if rdb != nil {
 		rdb.Close() //nolint:errcheck
 	}
@@ -181,6 +192,7 @@ func setupK8sCluster() {
 			gomega.Expect(stdin.Close()).To(gomega.Succeed())
 		}()
 		cfg := strings.ReplaceAll(kindClusterConfig, "${REDIS_PORT}", redisPort)
+		cfg = strings.ReplaceAll(cfg, "${PUBSUB_PORT}", pubsubPort)
 		cfg = strings.ReplaceAll(cfg, "${PROM_PORT}", promPort)
 		cfg = strings.ReplaceAll(cfg, "${SIM_PORT}", simPort)
 		cfg = strings.ReplaceAll(cfg, "${ENVOY_PORT}", envoyPort)
@@ -225,6 +237,9 @@ func setupK8sCluster() {
 
 	pullIfMissing(redisImage)
 	kindLoadImage(redisImage)
+
+	pullIfMissing(pubsubImage)
+	kindLoadImage(pubsubImage)
 
 	pullIfMissing("docker.io/envoyproxy/envoy:distroless-v1.33.2")
 	kindLoadImage("docker.io/envoyproxy/envoy:distroless-v1.33.2")
@@ -322,6 +337,18 @@ func applyManifests() {
 	ginkgo.By("Applying Redis manifest")
 	kubectlApplyFile(redisManifest, map[string]string{"${REDIS_IMAGE}": redisImage})
 
+	ginkgo.By("Applying PubSub emulator manifest")
+	kubectlApplyFile(pubsubManifest, map[string]string{"${PUBSUB_IMAGE}": pubsubImage})
+
+	ginkgo.By("Waiting for PubSub emulator deployment rollout")
+	cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
+		"-n", nsName, "rollout", "status", "deployment/pubsub-emulator", "--timeout=60s")
+	sess, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Eventually(sess).WithTimeout(60 * time.Second).Should(gexec.Exit(0))
+
+	setupPubSubEmulatorTopicsAndSubscriptions()
+
 	ginkgo.By("Applying sim manifest")
 	kubectlApplyFile(simManifest, nil)
 	kubectlApplyFile(simDeployManifest, map[string]string{"${SIM_IMAGE}": simImage})
@@ -350,6 +377,7 @@ func applyManifests() {
 	imageRepo, imageTag := splitImage(apImage)
 	for _, r := range []struct{ name, values string }{
 		{"integration", helmValuesDir + "/integration.yaml"},
+		{"pubsub", helmValuesDir + "/pubsub.yaml"},
 		{"saturation", helmValuesDir + "/saturation.yaml"},
 		{"budget", helmValuesDir + "/budget.yaml"},
 		{"redis-gate", helmValuesDir + "/redis-gate.yaml"},
@@ -446,6 +474,12 @@ func setupClients() {
 	gomega.Eventually(func() error {
 		return rdb.Ping(context.Background()).Err()
 	}, 30*time.Second, 1*time.Second).Should(gomega.Succeed())
+
+	ginkgo.By("Creating PubSub client on localhost:" + pubsubPort)
+	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
+	var err error
+	pubsubClient, err = pubsub.NewClient(context.Background(), "test-project")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Waiting for Prometheus to be ready")
 	gomega.Eventually(func(g gomega.Gomega) {
@@ -582,6 +616,7 @@ func doRedeployEPPWithFlowControl() {
 	// window can get 404s from Envoy that are classified as non-retryable.
 	for _, deploy := range []string{
 		"integration-llm-d-async",
+		"pubsub-llm-d-async",
 		"saturation-llm-d-async",
 		"budget-llm-d-async",
 		"redis-gate-llm-d-async",
@@ -604,6 +639,7 @@ func doRedeployEPPWithFlowControl() {
 	}
 	for _, deploy := range []string{
 		"integration-llm-d-async",
+		"pubsub-llm-d-async",
 		"saturation-llm-d-async",
 		"budget-llm-d-async",
 		"redis-gate-llm-d-async",
@@ -654,6 +690,9 @@ nodes:
   - containerPort: 30480
     hostPort: ${REDIS_PORT}
     protocol: TCP
+  - containerPort: 30485
+    hostPort: ${PUBSUB_PORT}
+    protocol: TCP
   - containerPort: 30491
     hostPort: ${PROM_PORT}
     protocol: TCP
@@ -670,3 +709,51 @@ nodes:
     hostPort: ${JAEGER_PORT}
     protocol: TCP
 `
+
+func setupPubSubEmulatorTopicsAndSubscriptions() {
+	ginkgo.By("Setting up PubSub emulator topics and subscriptions")
+	ctx := context.Background()
+	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
+
+	var client *pubsub.Client
+	gomega.Eventually(func() error {
+		var err error
+		client, err = pubsub.NewClient(ctx, "test-project")
+		if err != nil {
+			return err
+		}
+		reqTopic := "projects/test-project/topics/pubsub-e2e-request-topic"
+		_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: reqTopic})
+		if err != nil && status.Code(err) != codes.AlreadyExists {
+			_ = client.Close()
+			return err
+		}
+		return nil
+	}, 120*time.Second, 2*time.Second).Should(gomega.Succeed())
+	defer client.Close() //nolint:errcheck
+
+	resTopic := "projects/test-project/topics/pubsub-e2e-result-topic"
+	reqSub := "projects/test-project/subscriptions/pubsub-e2e-request-sub"
+	resSub := "projects/test-project/subscriptions/pubsub-e2e-result-sub"
+
+	_, err := client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: resTopic})
+	if err != nil && status.Code(err) != codes.AlreadyExists {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  reqSub,
+		Topic: "projects/test-project/topics/pubsub-e2e-request-topic",
+	})
+	if err != nil && status.Code(err) != codes.AlreadyExists {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  resSub,
+		Topic: resTopic,
+	})
+	if err != nil && status.Code(err) != codes.AlreadyExists {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -392,6 +392,7 @@ func applyManifests() {
 		{"mt-merge", helmValuesDir + "/mt-merge.yaml"},
 		{"benchmark", helmValuesDir + "/benchmark.yaml"},
 		{"benchmark-pool-gate", helmValuesDir + "/benchmark-pool-gate.yaml"},
+		{"benchmark-pubsub", helmValuesDir + "/benchmark-pubsub.yaml"},
 	} {
 		helmInstall(r.name, r.values, map[string]string{
 			"ap.image.repository": imageRepo,
@@ -630,6 +631,7 @@ func doRedeployEPPWithFlowControl() {
 		"mt-merge-llm-d-async",
 		"benchmark-llm-d-async",
 		"benchmark-pool-gate-llm-d-async",
+		"benchmark-pubsub-llm-d-async",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "restart", "deployment/"+deploy)
@@ -653,6 +655,7 @@ func doRedeployEPPWithFlowControl() {
 		"mt-merge-llm-d-async",
 		"benchmark-llm-d-async",
 		"benchmark-pool-gate-llm-d-async",
+		"benchmark-pubsub-llm-d-async",
 	} {
 		cmd := exec.Command("kubectl", "--kubeconfig", kindKubeconfig,
 			"-n", nsName, "rollout", "status", "deployment/"+deploy, "--timeout=120s")
@@ -714,10 +717,25 @@ func setupPubSubEmulatorTopicsAndSubscriptions() {
 	ginkgo.By("Setting up PubSub emulator topics and subscriptions")
 	ctx := context.Background()
 
-	reqTopic := fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubRequestTopic)
-	resTopic := fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubResultTopic)
-	reqSub := fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubRequestSub)
-	resSub := fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubResultSub)
+	pairs := []struct {
+		reqTopic string
+		reqSub   string
+		resTopic string
+		resSub   string
+	}{
+		{
+			reqTopic: fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubRequestTopic),
+			reqSub:   fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubRequestSub),
+			resTopic: fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubResultTopic),
+			resSub:   fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubResultSub),
+		},
+		{
+			reqTopic: fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubBenchRequestTopic),
+			reqSub:   fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubBenchRequestSub),
+			resTopic: fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubBenchResultTopic),
+			resSub:   fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubBenchResultSub),
+		},
+	}
 
 	var client *pubsub.Client
 	gomega.Eventually(func() error {
@@ -726,33 +744,37 @@ func setupPubSubEmulatorTopicsAndSubscriptions() {
 		if err != nil {
 			return err
 		}
-		_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: reqTopic})
-		if err != nil && status.Code(err) != codes.AlreadyExists {
-			_ = client.Close()
-			return err
+		for _, p := range pairs {
+			_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: p.reqTopic})
+			if err != nil && status.Code(err) != codes.AlreadyExists {
+				_ = client.Close()
+				return err
+			}
 		}
 		return nil
 	}, 120*time.Second, 2*time.Second).Should(gomega.Succeed())
 	defer client.Close() //nolint:errcheck
 
-	_, err := client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: resTopic})
-	if err != nil && status.Code(err) != codes.AlreadyExists {
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
+	for _, p := range pairs {
+		_, err := client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: p.resTopic})
+		if err != nil && status.Code(err) != codes.AlreadyExists {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 
-	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
-		Name:  reqSub,
-		Topic: reqTopic,
-	})
-	if err != nil && status.Code(err) != codes.AlreadyExists {
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
+		_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+			Name:  p.reqSub,
+			Topic: p.reqTopic,
+		})
+		if err != nil && status.Code(err) != codes.AlreadyExists {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 
-	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
-		Name:  resSub,
-		Topic: resTopic,
-	})
-	if err != nil && status.Code(err) != codes.AlreadyExists {
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+			Name:  p.resSub,
+			Topic: p.resTopic,
+		})
+		if err != nil && status.Code(err) != codes.AlreadyExists {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 	}
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -95,6 +95,7 @@ func TestEndToEnd(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	setupK8sCluster()
 	gomega.Expect(os.Setenv("KUBECONFIG", kindKubeconfig)).To(gomega.Succeed())
+	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
 	testConfig = testutils.NewTestConfig(nsName, "")
 	setupK8sClient()
 	setupNameSpace()
@@ -476,7 +477,6 @@ func setupClients() {
 	}, 30*time.Second, 1*time.Second).Should(gomega.Succeed())
 
 	ginkgo.By("Creating PubSub client on localhost:" + pubsubPort)
-	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
 	var err error
 	pubsubClient, err = pubsub.NewClient(context.Background(), pubsubProjectID)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -713,7 +713,6 @@ nodes:
 func setupPubSubEmulatorTopicsAndSubscriptions() {
 	ginkgo.By("Setting up PubSub emulator topics and subscriptions")
 	ctx := context.Background()
-	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
 
 	reqTopic := fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubRequestTopic)
 	resTopic := fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubResultTopic)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -66,7 +66,7 @@ var (
 	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
 	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
 	redisImage       = env.GetEnvString("REDIS_IMAGE", "valkey/valkey:8-alpine", ginkgo.GinkgoLogr)
-	pubsubImage      = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators", ginkgo.GinkgoLogr)
+	pubsubImage      = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:513.0.0-emulators", ginkgo.GinkgoLogr)
 	gaieRoot         = os.Getenv("GAIE_ROOT")
 	simRoot          = os.Getenv("SIM_ROOT")
 
@@ -478,7 +478,7 @@ func setupClients() {
 	ginkgo.By("Creating PubSub client on localhost:" + pubsubPort)
 	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
 	var err error
-	pubsubClient, err = pubsub.NewClient(context.Background(), "test-project")
+	pubsubClient, err = pubsub.NewClient(context.Background(), pubsubProjectID)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Waiting for Prometheus to be ready")
@@ -715,14 +715,18 @@ func setupPubSubEmulatorTopicsAndSubscriptions() {
 	ctx := context.Background()
 	gomega.Expect(os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:"+pubsubPort)).To(gomega.Succeed())
 
+	reqTopic := fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubRequestTopic)
+	resTopic := fmt.Sprintf("projects/%s/topics/%s", pubsubProjectID, pubsubResultTopic)
+	reqSub := fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubRequestSub)
+	resSub := fmt.Sprintf("projects/%s/subscriptions/%s", pubsubProjectID, pubsubResultSub)
+
 	var client *pubsub.Client
 	gomega.Eventually(func() error {
 		var err error
-		client, err = pubsub.NewClient(ctx, "test-project")
+		client, err = pubsub.NewClient(ctx, pubsubProjectID)
 		if err != nil {
 			return err
 		}
-		reqTopic := "projects/test-project/topics/pubsub-e2e-request-topic"
 		_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: reqTopic})
 		if err != nil && status.Code(err) != codes.AlreadyExists {
 			_ = client.Close()
@@ -732,10 +736,6 @@ func setupPubSubEmulatorTopicsAndSubscriptions() {
 	}, 120*time.Second, 2*time.Second).Should(gomega.Succeed())
 	defer client.Close() //nolint:errcheck
 
-	resTopic := "projects/test-project/topics/pubsub-e2e-result-topic"
-	reqSub := "projects/test-project/subscriptions/pubsub-e2e-request-sub"
-	resSub := "projects/test-project/subscriptions/pubsub-e2e-result-sub"
-
 	_, err := client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: resTopic})
 	if err != nil && status.Code(err) != codes.AlreadyExists {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -743,7 +743,7 @@ func setupPubSubEmulatorTopicsAndSubscriptions() {
 
 	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
 		Name:  reqSub,
-		Topic: "projects/test-project/topics/pubsub-e2e-request-topic",
+		Topic: reqTopic,
 	})
 	if err != nil && status.Code(err) != codes.AlreadyExists {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/helm/benchmark-pubsub.yaml
+++ b/test/e2e/helm/benchmark-pubsub.yaml
@@ -1,0 +1,27 @@
+ap:
+  imagePullPolicy: Never
+  concurrency: 64
+  prometheusURL: "http://prometheus.e2e-integration.svc.cluster.local:9090"
+  prometheusCacheTTL: "0s"
+  transport: gcp-pubsub
+  transportConfig:
+    project_id: "test-project"
+    result_topic_id: "pubsub-bench-result-topic"
+    batch_size: 256
+    topics:
+      - subscriber_id: "pubsub-bench-request-sub"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+        gate_type: "prometheus-saturation"
+        gate_params:
+          pool: "e2e-pool"
+          threshold: "0.8"
+  env:
+    - name: PUBSUB_EMULATOR_HOST
+      value: "pubsub-emulator.e2e-integration.svc.cluster.local:8085"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/helm/benchmark-pubsub.yaml
+++ b/test/e2e/helm/benchmark-pubsub.yaml
@@ -7,7 +7,7 @@ ap:
   transportConfig:
     project_id: "test-project"
     result_topic_id: "pubsub-bench-result-topic"
-    batch_size: 256
+    batch_size: 64
     topics:
       - subscriber_id: "pubsub-bench-request-sub"
         request_path_url: "/v1/completions"

--- a/test/e2e/helm/pubsub.yaml
+++ b/test/e2e/helm/pubsub.yaml
@@ -1,0 +1,27 @@
+ap:
+  imagePullPolicy: Never
+  concurrency: 1
+  prometheusCacheTTL: "0s"
+  otel:
+    endpoint: "http://jaeger.e2e-integration.svc.cluster.local:4317"
+    insecure: true
+    sampler: "always_on"
+    samplerArg: "1.0"
+  transport: gcp-pubsub
+  transportConfig:
+    project_id: "test-project"
+    result_topic_id: "pubsub-e2e-result-topic"
+    batch_size: 10
+    topics:
+      - subscriber_id: "pubsub-e2e-request-sub"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://envoy.e2e-integration.svc.cluster.local:8081"
+  env:
+    - name: PUBSUB_EMULATOR_HOST
+      value: "pubsub-emulator.e2e-integration.svc.cluster.local:8085"
+  metrics:
+    enabled: true
+    port: 9090
+    secure: false
+  modelServerMonitor:
+    enabled: false

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -47,6 +48,7 @@ const (
 	benchmarkPoolGateRequestQueue = "benchmark-pool-gate-request-sortedset"
 	benchmarkPoolGateResultQueue  = "benchmark-pool-gate-result-list"
 
+	pubsubProjectID    = "test-project"
 	pubsubRequestTopic = "pubsub-e2e-request-topic"
 	pubsubRequestSub   = "pubsub-e2e-request-sub"
 	pubsubResultTopic  = "pubsub-e2e-result-topic"
@@ -134,24 +136,42 @@ func enqueuePubSubMessages(ctx context.Context, client *pubsub.Client, topic str
 
 func popPubSubResult(ctx context.Context, client *pubsub.Client, subName string) *api.ResultMessage {
 	sub := client.Subscriber(subName)
+	sub.ReceiveSettings.MaxOutstandingMessages = 1
+	sub.ReceiveSettings.NumGoroutines = 1
+
 	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	var result *api.ResultMessage
 	var mu sync.Mutex
-	_ = sub.Receive(cctx, func(rctx context.Context, msg *pubsub.Message) {
+	err := sub.Receive(cctx, func(rctx context.Context, msg *pubsub.Message) {
 		mu.Lock()
 		defer mu.Unlock()
 		if result == nil {
 			var r api.ResultMessage
 			if json.Unmarshal(msg.Data, &r) == nil {
 				result = &r
+				msg.Ack()
+				cancel()
+				return
 			}
 		}
-		msg.Ack()
-		cancel()
+		msg.Nack()
 	})
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		ginkgo.GinkgoLogr.V(1).Info("popPubSubResult receive error", "error", err, "sub", subName)
+	}
 	return result
+}
+
+func drainPubSubResults(ctx context.Context, client *pubsub.Client, subName string) {
+	dctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	for dctx.Err() == nil {
+		if popPubSubResult(dctx, client, subName) == nil {
+			break
+		}
+	}
 }
 
 func makeRequestMessage(id string, deadlineOffset time.Duration) api.RequestMessage {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -53,6 +53,11 @@ const (
 	pubsubRequestSub   = "pubsub-e2e-request-sub"
 	pubsubResultTopic  = "pubsub-e2e-result-topic"
 	pubsubResultSub    = "pubsub-e2e-result-sub"
+
+	pubsubBenchRequestTopic = "pubsub-bench-request-topic"
+	pubsubBenchRequestSub   = "pubsub-bench-request-sub"
+	pubsubBenchResultTopic  = "pubsub-bench-result-topic"
+	pubsubBenchResultSub    = "pubsub-bench-result-sub"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}
@@ -128,9 +133,27 @@ func enqueuePubSubMessage(ctx context.Context, client *pubsub.Client, topic stri
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 }
 
+// enqueuePubSubMessages enqueues multiple messages to a PubSub topic. It publishes
+// all messages concurrently before waiting on publish results, allowing the SDK's
+// internal bundler to batch requests into efficient RPCs for bulk benchmarks (e.g. 5,000 msgs)
+// without blocking sequentially on each message round-trip.
 func enqueuePubSubMessages(ctx context.Context, client *pubsub.Client, topic string, msgs ...api.RequestMessage) {
-	for _, msg := range msgs {
-		enqueuePubSubMessage(ctx, client, topic, msg)
+	publisher := client.Publisher(topic)
+	results := make([]*pubsub.PublishResult, len(msgs))
+	for i, msg := range msgs {
+		data, err := json.Marshal(msg)
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		pubMsg := &pubsub.Message{
+			Data: data,
+		}
+		if msg.Metadata != nil {
+			pubMsg.Attributes = msg.Metadata
+		}
+		results[i] = publisher.Publish(ctx, pubMsg)
+	}
+	for _, res := range results {
+		_, err := res.Get(ctx)
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	}
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -9,8 +9,10 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/redis/go-redis/v9"
@@ -44,6 +46,11 @@ const (
 
 	benchmarkPoolGateRequestQueue = "benchmark-pool-gate-request-sortedset"
 	benchmarkPoolGateResultQueue  = "benchmark-pool-gate-result-list"
+
+	pubsubRequestTopic = "pubsub-e2e-request-topic"
+	pubsubRequestSub   = "pubsub-e2e-request-sub"
+	pubsubResultTopic  = "pubsub-e2e-result-topic"
+	pubsubResultSub    = "pubsub-e2e-result-sub"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}
@@ -103,6 +110,48 @@ func popResult(ctx context.Context, rdb *redis.Client, queue string) *api.Result
 	var msg api.ResultMessage
 	gomega.ExpectWithOffset(1, json.Unmarshal([]byte(val), &msg)).To(gomega.Succeed())
 	return &msg
+}
+
+func enqueuePubSubMessage(ctx context.Context, client *pubsub.Client, topic string, msg api.RequestMessage) {
+	data, err := json.Marshal(msg)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	pubMsg := &pubsub.Message{
+		Data: data,
+	}
+	if msg.Metadata != nil {
+		pubMsg.Attributes = msg.Metadata
+	}
+	res := client.Publisher(topic).Publish(ctx, pubMsg)
+	_, err = res.Get(ctx)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+}
+
+func enqueuePubSubMessages(ctx context.Context, client *pubsub.Client, topic string, msgs ...api.RequestMessage) {
+	for _, msg := range msgs {
+		enqueuePubSubMessage(ctx, client, topic, msg)
+	}
+}
+
+func popPubSubResult(ctx context.Context, client *pubsub.Client, subName string) *api.ResultMessage {
+	sub := client.Subscriber(subName)
+	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	var result *api.ResultMessage
+	var mu sync.Mutex
+	_ = sub.Receive(cctx, func(rctx context.Context, msg *pubsub.Message) {
+		mu.Lock()
+		defer mu.Unlock()
+		if result == nil {
+			var r api.ResultMessage
+			if json.Unmarshal(msg.Data, &r) == nil {
+				result = &r
+			}
+		}
+		msg.Ack()
+		cancel()
+	})
+	return result
 }
 
 func makeRequestMessage(id string, deadlineOffset time.Duration) api.RequestMessage {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/llm-d/llm-d-async/api"
 )
@@ -189,8 +191,11 @@ func popPubSubResult(ctx context.Context, client *pubsub.Client, subName string)
 func recreatePubSubSubscription(ctx context.Context, client *pubsub.Client, projectID, subID, topicID string) {
 	subName := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID)
 	topicName := fmt.Sprintf("projects/%s/topics/%s", projectID, topicID)
-	_ = client.SubscriptionAdminClient.DeleteSubscription(ctx, &pubsubpb.DeleteSubscriptionRequest{Subscription: subName})
-	_, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+	err := client.SubscriptionAdminClient.DeleteSubscription(ctx, &pubsubpb.DeleteSubscriptionRequest{Subscription: subName})
+	if err != nil && status.Code(err) != codes.NotFound {
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	}
+	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
 		Name:  subName,
 		Topic: topicName,
 	})

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/redis/go-redis/v9"
@@ -139,22 +139,21 @@ func popPubSubResult(ctx context.Context, client *pubsub.Client, subName string)
 	sub.ReceiveSettings.MaxOutstandingMessages = 1
 	sub.ReceiveSettings.NumGoroutines = 1
 
-	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	var result *api.ResultMessage
-	var mu sync.Mutex
 	err := sub.Receive(cctx, func(rctx context.Context, msg *pubsub.Message) {
-		mu.Lock()
-		defer mu.Unlock()
 		if result == nil {
 			var r api.ResultMessage
-			if json.Unmarshal(msg.Data, &r) == nil {
+			if err := json.Unmarshal(msg.Data, &r); err != nil {
+				ginkgo.GinkgoLogr.V(1).Info("popPubSubResult unmarshal error", "error", err, "sub", subName)
+			} else {
 				result = &r
-				msg.Ack()
-				cancel()
-				return
 			}
+			msg.Ack()
+			cancel()
+			return
 		}
 		msg.Nack()
 	})
@@ -164,14 +163,15 @@ func popPubSubResult(ctx context.Context, client *pubsub.Client, subName string)
 	return result
 }
 
-func drainPubSubResults(ctx context.Context, client *pubsub.Client, subName string) {
-	dctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	for dctx.Err() == nil {
-		if popPubSubResult(dctx, client, subName) == nil {
-			break
-		}
-	}
+func recreatePubSubSubscription(ctx context.Context, client *pubsub.Client, projectID, subID, topicID string) {
+	subName := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID)
+	topicName := fmt.Sprintf("projects/%s/topics/%s", projectID, topicID)
+	_ = client.SubscriptionAdminClient.DeleteSubscription(ctx, &pubsubpb.DeleteSubscriptionRequest{Subscription: subName})
+	_, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  subName,
+		Topic: topicName,
+	})
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 }
 
 func makeRequestMessage(id string, deadlineOffset time.Duration) api.RequestMessage {

--- a/test/e2e/yaml/pubsub.yaml
+++ b/test/e2e/yaml/pubsub.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pubsub-emulator
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pubsub-emulator
+  template:
+    metadata:
+      labels:
+        app: pubsub-emulator
+    spec:
+      containers:
+        - name: pubsub-emulator
+          image: ${PUBSUB_IMAGE}
+          command:
+            - gcloud
+            - beta
+            - emulators
+            - pubsub
+            - start
+            - --host-port=0.0.0.0:8085
+          ports:
+            - containerPort: 8085
+          readinessProbe:
+            tcpSocket:
+              port: 8085
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pubsub-emulator
+  namespace: ${NAMESPACE}
+spec:
+  type: NodePort
+  selector:
+    app: pubsub-emulator
+  ports:
+    - port: 8085
+      targetPort: 8085
+      nodePort: 30485


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

Add GCP PubSub transport testing to the end-to-end test suite using the GCP PubSub emulator.
- Add Kubernetes manifest for PubSub emulator (gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators) exposed via NodePort.
- Update Helm chart deployment template (ap-deployments.yaml) to support injecting custom environment variables via `ap.env`.
- Add Helm configuration (pubsub.yaml) for gcp-pubsub transport configured with PUBSUB_EMULATOR_HOST.
- Add PubSub test utility functions (enqueuePubSubMessage, enqueuePubSubMessages, popPubSubResult) to utils_test.go.
- Add e2e_pubsub_test.go covering end-to-end request processing, batching, and 5xx retries.


## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

Fixes #83 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
NONE
```
