### PR TITLE
test(e2e): update expired message test to expect DEADLINE_EXCEEDED results

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -108,25 +108,31 @@ var _ = ginkgo.Describe("General Integration", func() {
 		gomega.Expect(result.ID).To(gomega.Equal("retry-msg"))
 	})
 
-	ginkgo.It("drops expired messages and processes valid ones", func() {
+	ginkgo.It("surfaces expired messages as deadline exceeded and processes valid ones", func() {
 		expiredMsg := makeRequestMessage("expired-msg", -100*time.Second)
 		validMsg := makeRequestMessage("valid-msg", 5*time.Minute)
 
 		enqueueMessage(ctx, rdb, integrationRequestQueue, expiredMsg)
 		enqueueMessage(ctx, rdb, integrationRequestQueue, validMsg)
 
-		// The expired message is silently dropped at dequeue time (deadline
-		// already in the past). Only the valid message produces a result.
+		// The expired message emits a DEADLINE_EXCEEDED result at dequeue time (deadline
+		// already in the past). The valid message is dispatched and produces a successful result.
 		gomega.Eventually(func() int64 {
 			return getResultCount(ctx, rdb, integrationResultQueue)
-		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 1))
+		}, 60*time.Second, 1*time.Second).Should(gomega.BeNumerically(">=", 2))
 
-		result := popResult(ctx, rdb, integrationResultQueue)
-		gomega.Expect(result).NotTo(gomega.BeNil())
-		gomega.Expect(result.ID).To(gomega.Equal("valid-msg"))
+		expiredResult := popResult(ctx, rdb, integrationResultQueue)
+		gomega.Expect(expiredResult).NotTo(gomega.BeNil())
+		gomega.Expect(expiredResult.ID).To(gomega.Equal("expired-msg"))
+		gomega.Expect(expiredResult.ErrorCode).To(gomega.Equal(api.ErrCodeDeadlineExceeded))
+		gomega.Expect(expiredResult.ErrorMessage).To(gomega.Equal("deadline exceeded"))
 
-		// Verify the expired message was removed from the request queue
-		// without producing a result.
+		validResult := popResult(ctx, rdb, integrationResultQueue)
+		gomega.Expect(validResult).NotTo(gomega.BeNil())
+		gomega.Expect(validResult.ID).To(gomega.Equal("valid-msg"))
+		gomega.Expect(validResult.ErrorCode).To(gomega.BeEmpty())
+
+		// Verify no other messages remain in the result queue.
 		gomega.Consistently(func() int64 {
 			return getResultCount(ctx, rdb, integrationResultQueue)
 		}, 3*time.Second, 500*time.Millisecond).Should(gomega.Equal(int64(0)))


### PR DESCRIPTION

## What does this PR do?

following PR #394, the Redis sorted-set flow surfaces deadline-expired messages as DEADLINE_EXCEEDED result messages instead of silently dropping them at dequeue time.
Update the "drops expired messages and processes valid ones" e2e test to:
- Expect two results in the result queue instead of one.
- Assert that the expired message produces a DEADLINE_EXCEEDED result with error message "deadline exceeded".
- Assert that the valid message is processed successfully.

## Why is this change needed?

Fixes: #399 399

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

## Release note

<!--
Summarize any user-facing change in one entry, or write `NONE` if there is none.
For a user-facing change, ALSO add a fragment file
`release-notes.d/unreleased/<PR-number>.md` (see CONTRIBUTING.md → Release notes).
Prefix breaking changes with `Breaking:` and note the deprecation window.
-->
```release-note
NONE
```
