### PR TITLE
Fix/typo fix

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -7,7 +7,6 @@ IST = "IST"
 # `unmarshaling` is the standard Go/American spelling (typos suggests British).
 typ = "typ"
 unmarshaling = "unmarshaling"
-mis-sized="mis-sized"
 
 [files]
 extend-exclude = [
@@ -21,6 +20,9 @@ extend-exclude = [
 ]
 
 [default]
-extend-ignore-words-re = [
-    "^mis-.*$",
+extend-ignore-re = [
+    # Ignore prefix 'mis-' case insensitive, so it ignores the false error on 'mis-sized' 
+    "(?i)mis-[[:alpha:]]+",
+    #Ignore zadd case insensitive so it ignore the false error on 'ZADDed' word.                                        
+    "(?i)zadd[[:alpha:]]+",
 ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -7,6 +7,7 @@ IST = "IST"
 # `unmarshaling` is the standard Go/American spelling (typos suggests British).
 typ = "typ"
 unmarshaling = "unmarshaling"
+mis-sized="mis-sized"
 
 [files]
 extend-exclude = [
@@ -17,4 +18,9 @@ extend-exclude = [
     "go.sum",
     "build/",
     "testdata/"
+]
+
+[default]
+extend-ignore-words-re = [
+    "^mis-.*$",
 ]

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -315,7 +315,7 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 		// Report the resolved closing point. Every source in the cascade divides
 		// by max_concurrency per pod, so a value the pool can never reach leaves
 		// the gate permanently open with nothing in the logs or metrics to say so.
-		// Surfacing it here makes a miss-sized max_concurrency visible at startup.
+		// Surfacing it here makes a mis-sized max_concurrency visible at startup.
 		f.logger.Info("prometheus-budget gate configured",
 			"pool", pool,
 			"maxConcurrency", maxConcurrency,

--- a/pkg/async/inference/flowcontrol/gate_factory.go
+++ b/pkg/async/inference/flowcontrol/gate_factory.go
@@ -315,7 +315,7 @@ func (f *GateFactory) CreateGate(cfg pipeline.GateConfig) (pipeline.Gate, error)
 		// Report the resolved closing point. Every source in the cascade divides
 		// by max_concurrency per pod, so a value the pool can never reach leaves
 		// the gate permanently open with nothing in the logs or metrics to say so.
-		// Surfacing it here makes a mis-sized max_concurrency visible at startup.
+		// Surfacing it here makes a miss-sized max_concurrency visible at startup.
 		f.logger.Info("prometheus-budget gate configured",
 			"pool", pool,
 			"maxConcurrency", maxConcurrency,


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->
This Cahnge adds two ignore RE rules to skip typos check

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->
The issue discribed in issue #377 should not be a error since mis-sized makes sense over miss-sized. To address this issue, added ignore RE rule to skip similar issue so that any word starting with mis- is treated as meaningful and valid.
Similar for ZADDed which is also reqported as error by the typos tool, but it apparantly is a valid function name for this product. 

## How was this tested?
Run the 
<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x ] Manual testing performed 

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ x] Tests pass locally (`make test`)
- [ x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
NONE
```
