### PR TITLE
fix: add false positives to .typos.toml (issue #377) Fixes #377

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,9 +4,18 @@ KServe = "KServe"
 vLLM = "vLLM"
 IST = "IST"
 # Go convention: `typ` is a common identifier (since `type` is a keyword);
-# `unmarshaling` is the standard Go/American spelling (typos suggests British).
 typ = "typ"
+# `unmarshaling` is the standard Go/American spelling (typos suggests British).
 unmarshaling = "unmarshaling"
+# `mis-` is a valid English prefix meaning "wrongly/badly" (e.g. mis-sized, mis-configured);
+# the hyphen causes typos to tokenize `mis` as a standalone word and flag it as `miss`.
+mis = "mis"
+
+# `ZADDed` is the past tense of the Redis ZADD command used as a verb in comments;
+ZADDed = "ZADDed"
+
+# typos sees the trailing `Ded` token and flags it as `Dead`.
+Ded = "Ded"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## What does this PR do?

This adds three spelling exceptions to typos.toml to prevent overnight job from picking up false positives.

## Why is this change needed?

The overnight job was picking up false positives on these terms.

## How was this tested?
These are string only changes.

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [X] Tests pass locally (`make test`)
- [X] Linters pass (`make lint`)
- [X] Documentation updated (if applicable)

## Related Issues

Fixes #377 

## Release note

```release-note
NONE
```
