### PR TITLE
feat(redis): hot reload sorted-set queue configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ make deploy-ap-on-k8s
        kubectl run --rm -i -t publishmsgbox --image=redis --restart=Never -- /usr/local/bin/redis-cli -h $REDIS_IP PUBLISH request-queue '{"id" : "testmsg", "payload":{ "model":"food-review-1", "prompt":"Hi, good morning "}, "deadline" :23472348233323 }'
      ```
 
-## Configuration Reference
-
 ### Command Line Parameters
 
 **Core:**
@@ -205,6 +203,7 @@ make deploy-ap-on-k8s
 | `transport` | `redis-pubsub` | The transport (message queue) implementation. One of `redis-pubsub`, `redis-sortedset`, `gcp-pubsub`. Gating is configured per queue/topic via `gate_type` in the transport config (this replaces the former `gcp-pubsub-gated` implementation). |
 | `transport-config` | — | Inline JSON transport configuration. See [Transport Configuration](#transport-configuration). Mutually exclusive with `transport-config-file`; exactly one of the two is required. |
 | `transport-config-file` | — | Path to a JSON file with the transport configuration. Mutually exclusive with `transport-config`. |
+| `transport-config-watch-interval` | `0` | For `redis-sortedset` only, periodically reloads the `queues` field from `transport-config-file`. The file must contain a complete valid transport configuration. Changes to other transport fields require a restart. |
 | `pool-config-file` | — | Path to the JSON worker pool definitions. If omitted, a single `"default"` worker pool is created with concurrency determined by the global `concurrency` flag. See [Worker Pools Configuration](#worker-pools-configuration). |
 | `request-merge-policy-config-file` | — | Path to the JSON request merge policy specification (`type` and `parameters`). If not specified, defaults to the `random-robin` policy. The older `--request-merge-policy-config` name is a deprecated alias. |
 | `transform-config-file` | — | Path to the JSON request body transform configuration. Empty disables transforms. See [Request Body Transform Reference](#request-body-transform-reference). |
@@ -276,6 +275,8 @@ The transport (message queue) is selected with `--transport` and configured with
   "queues": [ { "queue_name": "request-sortedset", "igw_base_url": "http://localhost:30800", "gate_type": "redis", "gate_params": { "address": "localhost:6379" } } ]
 }
 ```
+
+Queue hot reload is enabled with `--transport redis-sortedset --transport-config-file FILE --transport-config-watch-interval INTERVAL`. Only `queues` may change; URL, retry/result queue names, polling, batch, tracing, and any other transport fields are rejected until restart. An empty `queues` array drains all queues, and queues may be added again by a later reload. Inline `--transport-config` and deprecated per-backend queue configuration do not support hot reload.
 
 **`gcp-pubsub`:**
 ```json

--- a/api/internal_api.go
+++ b/api/internal_api.go
@@ -37,6 +37,8 @@ type InternalRouting struct {
 	RequestToken           string `json:"request_token,omitempty"`
 	RequestQueueName       string `json:"request_queue_name,omitempty"`
 	ResultQueueName        string `json:"result_queue_name,omitempty"`
+	ResultTTLSeconds       int64  `json:"result_ttl_seconds,omitempty"`
+	ResultRoutingResolved  bool   `json:"result_routing_resolved,omitempty"`
 	TransportCorrelationID string `json:"transport_correlation_id,omitempty"`
 	// Labels is the framework's per-message label set. Seeded by the
 	// Flow at pull time from the originating channel's effective

--- a/api/internal_api_test.go
+++ b/api/internal_api_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRoundTrip_PlainRequestMessage(t *testing.T) {
 	ir := NewInternalRequest(
-		InternalRouting{RetryCount: 2, RequestQueueName: "rq", ResultQueueName: "resq"},
+		InternalRouting{RetryCount: 2, RequestQueueName: "rq", ResultQueueName: "resq", ResultTTLSeconds: 60, ResultRoutingResolved: true},
 		&RequestMessage{
 			ID: "plain-1", Created: 1000, Deadline: 2000,
 			Payload:  map[string]any{"model": "m1"},
@@ -267,6 +267,12 @@ func assertRouting(t *testing.T, got, want InternalRouting) {
 	}
 	if got.ResultQueueName != want.ResultQueueName {
 		t.Errorf("ResultQueueName = %q, want %q", got.ResultQueueName, want.ResultQueueName)
+	}
+	if got.ResultTTLSeconds != want.ResultTTLSeconds {
+		t.Errorf("ResultTTLSeconds = %d, want %d", got.ResultTTLSeconds, want.ResultTTLSeconds)
+	}
+	if got.ResultRoutingResolved != want.ResultRoutingResolved {
+		t.Errorf("ResultRoutingResolved = %v, want %v", got.ResultRoutingResolved, want.ResultRoutingResolved)
 	}
 	if got.TransportCorrelationID != want.TransportCorrelationID {
 		t.Errorf("TransportCorrelationID = %q, want %q", got.TransportCorrelationID, want.TransportCorrelationID)

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -31,6 +31,22 @@ type RequestMergePolicy interface {
 	MergeRequestChannels(channels []RequestChannel, pools map[string]WorkerPoolConfig) PoolDispatch
 }
 
+// DynamicRequestMergePolicy is an optional capability of RequestMergePolicy
+// implementations that support taking on additional fan-in source channels at
+// runtime, e.g. after a hot reload of a queue configuration. The per-pool
+// merged channels returned by MergeRequestChannels stay stable for the
+// lifetime of the policy; only the set of source channels feeding each pool
+// changes. A source channel is removed from a pool by closing it: both
+// policies treat a closed source channel as a removal and stop reading it.
+type DynamicRequestMergePolicy interface {
+	RequestMergePolicy
+	// AddRequestChannels registers additional source channels, grouped by
+	// each channel's WorkerPoolID. A channel referencing a pool unknown to
+	// the policy is an error, in which case no channel is added. Adding a
+	// channel already registered is a no-op.
+	AddRequestChannels(channels []RequestChannel, pools map[string]WorkerPoolConfig) error
+}
+
 // ExpiringCount pairs a deadline-proximity bucket with the exact number of
 // queued items whose deadline falls within it. Window is the histogram le
 // bucket label (e.g. "0" for expired items, "60000" for up to 60s away) and

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
@@ -98,6 +98,8 @@ func newPoolFanIn(buffer int) *poolFanIn {
 }
 
 func (f *poolFanIn) addSource(ch pipeline.RequestChannel) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if _, ok := f.sources[ch.Channel]; !ok {
 		f.sources[ch.Channel] = ch
 		f.notifyChanged()
@@ -105,6 +107,8 @@ func (f *poolFanIn) addSource(ch pipeline.RequestChannel) {
 }
 
 func (f *poolFanIn) removeSource(c chan *api.InternalRequest) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if _, ok := f.sources[c]; ok {
 		delete(f.sources, c)
 		f.notifyChanged()
@@ -203,9 +207,7 @@ func (r *RandomRobinPolicy) merge(channels []pipeline.RequestChannel, pools map[
 		if !ok {
 			return fmt.Errorf("worker pool %q not found in pools map", workerPoolID)
 		}
-		f.mu.Lock()
 		f.addSource(ch)
-		f.mu.Unlock()
 	}
 	return nil
 }

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sync"
 
 	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
@@ -50,15 +51,20 @@ func NewRandomRobinPolicy(name string, cfg Config) *RandomRobinPolicy {
 	return &RandomRobinPolicy{
 		name:     name,
 		fairness: fairness.New(cfg.FairnessHeader, cfg.FairnessAttribute),
+		pools:    make(map[string]*poolFanIn),
 	}
 }
 
 var _ pipeline.RequestMergePolicy = (*RandomRobinPolicy)(nil)
+var _ pipeline.DynamicRequestMergePolicy = (*RandomRobinPolicy)(nil)
 var _ plugins.Plugin = (*RandomRobinPolicy)(nil)
 
 type RandomRobinPolicy struct {
 	name     string
 	fairness fairness.Stamper
+
+	mu    sync.Mutex
+	pools map[string]*poolFanIn
 }
 
 func (r *RandomRobinPolicy) TypedName() plugins.TypedName {
@@ -66,6 +72,142 @@ func (r *RandomRobinPolicy) TypedName() plugins.TypedName {
 		Type: "random-robin",
 		Name: r.name,
 	}
+}
+
+// poolFanIn merges a dynamic set of source channels into a single merged
+// channel. Sources are added via AddRequestChannels and removed by closing
+// the source channel. The merged channel lives for as long as the policy
+// does and is never closed: the number of sources may legitimately drop to
+// zero (e.g. every queue removed by a config reload) and grow again later.
+type poolFanIn struct {
+	merged chan pipeline.EmbelishedRequestMessage
+
+	mu      sync.Mutex
+	sources map[chan *api.InternalRequest]pipeline.RequestChannel
+	// changed is buffered and sent non-blockingly whenever sources changes,
+	// so the fan-in goroutine rebuilds its select cases.
+	changed chan struct{}
+}
+
+func newPoolFanIn(buffer int) *poolFanIn {
+	return &poolFanIn{
+		merged:  make(chan pipeline.EmbelishedRequestMessage, buffer),
+		sources: make(map[chan *api.InternalRequest]pipeline.RequestChannel),
+		changed: make(chan struct{}, 1),
+	}
+}
+
+func (f *poolFanIn) addSource(ch pipeline.RequestChannel) {
+	if _, ok := f.sources[ch.Channel]; !ok {
+		f.sources[ch.Channel] = ch
+		f.notifyChanged()
+	}
+}
+
+func (f *poolFanIn) removeSource(c chan *api.InternalRequest) {
+	if _, ok := f.sources[c]; ok {
+		delete(f.sources, c)
+		f.notifyChanged()
+	}
+}
+
+func (f *poolFanIn) notifyChanged() {
+	select {
+	case f.changed <- struct{}{}:
+	default:
+	}
+}
+
+// snapshot returns the current source set plus a matching case list. Case 0
+// is always the changed-notification channel; source channels follow.
+func (f *poolFanIn) snapshot() ([]pipeline.RequestChannel, []reflect.SelectCase) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	metas := make([]pipeline.RequestChannel, 0, len(f.sources))
+	cases := make([]reflect.SelectCase, 0, len(f.sources)+1)
+	cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(f.changed)})
+	for c, meta := range f.sources {
+		metas = append(metas, meta)
+		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(c)})
+	}
+	return metas, cases
+}
+
+func (f *poolFanIn) run(stamp func(headers map[string]string, msg pipeline.RequestChannel, ir *api.InternalRequest), workerPoolID string) {
+	for {
+		metas, cases := f.snapshot()
+		if len(metas) == 0 {
+			// No sources: block on the change notification alone.
+			<-f.changed
+			continue
+		}
+		idx, val, ok := reflect.Select(cases)
+		if idx == 0 {
+			// Source set changed; rebuild the cases.
+			continue
+		}
+		if !ok {
+			f.removeSource(metas[idx-1].Channel)
+			continue
+		}
+		ir, ok := val.Interface().(*api.InternalRequest)
+		if !ok || ir == nil {
+			continue
+		}
+		chMeta := metas[idx-1]
+
+		headers := map[string]string{}
+		stamp(headers, chMeta, ir)
+		erm := pipeline.EmbelishedRequestMessage{
+			InternalRequest: ir,
+			HttpHeaders:     headers,
+			RequestURL:      requestURL(chMeta, ir),
+			WorkerPoolID:    workerPoolID,
+		}
+		metrics.IncQueueDepth(ir.QueueID, ir.RequestQueueName, workerPoolID)
+		f.merged <- erm
+	}
+}
+
+// requestURL joins the queue's IGW base URL with the request's effective
+// path: the per-request endpoint wins over the queue default when set.
+func requestURL(chMeta pipeline.RequestChannel, ir *api.InternalRequest) string {
+	requestPath := chMeta.RequestPathURL
+	if ep := ir.PublicRequest.ReqEndpoint(); ep != "" {
+		requestPath = ep
+	}
+	u, _ := url.JoinPath(chMeta.IGWBaseURL, requestPath)
+	return u
+}
+
+func (r *RandomRobinPolicy) stampHeaders(headers map[string]string, chMeta pipeline.RequestChannel, ir *api.InternalRequest) {
+	headers["Content-Type"] = "application/json"
+	if chMeta.InferenceObjective != "" {
+		headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
+	}
+	for k, v := range ir.PublicRequest.ReqHeaders() {
+		headers[k] = v
+	}
+	// Stamped after the caller's headers so the tenant the quota
+	// gate accounts on is the one the gateway arbitrates on.
+	r.fairness.Stamp(headers, ir.PublicRequest)
+}
+
+func (r *RandomRobinPolicy) merge(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
+	for _, ch := range channels {
+		workerPoolID := ch.WorkerPoolID
+		if workerPoolID == "" {
+			workerPoolID = "default"
+		}
+		f, ok := r.pools[workerPoolID]
+		if !ok {
+			return fmt.Errorf("worker pool %q not found in pools map", workerPoolID)
+		}
+		f.mu.Lock()
+		f.addSource(ch)
+		f.mu.Unlock()
+	}
+	return nil
 }
 
 func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) pipeline.PoolDispatch {
@@ -81,73 +223,43 @@ func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChan
 		channelsByPool[workerPoolID] = append(channelsByPool[workerPoolID], ch)
 	}
 
+	// A fan-in exists for every configured pool, even those with no source
+	// channels yet, so queue reloads can add sources to any pool and the
+	// merged channel the workers already read never has to be replaced. The
+	// buffer matches the pool's initial source count, preserving the
+	// historical backpressure of a statically configured pool.
+	for workerPoolID := range pools {
+		f := newPoolFanIn(len(channelsByPool[workerPoolID]))
+		r.pools[workerPoolID] = f
+		go f.run(r.stampHeaders, workerPoolID)
+	}
+	if err := r.merge(channels, pools); err != nil {
+		// Unreachable: the pool membership precheck above covers the groups
+		// merge registers. Kept as a hard failure rather than silently
+		// dropping a source channel.
+		panic(err.Error())
+	}
+
 	dispatch := pipeline.PoolDispatch{
 		Channels: make(map[string]chan pipeline.EmbelishedRequestMessage),
 	}
-
-	for workerPoolID, poolChs := range channelsByPool {
-		mergedChannel := make(chan pipeline.EmbelishedRequestMessage, len(poolChs))
-		dispatch.Channels[workerPoolID] = mergedChannel
-
-		if len(poolChs) == 0 {
-			close(mergedChannel)
-			continue
-		}
-
-		cases := make([]reflect.SelectCase, len(poolChs))
-		meta := make([]pipeline.RequestChannel, len(poolChs))
-		for i, ch := range poolChs {
-			cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch.Channel)}
-			meta[i] = ch
-		}
-
-		go func(workerPoolID string, cases []reflect.SelectCase, meta []pipeline.RequestChannel, mergedChannel chan pipeline.EmbelishedRequestMessage) {
-			for {
-				i1, val, ok := reflect.Select(cases)
-				if !ok {
-					// one of the channels is closed, remove it
-					cases = append(cases[:i1], cases[i1+1:]...)
-					meta = append(meta[:i1], meta[i1+1:]...)
-					if len(cases) == 0 {
-						close(mergedChannel)
-						break
-					}
-				} else {
-					ir, ok := val.Interface().(*api.InternalRequest)
-					if !ok || ir == nil {
-						continue
-					}
-					chMeta := meta[i1]
-
-					requestPath := chMeta.RequestPathURL
-					if ep := ir.PublicRequest.ReqEndpoint(); ep != "" {
-						requestPath = ep
-					}
-					requestURL, _ := url.JoinPath(chMeta.IGWBaseURL, requestPath)
-					headers := map[string]string{
-						"Content-Type": "application/json",
-					}
-					if chMeta.InferenceObjective != "" {
-						headers["x-gateway-inference-objective"] = chMeta.InferenceObjective
-					}
-					for k, v := range ir.PublicRequest.ReqHeaders() {
-						headers[k] = v
-					}
-					// Stamped after the caller's headers so the tenant the quota
-					// gate accounts on is the one the gateway arbitrates on.
-					r.fairness.Stamp(headers, ir.PublicRequest)
-					erm := pipeline.EmbelishedRequestMessage{
-						InternalRequest: ir,
-						HttpHeaders:     headers,
-						RequestURL:      requestURL,
-						WorkerPoolID:    workerPoolID,
-					}
-					metrics.IncQueueDepth(ir.QueueID, ir.RequestQueueName, workerPoolID)
-					mergedChannel <- erm
-				}
-			}
-		}(workerPoolID, cases, meta, mergedChannel)
+	for workerPoolID, f := range r.pools {
+		dispatch.Channels[workerPoolID] = f.merged
 	}
-
 	return dispatch
+}
+
+func (r *RandomRobinPolicy) AddRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, ch := range channels {
+		workerPoolID := ch.WorkerPoolID
+		if workerPoolID == "" {
+			workerPoolID = "default"
+		}
+		if _, ok := r.pools[workerPoolID]; !ok {
+			return fmt.Errorf("worker pool %q not found in pools map", workerPoolID)
+		}
+	}
+	return r.merge(channels, pools)
 }

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy.go
@@ -211,6 +211,9 @@ func (r *RandomRobinPolicy) merge(channels []pipeline.RequestChannel, pools map[
 }
 
 func (r *RandomRobinPolicy) MergeRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) pipeline.PoolDispatch {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	channelsByPool := make(map[string][]pipeline.RequestChannel)
 	for _, ch := range channels {
 		workerPoolID := ch.WorkerPoolID

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
@@ -366,3 +366,103 @@ func TestMergeRequestChannels_PanicOnMissingPool(t *testing.T) {
 
 	policy.MergeRequestChannels(channels, map[string]pipeline.WorkerPoolConfig{})
 }
+
+func TestAddRequestChannels_DeliversFromNewSource(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"default": {ID: "default", Workers: 1},
+	}
+	initial := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 1),
+		WorkerPoolID: "default",
+		IGWBaseURL:   "http://gw",
+	}
+	policy := NewRandomRobinPolicy("test", Config{})
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{initial}, pools)
+	mergedChannel := dispatch.Channels["default"]
+
+	added := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 1),
+		WorkerPoolID: "default",
+		IGWBaseURL:   "http://gw2",
+	}
+	if err := policy.AddRequestChannels([]pipeline.RequestChannel{added}, pools); err != nil {
+		t.Fatalf("AddRequestChannels failed: %v", err)
+	}
+
+	initial.Channel <- irID("from-initial")
+	added.Channel <- irID("from-added")
+
+	got := map[string]bool{}
+	deadline := time.After(3 * time.Second)
+	for len(got) < 2 {
+		select {
+		case msg := <-mergedChannel:
+			got[msg.PublicRequest.ReqID()] = true
+		case <-deadline:
+			t.Fatalf("timed out, only got %v", got)
+		}
+	}
+	if !got["from-initial"] || !got["from-added"] {
+		t.Fatalf("expected messages from both channels, got %v", got)
+	}
+
+	// Closing the added channel must withdraw only that source; the initial
+	// channel keeps feeding the same merged channel.
+	close(added.Channel)
+	initial.Channel <- irID("after-close")
+	select {
+	case msg := <-mergedChannel:
+		if msg.PublicRequest.ReqID() != "after-close" {
+			t.Fatalf("expected after-close, got %q", msg.PublicRequest.ReqID())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("merged channel stopped after source closure")
+	}
+}
+
+func TestAddRequestChannels_UnknownPool(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"default": {ID: "default", Workers: 1},
+	}
+	policy := NewRandomRobinPolicy("test", Config{})
+	policy.MergeRequestChannels(nil, pools)
+
+	err := policy.AddRequestChannels([]pipeline.RequestChannel{
+		{Channel: make(chan *api.InternalRequest), WorkerPoolID: "ghost"},
+	}, pools)
+	if err == nil {
+		t.Fatal("expected error for unknown pool")
+	}
+}
+
+func TestAddRequestChannels_Idempotent(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"default": {ID: "default", Workers: 1},
+	}
+	policy := NewRandomRobinPolicy("test", Config{})
+	dispatch := policy.MergeRequestChannels(nil, pools)
+	mergedChannel := dispatch.Channels["default"]
+
+	ch := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1), WorkerPoolID: "default", IGWBaseURL: "http://gw"}
+	for range 3 {
+		if err := policy.AddRequestChannels([]pipeline.RequestChannel{ch}, pools); err != nil {
+			t.Fatalf("AddRequestChannels failed: %v", err)
+		}
+	}
+
+	// A duplicate registration must not duplicate deliveries.
+	ch.Channel <- irID("once")
+	select {
+	case msg := <-mergedChannel:
+		if msg.PublicRequest.ReqID() != "once" {
+			t.Fatalf("unexpected id %q", msg.PublicRequest.ReqID())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+	select {
+	case msg := <-mergedChannel:
+		t.Fatalf("duplicate delivery of registered channel: %q", msg.PublicRequest.ReqID())
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
+++ b/pkg/async/mergepolicy/randomrobin/random_robin_policy_test.go
@@ -2,6 +2,8 @@ package randomrobin
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -464,5 +466,56 @@ func TestAddRequestChannels_Idempotent(t *testing.T) {
 	case msg := <-mergedChannel:
 		t.Fatalf("duplicate delivery of registered channel: %q", msg.PublicRequest.ReqID())
 	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+func TestAddRequestChannelsConcurrentWithSourceClose(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+	policy := NewRandomRobinPolicy("test", Config{})
+	initial := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest), WorkerPoolID: "default"}
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{initial}, pools)
+	merged := dispatch.Channels["default"]
+	added := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1), WorkerPoolID: "default", IGWBaseURL: "http://added"}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		close(initial.Channel)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		if err := policy.AddRequestChannels([]pipeline.RequestChannel{added}, pools); err != nil {
+			t.Errorf("AddRequestChannels failed: %v", err)
+		}
+	}()
+	close(start)
+	wg.Wait()
+	fanIn := policy.pools["default"]
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		fanIn.mu.Lock()
+		_, initialExists := fanIn.sources[initial.Channel]
+		_, addedExists := fanIn.sources[added.Channel]
+		fanIn.mu.Unlock()
+		if !initialExists && addedExists {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fan-in did not remove the closed source and retain the added source")
+		}
+		runtime.Gosched()
+	}
+
+	added.Channel <- irID("after-concurrent-close")
+	select {
+	case msg := <-merged:
+		if msg.PublicRequest.ReqID() != "after-concurrent-close" {
+			t.Fatalf("unexpected message %q", msg.PublicRequest.ReqID())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("new source was not available after concurrent close")
 	}
 }

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -335,10 +335,15 @@ func (s *scheduler) Close() {
 // queue stay strictly round-robined within their lane. The reader exits when
 // the source channel is closed — the standard way a dynamically removed
 // queue leaves the merge.
-func (p *TierPriorityPolicy) startReader(s *scheduler, ch pipeline.RequestChannel) {
-	s.AddReader()
-	go func(ch pipeline.RequestChannel, s *scheduler) {
-		defer s.DecrementReaders()
+func (p *TierPriorityPolicy) startReader(pm *poolMerge, ch pipeline.RequestChannel) {
+	pm.scheduler.AddReader()
+	go func() {
+		defer func() {
+			pm.scheduler.DecrementReaders()
+			p.mu.Lock()
+			delete(pm.sources, ch.Channel)
+			p.mu.Unlock()
+		}()
 		for {
 			val, ok := <-ch.Channel
 			if !ok {
@@ -347,11 +352,11 @@ func (p *TierPriorityPolicy) startReader(s *scheduler, ch pipeline.RequestChanne
 			if val == nil {
 				continue
 			}
-			if !s.Push(val, ch) {
+			if !pm.scheduler.Push(val, ch) {
 				break
 			}
 		}
-	}(ch, s)
+	}()
 }
 
 // addChannels validates the pool reference of every channel before starting
@@ -376,12 +381,15 @@ func (p *TierPriorityPolicy) addChannels(channels []pipeline.RequestChannel, poo
 			continue
 		}
 		pm.sources[ch.Channel] = struct{}{}
-		p.startReader(pm.scheduler, ch)
+		p.startReader(pm, ch)
 	}
 	return nil
 }
 
 func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) pipeline.PoolDispatch {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	channelsByPool := make(map[string][]pipeline.RequestChannel)
 	for _, ch := range channels {
 		workerPoolID := ch.WorkerPoolID

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy.go
@@ -107,11 +107,23 @@ func NewTierPriorityPolicy(name string, cfg Config) *TierPriorityPolicy {
 		objectiveHeader: objectiveHeader,
 		laneObjectives:  cfg.LaneObjectives,
 		fairness:        fairness.New(cfg.FairnessHeader, cfg.FairnessAttribute),
+		pools:           make(map[string]*poolMerge),
 	}
 }
 
 var _ pipeline.RequestMergePolicy = (*TierPriorityPolicy)(nil)
+var _ pipeline.DynamicRequestMergePolicy = (*TierPriorityPolicy)(nil)
 var _ plugins.Plugin = (*TierPriorityPolicy)(nil)
+
+// poolMerge holds the per-pool merge state so the fan-in can take on
+// additional source channels after MergeRequestChannels has returned: the
+// merged channel lives for the policy's lifetime, and a closed source
+// channel removes that source's reader from the scheduler.
+type poolMerge struct {
+	scheduler     *scheduler
+	sources       map[chan *api.InternalRequest]struct{}
+	mergedChannel chan pipeline.EmbelishedRequestMessage
+}
 
 type TierPriorityPolicy struct {
 	name            string
@@ -120,6 +132,11 @@ type TierPriorityPolicy struct {
 	objectiveHeader string
 	laneObjectives  map[string]string
 	fairness        fairness.Stamper
+
+	mu sync.Mutex
+	// pools is populated once by MergeRequestChannels (one entry per
+	// configured pool) and then only read by AddRequestChannels.
+	pools map[string]*poolMerge
 }
 
 func (p *TierPriorityPolicy) TypedName() plugins.TypedName {
@@ -268,12 +285,21 @@ func (s *scheduler) Push(ir *api.InternalRequest, chMeta pipeline.RequestChannel
 	return true
 }
 
+func (s *scheduler) AddReader() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeReaders++
+}
+
 func (s *scheduler) Pop() (msgAndMeta, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	for s.totalBuffered == 0 {
-		if s.activeReaders == 0 || s.closed {
+		// Sources are dynamic: every reader may exit (all source channels
+		// closed) while new sources are added later. Only an explicit Close
+		// ends the pop loop.
+		if s.closed {
 			return msgAndMeta{}, false
 		}
 		s.cond.Wait()
@@ -304,6 +330,57 @@ func (s *scheduler) Close() {
 	s.cond.Broadcast()
 }
 
+// startReader reads one source channel and pushes every message into the
+// pool scheduler, keyed by the channel pointer so messages from the same
+// queue stay strictly round-robined within their lane. The reader exits when
+// the source channel is closed — the standard way a dynamically removed
+// queue leaves the merge.
+func (p *TierPriorityPolicy) startReader(s *scheduler, ch pipeline.RequestChannel) {
+	s.AddReader()
+	go func(ch pipeline.RequestChannel, s *scheduler) {
+		defer s.DecrementReaders()
+		for {
+			val, ok := <-ch.Channel
+			if !ok {
+				break
+			}
+			if val == nil {
+				continue
+			}
+			if !s.Push(val, ch) {
+				break
+			}
+		}
+	}(ch, s)
+}
+
+// addChannels validates the pool reference of every channel before starting
+// any reader, so a bad channel cannot leave the pool set partially extended.
+func (p *TierPriorityPolicy) addChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
+	for _, ch := range channels {
+		workerPoolID := ch.WorkerPoolID
+		if workerPoolID == "" {
+			workerPoolID = "default"
+		}
+		if _, ok := p.pools[workerPoolID]; !ok {
+			return fmt.Errorf("worker pool %q not found in pools map", workerPoolID)
+		}
+	}
+	for _, ch := range channels {
+		workerPoolID := ch.WorkerPoolID
+		if workerPoolID == "" {
+			workerPoolID = "default"
+		}
+		pm := p.pools[workerPoolID]
+		if _, already := pm.sources[ch.Channel]; already {
+			continue
+		}
+		pm.sources[ch.Channel] = struct{}{}
+		p.startReader(pm.scheduler, ch)
+	}
+	return nil
+}
+
 func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) pipeline.PoolDispatch {
 	channelsByPool := make(map[string][]pipeline.RequestChannel)
 	for _, ch := range channels {
@@ -317,39 +394,28 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 		channelsByPool[workerPoolID] = append(channelsByPool[workerPoolID], ch)
 	}
 
-	dispatch := pipeline.PoolDispatch{
-		Channels: make(map[string]chan pipeline.EmbelishedRequestMessage),
+	// A scheduler and merged channel exist for every configured pool, even
+	// those without any source channel yet: queue reloads may add sources to
+	// any pool later, and the merged channel workers already read must never
+	// be replaced.
+	for workerPoolID := range pools {
+		s := newScheduler(1000, 0, p.tierLabel)
+		p.pools[workerPoolID] = &poolMerge{
+			scheduler:     s,
+			sources:       make(map[chan *api.InternalRequest]struct{}),
+			mergedChannel: make(chan pipeline.EmbelishedRequestMessage, len(channelsByPool[workerPoolID])),
+		}
 	}
 
-	for workerPoolID, poolChs := range channelsByPool {
-		mergedChannel := make(chan pipeline.EmbelishedRequestMessage, len(poolChs))
-		dispatch.Channels[workerPoolID] = mergedChannel
+	if err := p.addChannels(channels, pools); err != nil {
+		// Preserve the historical panic: MergeRequestChannels has no error
+		// return, and a misconfigured channel/pool pair is a startup bug.
+		panic(err.Error())
+	}
 
-		if len(poolChs) == 0 {
-			close(mergedChannel)
-			continue
-		}
-
-		s := newScheduler(1000, len(poolChs), p.tierLabel)
-
-		for _, ch := range poolChs {
-			go func(ch pipeline.RequestChannel, s *scheduler) {
-				defer s.DecrementReaders()
-				for {
-					val, ok := <-ch.Channel
-					if !ok {
-						break
-					}
-					if val == nil {
-						continue
-					}
-					if !s.Push(val, ch) {
-						break
-					}
-				}
-			}(ch, s)
-		}
-
+	for workerPoolID, pm := range p.pools {
+		s := pm.scheduler
+		mergedChannel := pm.mergedChannel
 		go func(workerPoolID string, s *scheduler, mergedChannel chan pipeline.EmbelishedRequestMessage, priorityHeader string, tierLabel string, fairnessStamper fairness.Stamper) {
 			defer close(mergedChannel)
 			defer s.Close()
@@ -404,5 +470,17 @@ func (p *TierPriorityPolicy) MergeRequestChannels(channels []pipeline.RequestCha
 		}(workerPoolID, s, mergedChannel, p.priorityHeader, p.tierLabel, p.fairness)
 	}
 
+	dispatch := pipeline.PoolDispatch{
+		Channels: make(map[string]chan pipeline.EmbelishedRequestMessage),
+	}
+	for workerPoolID, pm := range p.pools {
+		dispatch.Channels[workerPoolID] = pm.mergedChannel
+	}
 	return dispatch
+}
+
+func (p *TierPriorityPolicy) AddRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.addChannels(channels, pools)
 }

--- a/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
+++ b/pkg/async/mergepolicy/tierpriority/tier_priority_policy_test.go
@@ -344,3 +344,104 @@ func TestTierPriorityStamping(t *testing.T) {
 		}
 	}
 }
+
+func TestAddRequestChannels_NewSourceJoinsScheduler(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-d": {ID: "pool-d", Workers: 1},
+	}
+	ch1 := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 2),
+		WorkerPoolID: "pool-d",
+		IGWBaseURL:   "http://gw",
+	}
+	policy := NewTierPriorityPolicy("test-dynamic", Config{TierLabel: "tier"})
+	dispatch := policy.MergeRequestChannels([]pipeline.RequestChannel{ch1}, pools)
+	merged := dispatch.Channels["pool-d"]
+
+	ch2 := pipeline.RequestChannel{
+		Channel:      make(chan *api.InternalRequest, 2),
+		WorkerPoolID: "pool-d",
+		IGWBaseURL:   "http://gw2",
+	}
+	if err := policy.AddRequestChannels([]pipeline.RequestChannel{ch2}, pools); err != nil {
+		t.Fatalf("AddRequestChannels failed: %v", err)
+	}
+
+	ch1.Channel <- irWithLabels("dyn-1", nil)
+	ch2.Channel <- irWithLabels("dyn-2", nil)
+
+	got := map[string]bool{}
+	deadline := time.After(3 * time.Second)
+	for len(got) < 2 {
+		select {
+		case msg := <-merged:
+			got[msg.PublicRequest.ReqID()] = true
+		case <-deadline:
+			t.Fatalf("timed out, only got %v", got)
+		}
+	}
+	if !got["dyn-1"] || !got["dyn-2"] {
+		t.Fatalf("expected messages from both channels, got %v", got)
+	}
+
+	// Closing the added channel removes exactly its reader; the remaining
+	// source keeps feeding the same merged channel.
+	close(ch2.Channel)
+	deadline = time.After(3 * time.Second)
+	for {
+		select {
+		case msg := <-merged:
+			if msg.PublicRequest.ReqID() == "dyn-3" {
+				return
+			}
+		case ch1.Channel <- irWithLabels("dyn-3", nil):
+		case <-deadline:
+			t.Fatal("merged channel stopped after source closure")
+		}
+	}
+}
+
+func TestAddRequestChannels_UnknownPool(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-d": {ID: "pool-d", Workers: 1},
+	}
+	policy := NewTierPriorityPolicy("test-err", Config{})
+	policy.MergeRequestChannels(nil, pools)
+
+	if err := policy.AddRequestChannels([]pipeline.RequestChannel{
+		{Channel: make(chan *api.InternalRequest), WorkerPoolID: "ghost"},
+	}, pools); err == nil {
+		t.Fatal("expected error for unknown pool")
+	}
+}
+
+func TestAddRequestChannels_Idempotent(t *testing.T) {
+	pools := map[string]pipeline.WorkerPoolConfig{
+		"pool-d": {ID: "pool-d", Workers: 1},
+	}
+	policy := NewTierPriorityPolicy("test-idem", Config{})
+	dispatch := policy.MergeRequestChannels(nil, pools)
+	merged := dispatch.Channels["pool-d"]
+
+	ch := pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1), WorkerPoolID: "pool-d", IGWBaseURL: "http://gw"}
+	for range 3 {
+		if err := policy.AddRequestChannels([]pipeline.RequestChannel{ch}, pools); err != nil {
+			t.Fatalf("AddRequestChannels failed: %v", err)
+		}
+	}
+
+	ch.Channel <- irWithLabels("once", nil)
+	select {
+	case msg := <-merged:
+		if msg.PublicRequest.ReqID() != "once" {
+			t.Fatalf("unexpected id %q", msg.PublicRequest.ReqID())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+	select {
+	case msg := <-merged:
+		t.Fatalf("duplicate delivery of registered channel: %q", msg.PublicRequest.ReqID())
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -117,6 +117,14 @@ var (
 		Subsystem: SchedulerSubsystem, Name: "async_pool_worker_limit",
 		Help: "Configured number of concurrent workers (the concurrency limit) for a pool. Compare against async_inflight_requests for worker utilization.",
 	}, []string{LabelPoolName})
+	QueueConfigReloads = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_queue_config_reloads_total",
+		Help: "Count of queue-config hot reload attempts, by result (success or error). Errors leave the last good configuration in effect.",
+	}, []string{"result"})
+	QueueConfigLastSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: SchedulerSubsystem, Name: "async_queue_config_last_success_timestamp_seconds",
+		Help: "Unix timestamp of the last successfully applied queue-config hot reload.",
+	})
 	GateDecisions = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: SchedulerSubsystem, Name: "async_gate_decisions_total",
 		Help: "Count of gate decisions that prevented dispatch, by reason (gate_closed, quota_exhausted, dropped, error). quota_exhausted/dropped/error count individual messages refused after they were dequeued; gate_closed counts those plus each dequeue round in which the gate's budget shrank the batch to zero, which is how budget-based gates (prometheus-budget/-saturation/-query) shed work before any message is dequeued.",
@@ -375,6 +383,18 @@ func DecInflight(queueID, queueName, poolName string) {
 	InflightRequests.WithLabelValues(queueID, queueName, poolName).Dec()
 }
 
+// RecordQueueConfigReload counts one queue-config hot reload attempt and,
+// on success, marks the last-applied timestamp so operators can compare
+// desired and actual configuration generations.
+func RecordQueueConfigReload(success bool) {
+	if success {
+		QueueConfigReloads.WithLabelValues("success").Inc()
+		QueueConfigLastSuccess.SetToCurrentTime()
+		return
+	}
+	QueueConfigReloads.WithLabelValues("error").Inc()
+}
+
 // SetBrokerBacklog sets the broker-side backlog for a queue.
 func SetBrokerBacklog(queueID, queueName, poolName string, n float64) {
 	BrokerBacklog.WithLabelValues(queueID, queueName, poolName).Set(n)
@@ -436,7 +456,7 @@ func GetAsyncProcessorCollectors(supportsMessageLatency bool) []prometheus.Colle
 		Retries, AsyncReqs, ExceededDeadlineReqs, FailedReqs, SuccessfulReqs, SheddedRequests, Tokens,
 		QueueDepth, InflightRequests, BrokerBacklog, InferenceLatencyTime, QueueResidenceTime,
 		DeadlineProximity,
-		DispatchBudget, PoolWorkerLimit, GateDecisions,
+		DispatchBudget, PoolWorkerLimit, QueueConfigReloads, QueueConfigLastSuccess, GateDecisions,
 		GateMetricValue, GateMetricThreshold, GateMetricSourceAvailable,
 	}
 	if supportsMessageLatency {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -304,6 +304,12 @@ func (c *deadlineProximityCollector) Set(queueID, queueName, poolName string, cu
 	}
 }
 
+func (c *deadlineProximityCollector) Delete(queueID, queueName, poolName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.series, queueID+"\x00"+queueName+"\x00"+poolName)
+}
+
 // Reset clears every snapshot series.
 func (c *deadlineProximityCollector) Reset() {
 	c.mu.Lock()
@@ -403,6 +409,14 @@ func SetBrokerBacklog(queueID, queueName, poolName string, n float64) {
 // SetDispatchBudget sets the current dispatch budget [0.0-1.0] for a queue's gate.
 func SetDispatchBudget(budget float64, queueID, queueName, poolName string) {
 	DispatchBudget.WithLabelValues(queueID, queueName, poolName).Set(budget)
+}
+
+// RemoveQueueSnapshots deletes point-in-time series for a queue that is no
+// longer configured. Historical counters and latency histograms are retained.
+func RemoveQueueSnapshots(queueID, queueName, poolName string) {
+	BrokerBacklog.DeleteLabelValues(queueID, queueName, poolName)
+	DispatchBudget.DeleteLabelValues(queueID, queueName, poolName)
+	DeadlineProximity.Delete(queueID, queueName, poolName)
 }
 
 // SetPoolWorkerLimit sets the configured worker concurrency limit for a pool.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -71,6 +71,26 @@ func TestSetDispatchBudget(t *testing.T) {
 	}
 }
 
+func TestRemoveQueueSnapshots(t *testing.T) {
+	BrokerBacklog.Reset()
+	DispatchBudget.Reset()
+	DeadlineProximity.Reset()
+	SetBrokerBacklog("q1", "queue-1", "pool-a", 2)
+	SetDispatchBudget(0.42, "q1", "queue-1", "pool-a")
+	SetDeadlineProximity("q1", "queue-1", "pool-a", make([]int64, len(DeadlineProximityBuckets())))
+
+	RemoveQueueSnapshots("q1", "queue-1", "pool-a")
+	if got := testutil.CollectAndCount(BrokerBacklog); got != 0 {
+		t.Errorf("BrokerBacklog still exposes %d series, want 0", got)
+	}
+	if got := testutil.CollectAndCount(DispatchBudget); got != 0 {
+		t.Errorf("DispatchBudget still exposes %d series, want 0", got)
+	}
+	if got := testutil.CollectAndCount(DeadlineProximity); got != 0 {
+		t.Errorf("DeadlineProximity still exposes %d series, want 0", got)
+	}
+}
+
 func TestSetPoolWorkerLimit(t *testing.T) {
 	SetPoolWorkerLimit("pool-a", 8)
 	got := testutil.ToFloat64(PoolWorkerLimit.WithLabelValues("pool-a"))

--- a/pkg/redis/options.go
+++ b/pkg/redis/options.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -227,17 +228,18 @@ func (o *PubSubFlowOptions) HasQueueConfig() bool {
 
 // SortedSetFlowOptions holds CLI flags for the Redis sorted-set flow.
 type SortedSetFlowOptions struct {
-	IGWBaseURL         string
-	RequestPathURL     string
-	InferenceObjective string
-	RequestQueueName   string
-	ResultQueueName    string
-	QueuesConfig       string
-	QueuesConfigFile   string
-	PollIntervalMs     int
-	BatchSize          int
-	GateType           string
-	GateParamsJSON     string
+	IGWBaseURL                string
+	RequestPathURL            string
+	InferenceObjective        string
+	RequestQueueName          string
+	ResultQueueName           string
+	QueuesConfig              string
+	QueuesConfigFile          string
+	QueuesConfigWatchInterval time.Duration
+	PollIntervalMs            int
+	BatchSize                 int
+	GateType                  string
+	GateParamsJSON            string
 }
 
 func NewSortedSetFlowOptions() *SortedSetFlowOptions {
@@ -259,6 +261,8 @@ func (o *SortedSetFlowOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ResultQueueName, "redis.ss.result-queue-name", o.ResultQueueName, "Result list name")
 	fs.StringVar(&o.QueuesConfig, "redis.ss.queues-config", o.QueuesConfig, "Inline JSON queues configuration")
 	fs.StringVar(&o.QueuesConfigFile, "redis.ss.queues-config-file", o.QueuesConfigFile, "Multiple queues config file")
+	fs.DurationVar(&o.QueuesConfigWatchInterval, "redis.ss.queues-config-watch-interval", 0,
+		"If positive, periodically re-read --redis.ss.queues-config-file and hot reload added/removed/updated queues without restarting. Requires the queues-config-file flag; 0 disables hot reload (default).")
 	fs.IntVar(&o.PollIntervalMs, "redis.ss.poll-interval-ms", o.PollIntervalMs, "Poll interval in milliseconds")
 	fs.IntVar(&o.BatchSize, "redis.ss.batch-size", o.BatchSize, "Number of messages to process per poll")
 	fs.StringVar(&o.GateType, "redis.ss.gate-type", o.GateType, "Gate type for single-queue mode (e.g. redis, prometheus-saturation, prometheus-budget)")

--- a/pkg/redis/options.go
+++ b/pkg/redis/options.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -94,13 +93,23 @@ type SortedSetConfig struct {
 
 // LoadSortedSetConfig parses, applies env overrides/defaults, and validates a SortedSetConfig.
 func LoadSortedSetConfig(data []byte) (*SortedSetConfig, error) {
+	return loadSortedSetConfig(data, false)
+}
+
+// LoadSortedSetConfigAllowEmptyQueues is used by queue hot reload, where an
+// operator may temporarily drain every queue. Startup still requires a queue.
+func LoadSortedSetConfigAllowEmptyQueues(data []byte) (*SortedSetConfig, error) {
+	return loadSortedSetConfig(data, true)
+}
+
+func loadSortedSetConfig(data []byte, allowEmptyQueues bool) (*SortedSetConfig, error) {
 	var cfg SortedSetConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse redis-sortedset transport config: %w", err)
 	}
 	cfg.ApplyEnvOverrides()
 	cfg.ApplyDefaults()
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.validate(allowEmptyQueues); err != nil {
 		return nil, fmt.Errorf("invalid redis-sortedset transport config: %w", err)
 	}
 	return &cfg, nil
@@ -142,10 +151,14 @@ func (c *SortedSetConfig) ApplyDefaults() {
 }
 
 func (c *SortedSetConfig) Validate() error {
+	return c.validate(false)
+}
+
+func (c *SortedSetConfig) validate(allowEmptyQueues bool) error {
 	if c.URL == "" {
 		return fmt.Errorf("url is required (set url in the transport config or REDIS_URL)")
 	}
-	if len(c.Queues) == 0 {
+	if !allowEmptyQueues && len(c.Queues) == 0 {
 		return fmt.Errorf("at least one queue must be configured")
 	}
 	seenID := make(map[string]bool, len(c.Queues))
@@ -228,18 +241,17 @@ func (o *PubSubFlowOptions) HasQueueConfig() bool {
 
 // SortedSetFlowOptions holds CLI flags for the Redis sorted-set flow.
 type SortedSetFlowOptions struct {
-	IGWBaseURL                string
-	RequestPathURL            string
-	InferenceObjective        string
-	RequestQueueName          string
-	ResultQueueName           string
-	QueuesConfig              string
-	QueuesConfigFile          string
-	QueuesConfigWatchInterval time.Duration
-	PollIntervalMs            int
-	BatchSize                 int
-	GateType                  string
-	GateParamsJSON            string
+	IGWBaseURL         string
+	RequestPathURL     string
+	InferenceObjective string
+	RequestQueueName   string
+	ResultQueueName    string
+	QueuesConfig       string
+	QueuesConfigFile   string
+	PollIntervalMs     int
+	BatchSize          int
+	GateType           string
+	GateParamsJSON     string
 }
 
 func NewSortedSetFlowOptions() *SortedSetFlowOptions {
@@ -261,8 +273,6 @@ func (o *SortedSetFlowOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ResultQueueName, "redis.ss.result-queue-name", o.ResultQueueName, "Result list name")
 	fs.StringVar(&o.QueuesConfig, "redis.ss.queues-config", o.QueuesConfig, "Inline JSON queues configuration")
 	fs.StringVar(&o.QueuesConfigFile, "redis.ss.queues-config-file", o.QueuesConfigFile, "Multiple queues config file")
-	fs.DurationVar(&o.QueuesConfigWatchInterval, "redis.ss.queues-config-watch-interval", 0,
-		"If positive, periodically re-read --redis.ss.queues-config-file and hot reload added/removed/updated queues without restarting. Requires the queues-config-file flag; 0 disables hot reload (default).")
 	fs.IntVar(&o.PollIntervalMs, "redis.ss.poll-interval-ms", o.PollIntervalMs, "Poll interval in milliseconds")
 	fs.IntVar(&o.BatchSize, "redis.ss.batch-size", o.BatchSize, "Number of messages to process per poll")
 	fs.StringVar(&o.GateType, "redis.ss.gate-type", o.GateType, "Gate type for single-queue mode (e.g. redis, prometheus-saturation, prometheus-budget)")

--- a/pkg/redis/options_test.go
+++ b/pkg/redis/options_test.go
@@ -53,3 +53,13 @@ func TestREDIS_URL_IsDefaultNotOverride(t *testing.T) {
 		}
 	})
 }
+
+func TestSortedSetConfigEmptyQueuesOnlyAllowedForReload(t *testing.T) {
+	data := []byte(`{"url":"redis://localhost:6379","queues":[]}`)
+	if _, err := LoadSortedSetConfig(data); err == nil {
+		t.Fatal("startup loader accepted an empty queue set")
+	}
+	if _, err := LoadSortedSetConfigAllowEmptyQueues(data); err != nil {
+		t.Fatalf("reload loader rejected empty queue set: %v", err)
+	}
+}

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -71,9 +71,11 @@ type QueueReconfigureResult struct {
 
 // SortedSetQueueReconfigurer is the optional capability of a Redis
 // sorted-set flow that supports replacing its queue set at runtime, e.g.
-// after a hot reload of a queues configuration file.
+// after a hot reload of a queues configuration file. beforeCommit receives
+// every new or replacement channel after preparation but before live state is
+// changed. If it returns an error, the old registry and workers are untouched.
 type SortedSetQueueReconfigurer interface {
-	ReconfigureQueues(queues []SortedSetQueueConfig) (QueueReconfigureResult, error)
+	ReconfigureQueues(queues []SortedSetQueueConfig, beforeCommit func([]pipeline.RequestChannel) error) (QueueReconfigureResult, error)
 }
 
 var errFlowStopped = errors.New("flow is stopped; cannot reconfigure queues")
@@ -389,8 +391,10 @@ func (r *RedisSortedSetFlow) StopConsuming() {
 // a worker cancelled mid-send re-enqueues the message into the queue before
 // exiting. Empty queue slices are legal — the flow idles and can still
 // accept queues later. Any validation error leaves the previous, last-good
-// configuration untouched.
-func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (QueueReconfigureResult, error) {
+// configuration untouched. beforeCommit runs after all preparation and the
+// final stopped check, but before any live state changes. Once it succeeds,
+// the remaining commit path cannot fail.
+func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig, beforeCommit func([]pipeline.RequestChannel) error) (QueueReconfigureResult, error) {
 	r.reconfigureMu.Lock()
 	defer r.reconfigureMu.Unlock()
 
@@ -456,10 +460,8 @@ func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (Q
 			continue
 		}
 		if exists {
-			// Modified: drain the old incarnation and replace it.
-			if old.cancel != nil {
-				old.cancel()
-			}
+			// Modified: drain the old incarnation and replace it after the
+			// commit callback succeeds.
 			removed = append(removed, old)
 			result.Removed = append(result.Removed, old.data.channel)
 		}
@@ -467,9 +469,6 @@ func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (Q
 		newQueues[queueCfg.ID] = entry
 		newOrder = append(newOrder, queueCfg.ID)
 		result.Added = append(result.Added, entry.data.channel)
-		if r.ctxForQueues != nil {
-			r.startQueueWorkerLocked(r.ctxForQueues, entry)
-		}
 	}
 	for _, id := range r.queueOrder {
 		if _, kept := newQueues[id]; kept {
@@ -477,11 +476,28 @@ func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (Q
 		}
 		// Removed outright: drain and unregister.
 		old := r.queues[id]
+		removed = append(removed, old)
+		result.Removed = append(result.Removed, old.data.channel)
+	}
+	if beforeCommit != nil && len(result.Added) > 0 {
+		if err := beforeCommit(result.Added); err != nil {
+			r.queueMu.Unlock()
+			return QueueReconfigureResult{}, err
+		}
+	}
+	for _, old := range removed {
 		if old.cancel != nil {
 			old.cancel()
 		}
-		removed = append(removed, old)
-		result.Removed = append(result.Removed, old.data.channel)
+	}
+	for _, queueCfg := range normalized {
+		old, exists := r.queues[queueCfg.ID]
+		if exists && reflect.DeepEqual(old.config, queueCfg) {
+			continue
+		}
+		if r.ctxForQueues != nil {
+			r.startQueueWorkerLocked(r.ctxForQueues, newQueues[queueCfg.ID])
+		}
 	}
 
 	r.queues = newQueues

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -3,8 +3,10 @@ package redis
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -45,10 +47,42 @@ type requestChannelData struct {
 	gate      pipeline.Gate
 }
 
+// queueRuntime tracks one live queue: its dispatch channel plus the consume
+// worker's lifecycle hooks. cancel stops the worker; done closes after the
+// worker returned, at which point the dispatch channel is safe to close.
+// started marks whether a consume worker has ever been launched, so a queue
+// registered before Start still gets a worker when Start runs.
+type queueRuntime struct {
+	data    requestChannelData
+	config  SortedSetQueueConfig
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started bool
+}
+
+// QueueReconfigureResult describes what one ReconfigureQueues call changed,
+// in the terms the merge policy layer understands: channels that appeared
+// (to be added to the fan-in) and channels that were closed (removed from
+// it; closing the source channel is how a merge policy forgets a queue).
+type QueueReconfigureResult struct {
+	Added   []pipeline.RequestChannel
+	Removed []pipeline.RequestChannel
+}
+
+// SortedSetQueueReconfigurer is the optional capability of a Redis
+// sorted-set flow that supports replacing its queue set at runtime, e.g.
+// after a hot reload of a queues configuration file.
+type SortedSetQueueReconfigurer interface {
+	ReconfigureQueues(queues []SortedSetQueueConfig) (QueueReconfigureResult, error)
+}
+
+var errFlowStopped = errors.New("flow is stopped; cannot reconfigure queues")
+
 var (
 	_ pipeline.Flow                        = (*RedisSortedSetFlow)(nil)
 	_ pipeline.HealthChecker               = (*RedisSortedSetFlow)(nil)
 	_ pipeline.CancellationCheckerProvider = (*RedisSortedSetFlow)(nil)
+	_ SortedSetQueueReconfigurer           = (*RedisSortedSetFlow)(nil)
 )
 
 var cleanupRequestStateScript = redis.NewScript(`
@@ -66,18 +100,32 @@ return 1
 `)
 
 type RedisSortedSetFlow struct {
-	rdb                     *redis.Client
-	cancellationChecker     api.CancellationChecker
-	requestChannels         []requestChannelData
-	retryChannel            chan pipeline.RetryMessage
-	resultChannel           chan api.ResultMessage
-	pollInterval            time.Duration
-	batchSize               int
-	retryQueueName          string
-	activeReleases          sync.Map
-	gate                    pipeline.Gate
-	gateFactory             pipeline.GateFactory
-	configMap               map[string]SortedSetQueueConfig
+	rdb                 *redis.Client
+	cancellationChecker api.CancellationChecker
+	retryChannel        chan pipeline.RetryMessage
+	resultChannel       chan api.ResultMessage
+	pollInterval        time.Duration
+	batchSize           int
+	retryQueueName      string
+	activeReleases      sync.Map
+	gate                pipeline.Gate
+	gateFactory         pipeline.GateFactory
+
+	// queueMu guards the live queue registry: queues, queueOrder,
+	// defaultRequestQueueName and stopped. consumeWg.Add for a queue worker
+	// must happen while holding it, so Wait in StopConsuming can never
+	// undercount a worker started concurrently.
+	queueMu      sync.RWMutex
+	queues       map[string]*queueRuntime
+	queueOrder   []string
+	stopped      bool
+	ctxForQueues context.Context
+
+	// configMap is read on message hot paths (labels, result routing, pool
+	// names); ReconfigureQueues swaps it wholesale under cfgMu.
+	cfgMu     sync.RWMutex
+	configMap map[string]SortedSetQueueConfig
+
 	defaultRequestQueueName string
 	defaultResultQueueName  string
 	workerPools             []pipeline.WorkerPoolConfig
@@ -111,6 +159,102 @@ func (c *redisCancellationChecker) IsCancelled(ctx context.Context, requestID, r
 // (LoadSortedSetConfig does this). workerPools resolves the named pool each
 // queue routes to; gateFactory, when non-nil, instantiates a per-queue gate for
 // any queue that declares a gate_type.
+// normalizeSortedSetQueue fills the Optional fields of a queue config with
+// the same defaults NewRedisSortedSetFlow has always applied: empty worker
+// pool → "default", empty request path → "/v1/completions", and empty ID →
+// the queue name. ReconfigureQueues applies these too so hot-loaded configs
+// behave exactly like startup configs.
+func normalizeSortedSetQueue(cfg *SortedSetQueueConfig) {
+	// Normalize before anything reads it: configMap is the source of the
+	// pool_name label on this queue's metrics, and an unset WorkerPoolID
+	// there would label them "" while the request channel below — and every
+	// pool-keyed series — says "default".
+	if cfg.WorkerPoolID == "" {
+		cfg.WorkerPoolID = "default"
+	}
+	if cfg.RequestPathURL == "" {
+		cfg.RequestPathURL = "/v1/completions"
+	}
+	if cfg.ID == "" {
+		cfg.ID = cfg.QueueName
+	}
+}
+
+// validateSortedSetQueues enforces the cross-entry constraints of a queue
+// set (unique IDs, unique names, every entry dispatchable) before any of
+// them is allowed to change live state.
+func (r *RedisSortedSetFlow) validateSortedSetQueues(queues []SortedSetQueueConfig) error {
+	seenID := make(map[string]bool, len(queues))
+	seenQueue := make(map[string]bool, len(queues))
+	for _, q := range queues {
+		if q.QueueName == "" {
+			return fmt.Errorf("queue_name is required for each queue")
+		}
+		if seenID[q.ID] {
+			return fmt.Errorf("duplicate queue id %q in queue configuration", q.ID)
+		}
+		seenID[q.ID] = true
+		if seenQueue[q.QueueName] {
+			return fmt.Errorf("duplicate queue name %q in queue configuration", q.QueueName)
+		}
+		seenQueue[q.QueueName] = true
+		if q.IGWBaseURL == "" {
+			return fmt.Errorf("queue config for queue %q: igw_base_url must be specified", q.QueueName)
+		}
+		found := false
+		for _, pool := range r.workerPools {
+			if pool.ID == q.WorkerPoolID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("worker pool %q specified in queue config not found in pool configuration", q.WorkerPoolID)
+		}
+	}
+	return nil
+}
+
+// newRequestChannel builds the dispatch channel (and attached gate) for a
+// single already-normalized, already-validated queue config.
+func (r *RedisSortedSetFlow) newRequestChannel(cfg SortedSetQueueConfig) (requestChannelData, error) {
+	workerPoolID := cfg.WorkerPoolID
+
+	var gate pipeline.Gate
+	if r.gateFactory != nil && cfg.GateType != "" {
+		gateCfg := cfg.GateConfig
+		gateCfg.Owner = pipeline.GateOwner{
+			QueueID:      cfg.ID,
+			QueueName:    cfg.QueueName,
+			WorkerPoolID: workerPoolID,
+		}
+		created, err := r.gateFactory.CreateGate(gateCfg)
+		if err != nil {
+			return requestChannelData{}, fmt.Errorf("failed to create gate for queue %q (gate_type=%q): %w", cfg.QueueName, cfg.GateType, err)
+		}
+		gate = created
+	} else if r.gate != nil {
+		gate = r.gate
+	} else {
+		gate = pipeline.ConstOpenGate()
+	}
+
+	ch := pipeline.RequestChannel{
+		Channel:            make(chan *api.InternalRequest),
+		InferenceObjective: cfg.InferenceObjective,
+		RequestPathURL:     cfg.RequestPathURL,
+		IGWBaseURL:         cfg.IGWBaseURL,
+		Gate:               gate,
+		WorkerPoolID:       workerPoolID,
+	}
+	return requestChannelData{
+		channel:   ch,
+		queueName: cfg.QueueName,
+		queueID:   cfg.ID,
+		gate:      gate,
+	}, nil
+}
+
 func NewRedisSortedSetFlow(cfg SortedSetConfig, workerPools []pipeline.WorkerPoolConfig, gateFactory pipeline.GateFactory) (*RedisSortedSetFlow, error) {
 	redisOpts, err := ParseRedisOptions(cfg.URL)
 	if err != nil {
@@ -118,7 +262,8 @@ func NewRedisSortedSetFlow(cfg SortedSetConfig, workerPools []pipeline.WorkerPoo
 	}
 	r := &RedisSortedSetFlow{
 		rdb:                    redis.NewClient(redisOpts),
-		requestChannels:        make([]requestChannelData, 0, len(cfg.Queues)),
+		queues:                 make(map[string]*queueRuntime, len(cfg.Queues)),
+		queueOrder:             make([]string, 0, len(cfg.Queues)),
 		retryChannel:           make(chan pipeline.RetryMessage),
 		resultChannel:          make(chan api.ResultMessage, resultChannelBuffer),
 		pollInterval:           time.Duration(cfg.PollIntervalMs) * time.Millisecond,
@@ -137,79 +282,34 @@ func NewRedisSortedSetFlow(cfg SortedSetConfig, workerPools []pipeline.WorkerPoo
 		}
 	}
 
+	queues := make([]SortedSetQueueConfig, len(cfg.Queues))
+	for i := range queues {
+		queues[i] = cfg.Queues[i]
+		normalizeSortedSetQueue(&queues[i])
+	}
+	if err := r.validateSortedSetQueues(queues); err != nil {
+		_ = r.rdb.Close()
+		return nil, err
+	}
+
 	// Retry messages that lack an explicit RequestQueueName fall back to this
 	// name when re-enqueued (flushRetryBatch). Default to the first configured
 	// queue so retries land on a real key rather than "" — preserving the
 	// previous single-queue fallback behavior.
-	if len(cfg.Queues) > 0 {
-		r.defaultRequestQueueName = cfg.Queues[0].QueueName
+	if len(queues) > 0 {
+		r.defaultRequestQueueName = queues[0].QueueName
 	}
 
-	r.configMap = make(map[string]SortedSetQueueConfig, len(cfg.Queues))
-	for _, cfg := range cfg.Queues {
-		// Normalize before anything reads it: configMap is the source of the
-		// pool_name label on this queue's metrics, and an unset WorkerPoolID
-		// there would label them "" while the request channel below — and every
-		// pool-keyed series — says "default".
-		if cfg.WorkerPoolID == "" {
-			cfg.WorkerPoolID = "default"
+	r.configMap = make(map[string]SortedSetQueueConfig, len(queues))
+	for _, queueCfg := range queues {
+		data, err := r.newRequestChannel(queueCfg)
+		if err != nil {
+			_ = r.rdb.Close()
+			return nil, err
 		}
-		workerPoolID := cfg.WorkerPoolID
-
-		var gate pipeline.Gate
-		if r.gateFactory != nil && cfg.GateType != "" {
-			gateCfg := cfg.GateConfig
-			gateCfg.Owner = pipeline.GateOwner{
-				QueueID:      cfg.ID,
-				QueueName:    cfg.QueueName,
-				WorkerPoolID: workerPoolID,
-			}
-			gate, err = r.gateFactory.CreateGate(gateCfg)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create gate for queue %q (gate_type=%q): %w", cfg.QueueName, cfg.GateType, err)
-			}
-		} else if r.gate != nil {
-			gate = r.gate
-		} else {
-			gate = pipeline.ConstOpenGate()
-		}
-
-		found := false
-		for _, pool := range r.workerPools {
-			if pool.ID == workerPoolID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("worker pool %q specified in queue config not found in pool configuration", workerPoolID)
-		}
-
-		if cfg.IGWBaseURL == "" {
-			return nil, fmt.Errorf("queue config for queue %q: igw_base_url must be specified", cfg.QueueName)
-		}
-
-		reqPath := cfg.RequestPathURL
-		if reqPath == "" {
-			reqPath = "/v1/completions"
-		}
-
-		ch := pipeline.RequestChannel{
-			Channel:            make(chan *api.InternalRequest),
-			InferenceObjective: cfg.InferenceObjective,
-			RequestPathURL:     reqPath,
-			IGWBaseURL:         cfg.IGWBaseURL,
-			Gate:               gate,
-			WorkerPoolID:       workerPoolID,
-		}
-
-		r.configMap[cfg.ID] = cfg
-		r.requestChannels = append(r.requestChannels, requestChannelData{
-			channel:   ch,
-			queueName: cfg.QueueName,
-			queueID:   cfg.ID,
-			gate:      gate,
-		})
+		r.configMap[queueCfg.ID] = queueCfg
+		r.queues[queueCfg.ID] = &queueRuntime{data: data, config: queueCfg, done: make(chan struct{})}
+		r.queueOrder = append(r.queueOrder, queueCfg.ID)
 	}
 
 	if r.gate == nil {
@@ -217,6 +317,26 @@ func NewRedisSortedSetFlow(cfg SortedSetConfig, workerPools []pipeline.WorkerPoo
 	}
 
 	return r, nil
+}
+
+// startQueueWorkerLocked launches the consume worker for a registered
+// queue. Callers hold queueMu, which serializes the consumeWg.Add against
+// Wait in StopConsuming; queues added by a hot reload before StopConsumer
+// is flagged are therefore always waited on.
+func (r *RedisSortedSetFlow) startQueueWorkerLocked(consumeCtx context.Context, entry *queueRuntime) {
+	if entry.started {
+		return
+	}
+	entry.started = true
+	entry.done = make(chan struct{})
+	queueCtx, cancel := context.WithCancel(consumeCtx)
+	entry.cancel = cancel
+	r.consumeWg.Add(1)
+	go func() {
+		defer r.consumeWg.Done()
+		defer close(entry.done)
+		r.requestWorker(queueCtx, entry)
+	}()
 }
 
 func (r *RedisSortedSetFlow) Start(ctx context.Context) {
@@ -227,13 +347,13 @@ func (r *RedisSortedSetFlow) Start(ctx context.Context) {
 	drainCtx, drainCancel := context.WithCancel(log.IntoContext(context.Background(), logger))
 	r.drainCancel = drainCancel
 
-	for _, ch := range r.requestChannels {
-		r.consumeWg.Add(1)
-		go func(ch requestChannelData) {
-			defer r.consumeWg.Done()
-			r.requestWorker(consumeCtx, ch.channel.Channel, ch.queueName, ch.queueID)
-		}(ch)
+	r.queueMu.Lock()
+	r.ctxForQueues = consumeCtx
+	for _, id := range r.queueOrder {
+		r.startQueueWorkerLocked(consumeCtx, r.queues[id])
 	}
+	r.queueMu.Unlock()
+
 	r.consumeWg.Add(1)
 	go func() { defer r.consumeWg.Done(); r.retryMover(consumeCtx) }()
 
@@ -243,10 +363,135 @@ func (r *RedisSortedSetFlow) Start(ctx context.Context) {
 }
 
 func (r *RedisSortedSetFlow) StopConsuming() {
+	// Flag first: any ReconfigureQueues racing the shutdown sees stopped
+	// (under queueMu) before it can start a worker Wait would miss.
+	r.queueMu.Lock()
+	r.stopped = true
+	r.queueMu.Unlock()
+
 	if r.consumeCancel != nil {
 		r.consumeCancel()
 	}
 	r.consumeWg.Wait()
+}
+
+// ReconfigureQueues swaps the live queue set against the registry in one
+// atomic step:
+//
+//   - A queue left unchanged across configs keeps its channel, its gate and
+//     its consume worker untouched.
+//   - A new or modified queue is validated and built before anything live
+//     changes; the fresh channel and worker start inside the registry swap,
+//     so a new queue is consumable the moment the function returns.
+//   - A removed or replaced queue's worker is cancelled; after it exits, the
+//     flow itself closes the queue's channel. Closing the source channel is
+//     how merge policies unregister a queue, keeping the policy's merged
+//     channel (and the inference workers reading it) untouched.
+//
+// Neither Redis backlog of removed queues nor in-flight messages are lost:
+// a worker cancelled mid-send re-enqueues the message into the queue before
+// exiting. Empty queue slices are legal — the flow idles and can still
+// accept queues later. Any validation error leaves the previous, last-good
+// configuration untouched.
+func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (QueueReconfigureResult, error) {
+	normalized := make([]SortedSetQueueConfig, len(queues))
+	for i := range normalized {
+		normalized[i] = queues[i]
+		normalizeSortedSetQueue(&normalized[i])
+	}
+	if err := r.validateSortedSetQueues(normalized); err != nil {
+		return QueueReconfigureResult{}, err
+	}
+
+	// Gate creation and channel allocation may fail or be slow; do all of
+	// it against the new config before touching live state so an error here
+	// cannot leave the registry half-updated.
+	prepared := make(map[string]*queueRuntime, len(normalized))
+	for _, queueCfg := range normalized {
+		data, err := r.newRequestChannel(queueCfg)
+		if err != nil {
+			return QueueReconfigureResult{}, err
+		}
+		prepared[queueCfg.ID] = &queueRuntime{data: data, config: queueCfg}
+	}
+
+	r.queueMu.Lock()
+	if r.stopped {
+		r.queueMu.Unlock()
+		return QueueReconfigureResult{}, errFlowStopped
+	}
+
+	var result QueueReconfigureResult
+	var removed []*queueRuntime
+	newQueues := make(map[string]*queueRuntime, len(normalized))
+	newOrder := make([]string, 0, len(normalized))
+	for _, queueCfg := range normalized {
+		old, exists := r.queues[queueCfg.ID]
+		if exists && reflect.DeepEqual(old.config, queueCfg) {
+			// Unchanged: keep channel, gate and worker exactly as they are.
+			newQueues[queueCfg.ID] = old
+			newOrder = append(newOrder, queueCfg.ID)
+			continue
+		}
+		if exists {
+			// Modified: drain the old incarnation and replace it.
+			if old.cancel != nil {
+				old.cancel()
+			}
+			removed = append(removed, old)
+			result.Removed = append(result.Removed, old.data.channel)
+		}
+		entry := prepared[queueCfg.ID]
+		newQueues[queueCfg.ID] = entry
+		newOrder = append(newOrder, queueCfg.ID)
+		result.Added = append(result.Added, entry.data.channel)
+		if r.ctxForQueues != nil {
+			r.startQueueWorkerLocked(r.ctxForQueues, entry)
+		}
+	}
+	for _, id := range r.queueOrder {
+		if _, kept := newQueues[id]; kept {
+			continue
+		}
+		// Removed outright: drain and unregister.
+		old := r.queues[id]
+		if old.cancel != nil {
+			old.cancel()
+		}
+		removed = append(removed, old)
+		result.Removed = append(result.Removed, old.data.channel)
+	}
+
+	r.queues = newQueues
+	r.queueOrder = newOrder
+	if len(normalized) > 0 {
+		r.defaultRequestQueueName = normalized[0].QueueName
+	}
+	r.queueMu.Unlock()
+
+	newConfigMap := make(map[string]SortedSetQueueConfig, len(normalized))
+	for _, queueCfg := range normalized {
+		newConfigMap[queueCfg.ID] = queueCfg
+	}
+	r.cfgMu.Lock()
+	r.configMap = newConfigMap
+	r.cfgMu.Unlock()
+
+	// Closing a channel whose worker might still send panics, so every
+	// removed worker must have fully returned first. Their cancel was issued
+	// above; a worker blocked pushing to its channel exits via the ctx.Done
+	// branch of the send select and re-enqueues the message into Redis. A
+	// queue removed before Start never had a worker at all: its channel was
+	// also never handed out, so it needs neither wait nor close.
+	for _, old := range removed {
+		if !old.started {
+			continue
+		}
+		<-old.done
+		close(old.data.channel.Channel)
+	}
+
+	return result, nil
 }
 
 func (r *RedisSortedSetFlow) Shutdown() {
@@ -257,9 +502,11 @@ func (r *RedisSortedSetFlow) Shutdown() {
 }
 
 func (r *RedisSortedSetFlow) RequestChannels() []pipeline.RequestChannel {
-	channels := make([]pipeline.RequestChannel, len(r.requestChannels))
-	for i, ch := range r.requestChannels {
-		channels[i] = ch.channel
+	r.queueMu.RLock()
+	defer r.queueMu.RUnlock()
+	channels := make([]pipeline.RequestChannel, 0, len(r.queueOrder))
+	for _, id := range r.queueOrder {
+		channels = append(channels, r.queues[id].data.channel)
 	}
 	return channels
 }
@@ -281,12 +528,25 @@ func zeroExpiringCounts(labels []string) []pipeline.ExpiringCount {
 // deadline. Bucket counts come from ZCOUNT, which compares only scores and
 // never reads member payloads, so the read cost is independent of request
 // size.
+// queueSnapshot copies the registered queues in config order; Redis I/O
+// afterwards must not hold queueMu.
+func (r *RedisSortedSetFlow) queueSnapshot() []requestChannelData {
+	r.queueMu.RLock()
+	defer r.queueMu.RUnlock()
+	out := make([]requestChannelData, 0, len(r.queueOrder))
+	for _, id := range r.queueOrder {
+		out = append(out, r.queues[id].data)
+	}
+	return out
+}
+
 func (r *RedisSortedSetFlow) QueueBacklog(ctx context.Context) ([]pipeline.QueueBacklogStat, error) {
-	stats := make([]pipeline.QueueBacklogStat, 0, len(r.requestChannels))
+	snapshot := r.queueSnapshot()
+	stats := make([]pipeline.QueueBacklogStat, 0, len(snapshot))
 	var firstErr error
 	buckets := metrics.DeadlineProximityBuckets()
 	bucketLabels := metrics.DeadlineProximityBucketLabels()
-	for _, cd := range r.requestChannels {
+	for _, cd := range snapshot {
 		stat := pipeline.QueueBacklogStat{
 			QueueID:   cd.queueID,
 			QueueName: cd.queueName,
@@ -384,39 +644,52 @@ func (r *RedisSortedSetFlow) Characteristics() pipeline.Characteristics {
 }
 
 // Polls sorted set and processes messages by deadline priority (earliest first)
-func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string) {
+func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, entry *queueRuntime) {
+	d := entry.data
 	logger := log.FromContext(ctx)
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 
-	// Find the gate for this queue
-	var gate pipeline.Gate
-	for _, ch := range r.requestChannels {
-		if ch.queueName == queueName {
-			gate = ch.gate
-			break
-		}
-	}
+	gate := d.gate
 	if gate == nil {
 		gate = r.gate
 	}
 
-	metrics.InitGateDecisions(queueID, queueName, r.poolNameFor(queueID))
+	metrics.InitGateDecisions(d.queueID, d.queueName, r.poolNameFor(d.queueID))
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			r.processMessages(ctx, msgChannel, queueName, queueID, gate, logger)
+			r.processMessages(ctx, d.channel.Channel, d.queueName, d.queueID, gate, logger)
 		}
 	}
+}
+
+// fallbackRequestQueue returns the queue retry messages without an explicit
+// origin queue land on. ReconfigureQueues keeps it pointing at the first
+// configured queue, so it follows hot reloads just like startup defaults.
+func (r *RedisSortedSetFlow) fallbackRequestQueue() string {
+	r.queueMu.RLock()
+	defer r.queueMu.RUnlock()
+	return r.defaultRequestQueueName
+}
+
+// queueConfigOf reads the currently live config of one queue. The map is
+// swapped wholesale by ReconfigureQueues; hot-path readers never see a
+// partially updated config set.
+func (r *RedisSortedSetFlow) queueConfigOf(queueID string) (SortedSetQueueConfig, bool) {
+	r.cfgMu.RLock()
+	defer r.cfgMu.RUnlock()
+	cfg, ok := r.configMap[queueID]
+	return cfg, ok
 }
 
 // poolNameFor returns the worker pool a queue routes to, or "" when the queue has
 // no config entry (the metric label is then empty rather than wrong).
 func (r *RedisSortedSetFlow) poolNameFor(queueID string) string {
-	if cfg, ok := r.configMap[queueID]; ok {
+	if cfg, ok := r.queueConfigOf(queueID); ok {
 		return cfg.WorkerPoolID
 	}
 	return ""
@@ -488,7 +761,7 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		if ir.QueueID == "" {
 			ir.QueueID = queueID
 		}
-		if cfg, ok := r.configMap[queueID]; ok && len(cfg.Labels) > 0 {
+		if cfg, ok := r.queueConfigOf(queueID); ok && len(cfg.Labels) > 0 {
 			if ir.Labels == nil {
 				ir.Labels = make(map[string]string, len(cfg.Labels))
 			}
@@ -658,7 +931,7 @@ func (r *RedisSortedSetFlow) flushRetryBatch(ctx context.Context, batch []pipeli
 		}
 		queueName := msg.RequestQueueName
 		if queueName == "" {
-			queueName = r.defaultRequestQueueName
+			queueName = r.fallbackRequestQueue()
 		}
 		// Preserve the origin queue in the envelope so the retry mover can
 		// re-enter the message into the right queue once it is due.
@@ -734,7 +1007,7 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 	resultTTLs := make(map[string]time.Duration)
 	for _, result := range batch {
 		resultQueue := defaultQueue
-		cfg, hasCfg := r.configMap[result.Routing.QueueID]
+		cfg, hasCfg := r.queueConfigOf(result.Routing.QueueID)
 		if hasCfg && cfg.ResultQueueName != "" {
 			resultQueue = cfg.ResultQueueName
 		} else if result.Routing.ResultQueueName != "" {
@@ -843,7 +1116,7 @@ func (r *RedisSortedSetFlow) retryMover(ctx context.Context) {
 				}
 				queueName := ir.RequestQueueName
 				if queueName == "" {
-					queueName = r.defaultRequestQueueName
+					queueName = r.fallbackRequestQueue()
 				}
 				if err := r.rdb.ZAdd(ctx, queueName, redis.Z{
 					Score:  float64(ir.PublicRequest.ReqDeadline()),

--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -111,20 +111,17 @@ type RedisSortedSetFlow struct {
 	gate                pipeline.Gate
 	gateFactory         pipeline.GateFactory
 
-	// queueMu guards the live queue registry: queues, queueOrder,
-	// defaultRequestQueueName and stopped. consumeWg.Add for a queue worker
-	// must happen while holding it, so Wait in StopConsuming can never
-	// undercount a worker started concurrently.
-	queueMu      sync.RWMutex
-	queues       map[string]*queueRuntime
-	queueOrder   []string
-	stopped      bool
-	ctxForQueues context.Context
-
-	// configMap is read on message hot paths (labels, result routing, pool
-	// names); ReconfigureQueues swaps it wholesale under cfgMu.
-	cfgMu     sync.RWMutex
-	configMap map[string]SortedSetQueueConfig
+	// queueMu guards the complete live queue state: queues, queueOrder,
+	// configMap, defaultRequestQueueName and stopped. consumeWg.Add for a
+	// queue worker must happen while holding it, so Wait in StopConsuming can
+	// never undercount a worker started concurrently.
+	queueMu       sync.RWMutex
+	reconfigureMu sync.Mutex
+	queues        map[string]*queueRuntime
+	queueOrder    []string
+	configMap     map[string]SortedSetQueueConfig
+	stopped       bool
+	ctxForQueues  context.Context
 
 	defaultRequestQueueName string
 	defaultResultQueueName  string
@@ -394,6 +391,9 @@ func (r *RedisSortedSetFlow) StopConsuming() {
 // accept queues later. Any validation error leaves the previous, last-good
 // configuration untouched.
 func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (QueueReconfigureResult, error) {
+	r.reconfigureMu.Lock()
+	defer r.reconfigureMu.Unlock()
+
 	normalized := make([]SortedSetQueueConfig, len(queues))
 	for i := range normalized {
 		normalized[i] = queues[i]
@@ -403,16 +403,38 @@ func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (Q
 		return QueueReconfigureResult{}, err
 	}
 
-	// Gate creation and channel allocation may fail or be slow; do all of
-	// it against the new config before touching live state so an error here
-	// cannot leave the registry half-updated.
+	r.queueMu.Lock()
+	if r.stopped {
+		r.queueMu.Unlock()
+		return QueueReconfigureResult{}, errFlowStopped
+	}
+	r.queueMu.Unlock()
+
+	// Gate creation and channel allocation may fail or be slow. Prepare only
+	// new or changed queues before touching live state; unchanged gates may
+	// own resources and must not be recreated and discarded on every poll.
 	prepared := make(map[string]*queueRuntime, len(normalized))
+	r.queueMu.RLock()
+	currentConfigs := make(map[string]SortedSetQueueConfig, len(r.queues))
+	for id, entry := range r.queues {
+		currentConfigs[id] = entry.config
+	}
+	r.queueMu.RUnlock()
 	for _, queueCfg := range normalized {
+		oldConfig, exists := currentConfigs[queueCfg.ID]
+		if exists && reflect.DeepEqual(oldConfig, queueCfg) {
+			continue
+		}
 		data, err := r.newRequestChannel(queueCfg)
 		if err != nil {
 			return QueueReconfigureResult{}, err
 		}
 		prepared[queueCfg.ID] = &queueRuntime{data: data, config: queueCfg}
+	}
+
+	newConfigMap := make(map[string]SortedSetQueueConfig, len(normalized))
+	for _, queueCfg := range normalized {
+		newConfigMap[queueCfg.ID] = queueCfg
 	}
 
 	r.queueMu.Lock()
@@ -464,18 +486,13 @@ func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (Q
 
 	r.queues = newQueues
 	r.queueOrder = newOrder
+	r.configMap = newConfigMap
 	if len(normalized) > 0 {
 		r.defaultRequestQueueName = normalized[0].QueueName
+	} else {
+		r.defaultRequestQueueName = ""
 	}
 	r.queueMu.Unlock()
-
-	newConfigMap := make(map[string]SortedSetQueueConfig, len(normalized))
-	for _, queueCfg := range normalized {
-		newConfigMap[queueCfg.ID] = queueCfg
-	}
-	r.cfgMu.Lock()
-	r.configMap = newConfigMap
-	r.cfgMu.Unlock()
 
 	// Closing a channel whose worker might still send panics, so every
 	// removed worker must have fully returned first. Their cancel was issued
@@ -484,11 +501,19 @@ func (r *RedisSortedSetFlow) ReconfigureQueues(queues []SortedSetQueueConfig) (Q
 	// queue removed before Start never had a worker at all: its channel was
 	// also never handed out, so it needs neither wait nor close.
 	for _, old := range removed {
+		newCfg, replaced := newConfigMap[old.data.queueID]
+		removeSnapshots := !replaced || newCfg.QueueName != old.data.queueName || newCfg.WorkerPoolID != old.config.WorkerPoolID
 		if !old.started {
+			if removeSnapshots {
+				metrics.RemoveQueueSnapshots(old.data.queueID, old.data.queueName, old.config.WorkerPoolID)
+			}
 			continue
 		}
 		<-old.done
 		close(old.data.channel.Channel)
+		if removeSnapshots {
+			metrics.RemoveQueueSnapshots(old.data.queueID, old.data.queueName, old.config.WorkerPoolID)
+		}
 	}
 
 	return result, nil
@@ -646,6 +671,10 @@ func (r *RedisSortedSetFlow) Characteristics() pipeline.Characteristics {
 // Polls sorted set and processes messages by deadline priority (earliest first)
 func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, entry *queueRuntime) {
 	d := entry.data
+	cfg := entry.config
+	if cfg.ID == "" && cfg.QueueName == "" {
+		cfg, _ = r.queueConfigOf(d.queueID)
+	}
 	logger := log.FromContext(ctx)
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
@@ -655,14 +684,14 @@ func (r *RedisSortedSetFlow) requestWorker(ctx context.Context, entry *queueRunt
 		gate = r.gate
 	}
 
-	metrics.InitGateDecisions(d.queueID, d.queueName, r.poolNameFor(d.queueID))
+	metrics.InitGateDecisions(d.queueID, d.queueName, cfg.WorkerPoolID)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			r.processMessages(ctx, d.channel.Channel, d.queueName, d.queueID, gate, logger)
+			r.processMessagesWithConfig(ctx, d.channel.Channel, d.queueName, d.queueID, gate, logger, cfg)
 		}
 	}
 }
@@ -676,30 +705,26 @@ func (r *RedisSortedSetFlow) fallbackRequestQueue() string {
 	return r.defaultRequestQueueName
 }
 
-// queueConfigOf reads the currently live config of one queue. The map is
-// swapped wholesale by ReconfigureQueues; hot-path readers never see a
-// partially updated config set.
+// queueConfigOf reads the currently live config of one queue. Queue registry
+// and config map are swapped together, so hot-path readers cannot observe a
+// mixed generation.
 func (r *RedisSortedSetFlow) queueConfigOf(queueID string) (SortedSetQueueConfig, bool) {
-	r.cfgMu.RLock()
-	defer r.cfgMu.RUnlock()
+	r.queueMu.RLock()
+	defer r.queueMu.RUnlock()
 	cfg, ok := r.configMap[queueID]
 	return cfg, ok
 }
 
-// poolNameFor returns the worker pool a queue routes to, or "" when the queue has
-// no config entry (the metric label is then empty rather than wrong).
-func (r *RedisSortedSetFlow) poolNameFor(queueID string) string {
-	if cfg, ok := r.queueConfigOf(queueID); ok {
-		return cfg.WorkerPoolID
-	}
-	return ""
+func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string, gate pipeline.Gate, logger logr.Logger) {
+	cfg, _ := r.queueConfigOf(queueID)
+	r.processMessagesWithConfig(ctx, msgChannel, queueName, queueID, gate, logger, cfg)
 }
 
-func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string, gate pipeline.Gate, logger logr.Logger) {
+func (r *RedisSortedSetFlow) processMessagesWithConfig(ctx context.Context, msgChannel chan *api.InternalRequest, queueName string, queueID string, gate pipeline.Gate, logger logr.Logger, cfg SortedSetQueueConfig) {
 	currentTime := float64(time.Now().Unix())
 
 	budget := gate.Budget(ctx)
-	poolName := r.poolNameFor(queueID)
+	poolName := cfg.WorkerPoolID
 	metrics.SetDispatchBudget(budget, queueID, queueName, poolName)
 	batchSize := int(math.Floor(float64(r.batchSize) * budget))
 	if batchSize <= 0 {
@@ -738,6 +763,19 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 		if rview == nil {
 			continue
 		}
+		if ir.RequestQueueName == "" {
+			ir.RequestQueueName = queueName
+		}
+		if ir.QueueID == "" {
+			ir.QueueID = queueID
+		}
+		if !ir.ResultRoutingResolved {
+			if cfg.ResultQueueName != "" {
+				ir.ResultQueueName = cfg.ResultQueueName
+			}
+			ir.ResultTTLSeconds = cfg.ResultTTLSeconds
+			ir.ResultRoutingResolved = true
+		}
 		if deadline < currentTime {
 			logger.V(logutil.DEFAULT).Info("Deadline expired", "id", rview.ReqID())
 			metrics.RecordExceededDeadlineReq(queueID, queueName, poolName)
@@ -755,13 +793,7 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 			continue
 		}
 
-		if ir.RequestQueueName == "" {
-			ir.RequestQueueName = queueName
-		}
-		if ir.QueueID == "" {
-			ir.QueueID = queueID
-		}
-		if cfg, ok := r.queueConfigOf(queueID); ok && len(cfg.Labels) > 0 {
+		if len(cfg.Labels) > 0 {
 			if ir.Labels == nil {
 				ir.Labels = make(map[string]string, len(cfg.Labels))
 			}
@@ -769,7 +801,6 @@ func (r *RedisSortedSetFlow) processMessages(ctx context.Context, msgChannel cha
 				ir.Labels[k] = v
 			}
 		}
-
 		cancelled, err := r.CancellationChecker().IsCancelled(ctx, rview.ReqID(), ir.RequestToken)
 		if err != nil {
 			// Best-effort at dequeue time only. The worker path performs the
@@ -1007,15 +1038,25 @@ func (r *RedisSortedSetFlow) flushResultBatch(ctx context.Context, batch []api.R
 	resultTTLs := make(map[string]time.Duration)
 	for _, result := range batch {
 		resultQueue := defaultQueue
-		cfg, hasCfg := r.queueConfigOf(result.Routing.QueueID)
-		if hasCfg && cfg.ResultQueueName != "" {
-			resultQueue = cfg.ResultQueueName
+		var resultTTL int64
+		if result.Routing.ResultRoutingResolved {
+			if result.Routing.ResultQueueName != "" {
+				resultQueue = result.Routing.ResultQueueName
+			}
+			resultTTL = result.Routing.ResultTTLSeconds
+		} else if cfg, hasCfg := r.queueConfigOf(result.Routing.QueueID); hasCfg {
+			if cfg.ResultQueueName != "" {
+				resultQueue = cfg.ResultQueueName
+			} else if result.Routing.ResultQueueName != "" {
+				resultQueue = result.Routing.ResultQueueName
+			}
+			resultTTL = cfg.ResultTTLSeconds
 		} else if result.Routing.ResultQueueName != "" {
 			resultQueue = result.Routing.ResultQueueName
 		}
 		queued[resultQueue] = append(queued[resultQueue], r.marshalResult(result))
-		if hasCfg && cfg.ResultTTLSeconds > 0 {
-			resultTTLs[resultQueue] = time.Duration(cfg.ResultTTLSeconds) * time.Second
+		if resultTTL > 0 {
+			resultTTLs[resultQueue] = time.Duration(resultTTL) * time.Second
 		}
 	}
 

--- a/pkg/redis/sortedset_impl_test.go
+++ b/pkg/redis/sortedset_impl_test.go
@@ -55,6 +55,16 @@ func envelopeJSON(rm api.RequestMessage) string {
 	return string(b)
 }
 
+// mkWorkerRuntime wraps a bare channel and queue identity into the runtime
+// shape requestWorker consumes, for tests that drive a worker directly.
+func mkWorkerRuntime(ch chan *api.InternalRequest, queue, queueID string) *queueRuntime {
+	return &queueRuntime{data: requestChannelData{
+		channel:   pipeline.RequestChannel{Channel: ch},
+		queueName: queue,
+		queueID:   queueID,
+	}}
+}
+
 func TestParseSortedSetQueueConfigs(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -148,10 +158,13 @@ func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 	queue := "test-queue"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:   []string{""},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -166,10 +179,10 @@ func TestSortedSetFlow_MessageProcessing(t *testing.T) {
 	}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	select {
-	case received := <-flow.requestChannels[0].channel.Channel:
+	case received := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		if received.PublicRequest == nil || received.PublicRequest.ReqID() != "msg-1" {
 			t.Errorf("Expected msg-1, got %v", received.PublicRequest)
 		}
@@ -216,7 +229,7 @@ func TestSortedSetFlow_DeadlineOrdering(t *testing.T) {
 	}
 
 	msgChannel := make(chan *api.InternalRequest, 10)
-	go flow.requestWorker(ctx, msgChannel, queue, "")
+	go flow.requestWorker(ctx, mkWorkerRuntime(msgChannel, queue, ""))
 
 	var processed []string
 	for i := 0; i < 3; i++ {
@@ -245,10 +258,13 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	queue := "expired-queue"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:    []string{""},
 		resultChannel: make(chan api.ResultMessage, 1),
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
@@ -259,7 +275,7 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	msg := api.RequestMessage{ID: "expired", Created: time.Now().Unix(), Deadline: pastDeadline}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(pastDeadline), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	// The expiry is surfaced as a DEADLINE_EXCEEDED result rather than a
 	// silent drop, so fetch can distinguish a queue timeout from an unknown id.
@@ -276,7 +292,7 @@ func TestSortedSetFlow_ExpiredMessages(t *testing.T) {
 	}
 
 	select {
-	case msg := <-flow.requestChannels[0].channel.Channel:
+	case msg := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		t.Fatalf("Should not receive expired message: %s", msg.PublicRequest.ReqID())
 	default:
 	}
@@ -298,10 +314,13 @@ func TestSortedSetFlow_ExpiredMessagesCleanupRequestState(t *testing.T) {
 	requestID := "expired-cleanup"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:    []string{""},
 		resultChannel: make(chan api.ResultMessage, 1),
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
@@ -318,7 +337,7 @@ func TestSortedSetFlow_ExpiredMessagesCleanupRequestState(t *testing.T) {
 	rdb.Set(ctx, api.RequestCancellationKey(requestID), token, time.Hour)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix() - 100), Member: string(msgBytes)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	time.Sleep(300 * time.Millisecond)
 
@@ -342,10 +361,13 @@ func TestSortedSetFlow_CancelledMessageProducesCancelledResult(t *testing.T) {
 	queue := "cancelled-queue"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:    []string{""},
 		resultChannel: make(chan api.ResultMessage, 1),
 		pollInterval:  50 * time.Millisecond,
 		batchSize:     10,
@@ -360,7 +382,7 @@ func TestSortedSetFlow_CancelledMessageProducesCancelledResult(t *testing.T) {
 	rdb.Set(ctx, api.RequestCancellationKey(ir.PublicRequest.ReqID()), requestToken, time.Hour)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	select {
 	case result := <-flow.resultChannel:
@@ -375,7 +397,7 @@ func TestSortedSetFlow_CancelledMessageProducesCancelledResult(t *testing.T) {
 	}
 
 	select {
-	case msg := <-flow.requestChannels[0].channel.Channel:
+	case msg := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		t.Fatalf("Cancelled message should not reach worker channel: %s", msg.PublicRequest.ReqID())
 	default:
 	}
@@ -390,10 +412,13 @@ func TestSortedSetFlow_CancellationCheckErrorLeavesMessageDispatchable(t *testin
 	queue := "cancel-check-error-queue"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 1)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:          []string{""},
 		resultChannel:       make(chan api.ResultMessage, 1),
 		pollInterval:        50 * time.Millisecond,
 		batchSize:           10,
@@ -408,10 +433,10 @@ func TestSortedSetFlow_CancellationCheckErrorLeavesMessageDispatchable(t *testin
 	msgBytes, _ := json.Marshal(ir)
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: string(msgBytes)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	select {
-	case msg := <-flow.requestChannels[0].channel.Channel:
+	case msg := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		if msg.PublicRequest.ReqID() != ir.PublicRequest.ReqID() {
 			t.Fatalf("expected message %q to remain dispatchable, got %q", ir.PublicRequest.ReqID(), msg.PublicRequest.ReqID())
 		}
@@ -431,10 +456,13 @@ func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 	queue := "malformed-queue"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:   []string{""},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -457,11 +485,11 @@ func TestSortedSetFlow_MalformedMessages(t *testing.T) {
 	validMsg := api.RequestMessage{ID: "valid", Created: time.Now().Unix(), Deadline: 9999999999}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(validMsg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	// Should skip malformed and receive valid message
 	select {
-	case msg := <-flow.requestChannels[0].channel.Channel:
+	case msg := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		if msg.PublicRequest == nil || msg.PublicRequest.ReqID() != "valid" {
 			t.Errorf("Expected valid message, got %v", msg.PublicRequest)
 		}
@@ -966,7 +994,7 @@ func TestSortedSetFlow_NoRaceCondition(t *testing.T) {
 			defer wg.Done()
 			workerCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 			defer cancel()
-			go flow.requestWorker(workerCtx, msgChan, queue, "")
+			go flow.requestWorker(workerCtx, mkWorkerRuntime(msgChan, queue, ""))
 			for {
 				select {
 				case msg := <-msgChan:
@@ -1017,7 +1045,7 @@ func TestSortedSetFlow_ContextCancellation(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		flow.requestWorker(workerCtx, msgChan, queue, "")
+		flow.requestWorker(workerCtx, mkWorkerRuntime(msgChan, queue, ""))
 		done <- true
 	}()
 
@@ -1093,10 +1121,13 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:   []string{""},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         gate,
@@ -1111,11 +1142,11 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 	}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	// Wait for several poll cycles - message should NOT be pulled (budget=0)
 	select {
-	case <-flow.requestChannels[0].channel.Channel:
+	case <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		t.Fatal("Should not receive message when budget is 0")
 	case <-time.After(200 * time.Millisecond):
 		// Expected - no message pulled
@@ -1132,7 +1163,7 @@ func TestSortedSetFlow_ZeroBudget(t *testing.T) {
 
 	// Message should now be pulled
 	select {
-	case received := <-flow.requestChannels[0].channel.Channel:
+	case received := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		if received.PublicRequest == nil || received.PublicRequest.ReqID() != "test-zero-budget" {
 			t.Errorf("Expected test-zero-budget, got %v", received.PublicRequest)
 		}
@@ -1363,10 +1394,13 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 20)},
-			queueName: queue,
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest, 20)},
+				queueName: queue,
+			}},
+		},
+		queueOrder:   []string{""},
 		pollInterval: 200 * time.Millisecond,
 		batchSize:    10,
 		gate:         gate,
@@ -1382,7 +1416,7 @@ func TestSortedSetFlow_PartialBudget(t *testing.T) {
 		rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix() + int64(i)), Member: envelopeJSON(msg)})
 	}
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, "")
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	// Wait for one poll cycle (200ms interval + buffer)
 	time.Sleep(250 * time.Millisecond)
@@ -1409,11 +1443,14 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: msgChan},
-			queueName: queue,
-			gate:      noopGate(),
-		}},
+		queues: map[string]*queueRuntime{
+			"": {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: msgChan},
+				queueName: queue,
+				gate:      noopGate(),
+			}},
+		},
+		queueOrder:   []string{""},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -1432,7 +1469,7 @@ func TestSortedSetFlow_RequestWorkerRequeuesOnShutdown(t *testing.T) {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
-		flow.requestWorker(workerCtx, msgChan, queue, "")
+		flow.requestWorker(workerCtx, mkWorkerRuntime(msgChan, queue, ""))
 		close(done)
 	}()
 
@@ -1559,11 +1596,14 @@ func TestSortedSetFlow_QueueIDSetOnDequeue(t *testing.T) {
 	queueID := "test-qid"
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-			queueID:   queueID,
-		}},
+		queues: map[string]*queueRuntime{
+			queueID: {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+				queueID:   queueID,
+			}},
+		},
+		queueOrder:   []string{queueID},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -1572,10 +1612,10 @@ func TestSortedSetFlow_QueueIDSetOnDequeue(t *testing.T) {
 	msg := api.RequestMessage{ID: "msg-qid", Created: time.Now().Unix(), Deadline: 9999999999}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, queueID)
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	select {
-	case received := <-flow.requestChannels[0].channel.Channel:
+	case received := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		if received.QueueID != queueID {
 			t.Errorf("Expected QueueID %q, got %q", queueID, received.QueueID)
 		}
@@ -1770,7 +1810,7 @@ func TestNewRedisSortedSetFlow_DefaultsWorkerPoolIDInConfigMap(t *testing.T) {
 	if qcfg.WorkerPoolID != "default" {
 		t.Errorf("configMap worker pool = %q, want %q", qcfg.WorkerPoolID, "default")
 	}
-	if got := flow.requestChannels[0].channel.WorkerPoolID; got != qcfg.WorkerPoolID {
+	if got := flow.queues[flow.queueOrder[0]].data.channel.WorkerPoolID; got != qcfg.WorkerPoolID {
 		t.Errorf("request channel worker pool = %q, configMap says %q; the two must agree or the metrics do not join", got, qcfg.WorkerPoolID)
 	}
 }
@@ -1840,10 +1880,11 @@ func TestQueueBacklog(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{
-			{queueName: "queue-a", queueID: "a"},
-			{queueName: "queue-b", queueID: "b"},
+		queues: map[string]*queueRuntime{
+			"a": {data: requestChannelData{queueName: "queue-a", queueID: "a"}},
+			"b": {data: requestChannelData{queueName: "queue-b", queueID: "b"}},
 		},
+		queueOrder: []string{"a", "b"},
 	}
 
 	// queue-a gets 3 members, queue-b gets 1, an unrelated key is ignored.
@@ -1876,9 +1917,10 @@ func TestQueueBacklogDeadlineViews(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{
-			{queueName: "queue-a", queueID: "a"},
+		queues: map[string]*queueRuntime{
+			"a": {data: requestChannelData{queueName: "queue-a", queueID: "a"}},
 		},
+		queueOrder: []string{"a"},
 	}
 
 	now := time.Now().Unix()
@@ -1951,9 +1993,10 @@ func TestQueueBacklogDeadlineCountsAtScale(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{
-			{queueName: "queue-big", queueID: "big"},
+		queues: map[string]*queueRuntime{
+			"big": {data: requestChannelData{queueName: "queue-big", queueID: "big"}},
 		},
+		queueOrder: []string{"big"},
 	}
 
 	now := time.Now().Unix()
@@ -1997,10 +2040,11 @@ func TestQueueBacklogReportsZeroOnError(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{
-			{queueName: "queue-ok", queueID: "ok"},
-			{queueName: "queue-bad", queueID: "bad"},
+		queues: map[string]*queueRuntime{
+			"ok":  {data: requestChannelData{queueName: "queue-ok", queueID: "ok"}},
+			"bad": {data: requestChannelData{queueName: "queue-bad", queueID: "bad"}},
 		},
+		queueOrder: []string{"ok", "bad"},
 	}
 
 	rdb.ZAdd(ctx, "queue-ok", redis.Z{Score: 0, Member: "m1"})
@@ -2061,11 +2105,14 @@ func TestSortedSetFlow_QueueLabelsSetOnDequeue(t *testing.T) {
 
 	flow := &RedisSortedSetFlow{
 		rdb: rdb,
-		requestChannels: []requestChannelData{{
-			channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
-			queueName: queue,
-			queueID:   queueID,
-		}},
+		queues: map[string]*queueRuntime{
+			queueID: {data: requestChannelData{
+				channel:   pipeline.RequestChannel{Channel: make(chan *api.InternalRequest)},
+				queueName: queue,
+				queueID:   queueID,
+			}},
+		},
+		queueOrder:   []string{queueID},
 		pollInterval: 50 * time.Millisecond,
 		batchSize:    10,
 		gate:         noopGate(),
@@ -2080,10 +2127,10 @@ func TestSortedSetFlow_QueueLabelsSetOnDequeue(t *testing.T) {
 	msg := api.RequestMessage{ID: "msg-labels", Created: time.Now().Unix(), Deadline: 9999999999}
 	rdb.ZAdd(ctx, queue, redis.Z{Score: float64(time.Now().Unix()), Member: envelopeJSON(msg)})
 
-	go flow.requestWorker(ctx, flow.requestChannels[0].channel.Channel, queue, queueID)
+	go flow.requestWorker(ctx, flow.queues[flow.queueOrder[0]])
 
 	select {
-	case received := <-flow.requestChannels[0].channel.Channel:
+	case received := <-flow.queues[flow.queueOrder[0]].data.channel.Channel:
 		if received.Labels == nil {
 			t.Fatal("Expected labels on dequeued request, got nil")
 		}

--- a/pkg/redis/sortedset_reconfigure_test.go
+++ b/pkg/redis/sortedset_reconfigure_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
 	redislib "github.com/redis/go-redis/v9"
@@ -182,6 +183,42 @@ func TestReconfigureQueues_ModifyReplacesChannel(t *testing.T) {
 
 	pushTestMessage(t, flow, ctx, "q1-queue", "after-modify")
 	awaitMessage(t, result.Added[0].Channel, "after-modify")
+}
+
+func TestReconfigureQueues_InFlightResultKeepsOriginalRouting(t *testing.T) {
+	s := miniredis.RunT(t)
+	original := testQueue("q1")
+	original.ResultQueueName = "results-old"
+	original.ResultTTLSeconds = 60
+	flow := reconfigureTestFlow(t, s, original)
+	defer flow.rdb.Close() // nolint:errcheck
+
+	ctx := context.Background()
+	pushTestMessage(t, flow, ctx, original.QueueName, "in-flight")
+	msgChannel := make(chan *api.InternalRequest, 1)
+	flow.processMessages(ctx, msgChannel, original.QueueName, original.ID, pipeline.ConstOpenGate(), logr.Discard())
+	ir := <-msgChannel
+
+	modified := original
+	modified.ResultQueueName = "results-new"
+	modified.ResultTTLSeconds = 120
+	if _, err := flow.ReconfigureQueues([]SortedSetQueueConfig{modified}); err != nil {
+		t.Fatalf("reconfigure failed: %v", err)
+	}
+
+	flow.flushResultBatch(ctx, []api.ResultMessage{{
+		ID:      ir.PublicRequest.ReqID(),
+		Routing: ir.InternalRouting,
+	}})
+	if n, _ := flow.rdb.LLen(ctx, "results-old").Result(); n != 1 {
+		t.Fatalf("in-flight result was not routed to original queue, got %d", n)
+	}
+	if n, _ := flow.rdb.LLen(ctx, "results-new").Result(); n != 0 {
+		t.Fatalf("in-flight result leaked to new queue, got %d", n)
+	}
+	if ttl := s.TTL("results-old"); ttl <= 0 || ttl > 60*time.Second {
+		t.Fatalf("in-flight result did not keep original TTL, got %v", ttl)
+	}
 }
 
 func TestReconfigureQueues_InvalidConfigKeepsLastGood(t *testing.T) {

--- a/pkg/redis/sortedset_reconfigure_test.go
+++ b/pkg/redis/sortedset_reconfigure_test.go
@@ -1,0 +1,315 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/llm-d/llm-d-async/api"
+	"github.com/llm-d/llm-d-async/pipeline"
+	redislib "github.com/redis/go-redis/v9"
+)
+
+var reconfigurePools = []pipeline.WorkerPoolConfig{{ID: "default", Workers: 1}}
+
+func reconfigureTestFlow(t *testing.T, s *miniredis.Miniredis, queues ...SortedSetQueueConfig) *RedisSortedSetFlow {
+	t.Helper()
+	flow, err := NewRedisSortedSetFlow(SortedSetConfig{
+		URL:            "redis://" + s.Addr(),
+		PollIntervalMs: 10,
+		BatchSize:      5,
+		Queues:         queues,
+	}, reconfigurePools, nil)
+	if err != nil {
+		t.Fatalf("failed to create flow: %v", err)
+	}
+	return flow
+}
+
+func testQueue(id string) SortedSetQueueConfig {
+	return SortedSetQueueConfig{ID: id, QueueName: id + "-queue", IGWBaseURL: "http://gw"}
+}
+
+// pushTestMessage enqueues one request into the named sorted set with a
+// future deadline, the same shape the frontend writes.
+func pushTestMessage(t *testing.T, flow *RedisSortedSetFlow, ctx context.Context, queue, id string) {
+	t.Helper()
+	ir := api.NewInternalRequest(api.InternalRouting{RequestToken: "tok"}, &api.RequestMessage{
+		ID:       id,
+		Created:  1,
+		Deadline: time.Now().Add(time.Hour).Unix(),
+	})
+	member, err := json.Marshal(ir)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := flow.rdb.ZAdd(ctx, queue, redislib.Z{Score: float64(time.Now().Add(time.Hour).Unix()), Member: string(member)}).Err(); err != nil {
+		t.Fatalf("zadd: %v", err)
+	}
+}
+
+// awaitMessage waits for a request to arrive on the channel with the given ID.
+func awaitMessage(t *testing.T, ch chan *api.InternalRequest, wantID string) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ir := <-ch:
+			if ir.PublicRequest.ReqID() == wantID {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for message %q", wantID)
+		}
+	}
+}
+
+func TestReconfigureQueues_AddNewQueueStartsConsuming(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")})
+	if err != nil {
+		t.Fatalf("reconfigure failed: %v", err)
+	}
+	if len(result.Added) != 1 || len(result.Removed) != 0 {
+		t.Fatalf("expected 1 added, 0 removed, got %d/%d", len(result.Added), len(result.Removed))
+	}
+	if result.Added[0].WorkerPoolID != "default" {
+		t.Fatalf("expected normalized default pool, got %q", result.Added[0].WorkerPoolID)
+	}
+
+	pushTestMessage(t, flow, ctx, "q2-queue", "msg-on-q2")
+	awaitMessage(t, result.Added[0].Channel, "msg-on-q2")
+
+	// The original queue still consumes on its own channel.
+	q1 := flow.queues["q1"].data.channel
+	pushTestMessage(t, flow, ctx, "q1-queue", "msg-on-q1")
+	awaitMessage(t, q1.Channel, "msg-on-q1")
+}
+
+func TestReconfigureQueues_RemoveStopsConsumingAndCloses(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"), testQueue("q2"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	q1Channel := flow.queues["q1"].data.channel.Channel
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q2")})
+	if err != nil {
+		t.Fatalf("reconfigure failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Removed) != 1 {
+		t.Fatalf("expected 0 added, 1 removed, got %d/%d", len(result.Added), len(result.Removed))
+	}
+
+	// The removed queue's channel must be closed so merge policies drop it.
+	select {
+	case _, ok := <-q1Channel:
+		if ok {
+			t.Fatal("expected removed queue's channel to be closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for removed queue's channel to close")
+	}
+
+	// Backlog of the removed queue stays in Redis, unconsumed; the kept
+	// queue still delivers.
+	if depth, err := flow.rdb.ZCard(ctx, "q1-queue").Result(); err == nil && depth != 0 {
+		t.Fatalf("unexpected q1 backlog: %d", depth)
+	}
+	pushTestMessage(t, flow, ctx, "q1-queue", "orphan")
+	pushTestMessage(t, flow, ctx, "q2-queue", "still-served")
+	q2Channel := flow.queues["q2"].data.channel.Channel
+	awaitMessage(t, q2Channel, "still-served")
+	if depth, err := flow.rdb.ZCard(ctx, "q1-queue").Result(); err != nil || depth != 1 {
+		t.Fatalf("removed queue must hold its backlog, got depth=%d err=%v", depth, err)
+	}
+
+	// Re-adding the same ID must produce a fresh channel that consumes the
+	// preserved backlog.
+	result2, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")})
+	if err != nil {
+		t.Fatalf("re-add failed: %v", err)
+	}
+	awaitMessage(t, result2.Added[0].Channel, "orphan")
+}
+
+func TestReconfigureQueues_ModifyReplacesChannel(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	oldChannel := flow.queues["q1"].data.channel.Channel
+	modified := testQueue("q1")
+	modified.InferenceObjective = "new-objective"
+
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{modified})
+	if err != nil {
+		t.Fatalf("reconfigure failed: %v", err)
+	}
+	if len(result.Added) != 1 || len(result.Removed) != 1 {
+		t.Fatalf("expected 1 added, 1 removed, got %d/%d", len(result.Added), len(result.Removed))
+	}
+	if result.Added[0].InferenceObjective != "new-objective" {
+		t.Fatalf("expected new objective, got %q", result.Added[0].InferenceObjective)
+	}
+
+	select {
+	case _, ok := <-oldChannel:
+		if ok {
+			t.Fatal("expected replaced channel to be closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for replaced channel to close")
+	}
+
+	pushTestMessage(t, flow, ctx, "q1-queue", "after-modify")
+	awaitMessage(t, result.Added[0].Channel, "after-modify")
+}
+
+func TestReconfigureQueues_InvalidConfigKeepsLastGood(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	cases := []struct {
+		name   string
+		queues []SortedSetQueueConfig
+	}{
+		{"duplicate queue names", []SortedSetQueueConfig{
+			{ID: "a", QueueName: "same", IGWBaseURL: "http://gw"},
+			{ID: "b", QueueName: "same", IGWBaseURL: "http://gw"},
+		}},
+		{"duplicate ids", []SortedSetQueueConfig{
+			{ID: "same", QueueName: "a", IGWBaseURL: "http://gw"},
+			{ID: "same", QueueName: "b", IGWBaseURL: "http://gw"},
+		}},
+		{"missing igw_base_url", []SortedSetQueueConfig{{ID: "a", QueueName: "a"}}},
+		{"unknown worker pool", []SortedSetQueueConfig{{ID: "a", QueueName: "a", IGWBaseURL: "http://gw", WorkerPoolID: "ghost"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := flow.ReconfigureQueues(tc.queues); err == nil {
+				t.Fatal("expected validation error")
+			}
+			// The live queue set must be untouched.
+			channels := flow.RequestChannels()
+			if len(channels) != 1 {
+				t.Fatalf("last good registry mutated: %d channels", len(channels))
+			}
+			if cfg, ok := flow.queueConfigOf("q1"); !ok || cfg.QueueName != "q1-queue" {
+				t.Fatalf("q1 config lost: %+v ok=%v", cfg, ok)
+			}
+		})
+	}
+
+	pushTestMessage(t, flow, ctx, "q1-queue", "last-good")
+	awaitMessage(t, flow.RequestChannels()[0].Channel, "last-good")
+}
+
+func TestReconfigureQueues_IdenticalConfigIsNoop(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")})
+	if err != nil {
+		t.Fatalf("reconfigure failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("identical config should be a no-op, got added=%d removed=%d", len(result.Added), len(result.Removed))
+	}
+}
+
+func TestReconfigureQueues_EmptyConfigDrainsAll(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	result, err := flow.ReconfigureQueues(nil)
+	if err != nil {
+		t.Fatalf("reconfigure failed: %v", err)
+	}
+	if len(result.Removed) != 1 {
+		t.Fatalf("expected 1 removed, got %d", len(result.Removed))
+	}
+	if got := len(flow.RequestChannels()); got != 0 {
+		t.Fatalf("expected empty registry, got %d", got)
+	}
+
+	// Empty is not a dead end: queues can still come back.
+	result2, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")})
+	if err != nil || len(result2.Added) != 1 {
+		t.Fatalf("re-add after drain failed: added=%d err=%v", len(result2.Added), err)
+	}
+	pushTestMessage(t, flow, ctx, "q1-queue", "revived")
+	awaitMessage(t, result2.Added[0].Channel, "revived")
+}
+
+func TestReconfigureQueues_AfterStopConsumingFails(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+	ctx := context.Background()
+	flow.Start(ctx)
+	flow.StopConsuming()
+	defer flow.Shutdown()
+
+	if _, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q2")}); !errors.Is(err, errFlowStopped) {
+		t.Fatalf("expected errFlowStopped, got %v", err)
+	}
+}
+
+func TestReconfigureQueues_RaceWithStopConsuming(t *testing.T) {
+	for i := range 20 {
+		t.Run(fmt.Sprintf("iter-%d", i), func(t *testing.T) {
+			s := miniredis.RunT(t)
+			flow := reconfigureTestFlow(t, s, testQueue("q1"))
+
+			ctx := context.Background()
+			flow.Start(ctx)
+
+			stopDone := make(chan struct{})
+			go func() {
+				flow.StopConsuming()
+				close(stopDone)
+			}()
+			// Either succeeds before stop or fails with errFlowStopped —
+			// both are legal; the run must not panic, deadlock or race.
+			go func() {
+				_, _ = flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")})
+			}()
+			<-stopDone
+			flow.Shutdown()
+		})
+	}
+}

--- a/pkg/redis/sortedset_reconfigure_test.go
+++ b/pkg/redis/sortedset_reconfigure_test.go
@@ -78,7 +78,7 @@ func TestReconfigureQueues_AddNewQueueStartsConsuming(t *testing.T) {
 	defer flow.StopConsuming()
 	defer flow.Shutdown()
 
-	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")})
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")}, nil)
 	if err != nil {
 		t.Fatalf("reconfigure failed: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestReconfigureQueues_RemoveStopsConsumingAndCloses(t *testing.T) {
 	defer flow.Shutdown()
 
 	q1Channel := flow.queues["q1"].data.channel.Channel
-	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q2")})
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q2")}, nil)
 	if err != nil {
 		t.Fatalf("reconfigure failed: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestReconfigureQueues_RemoveStopsConsumingAndCloses(t *testing.T) {
 
 	// Re-adding the same ID must produce a fresh channel that consumes the
 	// preserved backlog.
-	result2, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")})
+	result2, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")}, nil)
 	if err != nil {
 		t.Fatalf("re-add failed: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestReconfigureQueues_ModifyReplacesChannel(t *testing.T) {
 	modified := testQueue("q1")
 	modified.InferenceObjective = "new-objective"
 
-	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{modified})
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{modified}, nil)
 	if err != nil {
 		t.Fatalf("reconfigure failed: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestReconfigureQueues_InFlightResultKeepsOriginalRouting(t *testing.T) {
 	modified := original
 	modified.ResultQueueName = "results-new"
 	modified.ResultTTLSeconds = 120
-	if _, err := flow.ReconfigureQueues([]SortedSetQueueConfig{modified}); err != nil {
+	if _, err := flow.ReconfigureQueues([]SortedSetQueueConfig{modified}, nil); err != nil {
 		t.Fatalf("reconfigure failed: %v", err)
 	}
 
@@ -247,7 +247,7 @@ func TestReconfigureQueues_InvalidConfigKeepsLastGood(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := flow.ReconfigureQueues(tc.queues); err == nil {
+			if _, err := flow.ReconfigureQueues(tc.queues, nil); err == nil {
 				t.Fatal("expected validation error")
 			}
 			// The live queue set must be untouched.
@@ -265,6 +265,100 @@ func TestReconfigureQueues_InvalidConfigKeepsLastGood(t *testing.T) {
 	awaitMessage(t, flow.RequestChannels()[0].Channel, "last-good")
 }
 
+func TestReconfigureQueues_CallbackErrorKeepsLiveRegistry(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+	flow.Start(context.Background())
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	old := flow.RequestChannels()[0]
+	wantErr := errors.New("policy unavailable")
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")}, func(added []pipeline.RequestChannel) error {
+		if len(added) != 1 || added[0].WorkerPoolID != "default" || added[0].IGWBaseURL != "http://gw" {
+			t.Fatalf("callback saw wrong added channels: %+v", added)
+		}
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if len(result.Added) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("failed callback returned result: %+v", result)
+	}
+	channels := flow.RequestChannels()
+	if len(channels) != 1 || channels[0].Channel != old.Channel {
+		t.Fatalf("live registry changed after callback failure: %+v", channels)
+	}
+	pushTestMessage(t, flow, context.Background(), "q1-queue", "still-live")
+	awaitMessage(t, old.Channel, "still-live")
+}
+
+func TestReconfigureQueues_CallbackSeesAddedBeforeCommit(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+	flow.Start(context.Background())
+	defer flow.StopConsuming()
+	defer flow.Shutdown()
+
+	callbackCalled := false
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1"), testQueue("q2")}, func(added []pipeline.RequestChannel) error {
+		callbackCalled = true
+		if len(added) != 1 || added[0].WorkerPoolID != "default" {
+			t.Fatalf("callback saw wrong added channels: %+v", added)
+		}
+		return nil
+	})
+	if err != nil || !callbackCalled {
+		t.Fatalf("reconfigure callback result: called=%v err=%v", callbackCalled, err)
+	}
+	if len(result.Added) != 1 || len(flow.RequestChannels()) != 2 {
+		t.Fatalf("successful callback did not commit: result=%+v channels=%d", result, len(flow.RequestChannels()))
+	}
+}
+
+func TestReconfigureQueues_WaitingWorkerIsReleasedByStopConsuming(t *testing.T) {
+	s := miniredis.RunT(t)
+	flow := reconfigureTestFlow(t, s, testQueue("q1"))
+	flow.Start(context.Background())
+	defer flow.Shutdown()
+
+	old := flow.queues["q1"]
+	cancelCalled := make(chan struct{})
+	old.cancel = func() {
+		close(cancelCalled)
+	}
+	reconfigureDone := make(chan error, 1)
+	go func() {
+		_, err := flow.ReconfigureQueues(nil, nil)
+		reconfigureDone <- err
+	}()
+	select {
+	case <-cancelCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("reconfigure did not begin draining the removed worker")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		flow.StopConsuming()
+		close(stopDone)
+	}()
+	select {
+	case err := <-reconfigureDone:
+		if err != nil {
+			t.Fatalf("reconfigure failed: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("reconfigure remained blocked after StopConsuming")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StopConsuming did not return")
+	}
+}
+
 func TestReconfigureQueues_IdenticalConfigIsNoop(t *testing.T) {
 	s := miniredis.RunT(t)
 	flow := reconfigureTestFlow(t, s, testQueue("q1"))
@@ -274,7 +368,7 @@ func TestReconfigureQueues_IdenticalConfigIsNoop(t *testing.T) {
 	defer flow.StopConsuming()
 	defer flow.Shutdown()
 
-	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")})
+	result, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")}, nil)
 	if err != nil {
 		t.Fatalf("reconfigure failed: %v", err)
 	}
@@ -292,7 +386,7 @@ func TestReconfigureQueues_EmptyConfigDrainsAll(t *testing.T) {
 	defer flow.StopConsuming()
 	defer flow.Shutdown()
 
-	result, err := flow.ReconfigureQueues(nil)
+	result, err := flow.ReconfigureQueues(nil, nil)
 	if err != nil {
 		t.Fatalf("reconfigure failed: %v", err)
 	}
@@ -304,7 +398,7 @@ func TestReconfigureQueues_EmptyConfigDrainsAll(t *testing.T) {
 	}
 
 	// Empty is not a dead end: queues can still come back.
-	result2, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")})
+	result2, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")}, nil)
 	if err != nil || len(result2.Added) != 1 {
 		t.Fatalf("re-add after drain failed: added=%d err=%v", len(result2.Added), err)
 	}
@@ -321,7 +415,7 @@ func TestReconfigureQueues_AfterStopConsumingFails(t *testing.T) {
 	flow.StopConsuming()
 	defer flow.Shutdown()
 
-	if _, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q2")}); !errors.Is(err, errFlowStopped) {
+	if _, err := flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q2")}, nil); !errors.Is(err, errFlowStopped) {
 		t.Fatalf("expected errFlowStopped, got %v", err)
 	}
 }
@@ -343,7 +437,7 @@ func TestReconfigureQueues_RaceWithStopConsuming(t *testing.T) {
 			// Either succeeds before stop or fails with errFlowStopped —
 			// both are legal; the run must not panic, deadlock or race.
 			go func() {
-				_, _ = flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")})
+				_, _ = flow.ReconfigureQueues([]SortedSetQueueConfig{testQueue("q1")}, nil)
 			}()
 			<-stopDone
 			flow.Shutdown()

--- a/pkg/server/compat_test.go
+++ b/pkg/server/compat_test.go
@@ -146,6 +146,49 @@ func TestResolveTransport_PrefersNewFlags(t *testing.T) {
 	}
 }
 
+func TestValidateTransportConfigWatchCombinations(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "canonical file sorted set",
+			args: []string{"--transport=redis-sortedset", "--transport-config-file=/tmp/transport.json", "--transport-config-watch-interval=1s"},
+		},
+		{
+			name: "inline config rejected",
+			args: []string{"--transport=redis-sortedset", `--transport-config={"url":"redis://x","queues":[{"queue_name":"q","igw_base_url":"http://gw"}]}`, "--transport-config-watch-interval=1s"},
+			want: "--transport-config-file",
+		},
+		{
+			name: "other transport rejected",
+			args: []string{"--transport=redis-pubsub", "--transport-config-file=/tmp/transport.json", "--transport-config-watch-interval=1s"},
+			want: "redis-sortedset",
+		},
+		{
+			name: "legacy transport rejected",
+			args: []string{"--message-queue-impl=redis-sortedset", "--transport-config-watch-interval=1s"},
+			want: "redis-sortedset",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newTestOptions(t, tt.args...)
+			err := o.Validate()
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("Validate() failed: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveTransport_NormalizesGatedAlias(t *testing.T) {
 	o := newTestOptions(t,
 		"--message-queue-impl=gcp-pubsub-gated",

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -39,6 +39,7 @@ type TransportOptions struct {
 	Type                  string
 	Config                string
 	ConfigFile            string
+	ConfigWatchInterval   time.Duration
 	MergePolicyConfigFile string
 	BacklogPollInterval   time.Duration
 }
@@ -138,6 +139,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Transport.Type, "transport", o.Transport.Type, "The transport implementation to use. Supported: redis-pubsub, redis-sortedset, gcp-pubsub")
 	fs.StringVar(&o.Transport.Config, "transport-config", o.Transport.Config, "Inline JSON transport configuration. Mutually exclusive with --transport-config-file.")
 	fs.StringVar(&o.Transport.ConfigFile, "transport-config-file", o.Transport.ConfigFile, "Path to transport configuration JSON file. Mutually exclusive with --transport-config.")
+	fs.DurationVar(&o.Transport.ConfigWatchInterval, "transport-config-watch-interval", o.Transport.ConfigWatchInterval, "If positive, periodically reload the queues field of --transport-config-file; 0 disables hot reload (default)")
 	fs.StringVar(&o.Transport.MergePolicyConfigFile, "request-merge-policy-config-file", o.Transport.MergePolicyConfigFile, "Path to the request merge policy configuration JSON file (empty defaults to random-robin)")
 	// Deprecated: use --request-merge-policy-config-file. Retained for backwards compatibility.
 	fs.StringVar(&o.legacyMergePolicyConfigFile, "request-merge-policy-config", o.legacyMergePolicyConfigFile, "Deprecated: use --request-merge-policy-config-file. Path to the request merge policy configuration JSON file")
@@ -226,6 +228,17 @@ var (
 )
 
 func (o *Options) Validate() error {
+	if o.Transport.ConfigWatchInterval < 0 {
+		return fmt.Errorf("--transport-config-watch-interval must not be negative")
+	}
+	if o.Transport.ConfigWatchInterval > 0 {
+		if !o.usingNewTransport() || o.Transport.Type != "redis-sortedset" {
+			return fmt.Errorf("--transport-config-watch-interval requires --transport redis-sortedset")
+		}
+		if o.Transport.Config != "" || o.Transport.ConfigFile == "" {
+			return fmt.Errorf("--transport-config-watch-interval requires --transport-config-file and cannot be used with --transport-config")
+		}
+	}
 	if o.usingNewTransport() {
 		if err := o.validateNewTransport(); err != nil {
 			return err

--- a/pkg/server/queues_reload.go
+++ b/pkg/server/queues_reload.go
@@ -2,10 +2,9 @@ package server
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -17,9 +16,9 @@ import (
 // startQueuesConfigReload periodically re-reads the sorted-set queues config
 // file and applies queue set changes to the running flow: new and modified
 // queues become consumable without a restart, removed queues are drained and
-// their channels closed. The whole pipeline is fingerprint-gated — an
-// unchanged file is a no-op, and a file that fails to read, parse or apply
-// leaves the last good configuration exactly as it was.
+// their channels closed. An unchanged normalized config is a no-op, and a
+// file that fails to read, parse or apply leaves the last good configuration
+// exactly as it was.
 //
 // The merged channels observed by inference pool workers never change: the
 // merge policy learns new sources through AddRequestChannels and forgets
@@ -28,6 +27,7 @@ func startQueuesConfigReload(
 	ctx context.Context,
 	path string,
 	interval time.Duration,
+	lastGood *redis.SortedSetConfig,
 	flow redis.SortedSetQueueReconfigurer,
 	policy pipeline.DynamicRequestMergePolicy,
 	pools map[string]pipeline.WorkerPoolConfig,
@@ -40,63 +40,49 @@ func startQueuesConfigReload(
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		// Unknown initial fingerprint: the first successful pass applies the
-		// file even when it matches the startup config — ReconfigureQueues is
-		// idempotent for identical sets, so this only seeds lastApplied.
-		var lastApplied [32]byte
-		var pendingAdded []pipeline.RequestChannel
-
 		reload := func() {
-			if len(pendingAdded) > 0 {
-				if err := policy.AddRequestChannels(pendingAdded, pools); err != nil {
-					metrics.RecordQueueConfigReload(false)
-					logger.Error(err, "Failed to retry merge fan-in extension; retrying next tick", "pending", len(pendingAdded))
-					return
-				}
-				pendingAdded = nil
-			}
-
 			data, err := os.ReadFile(path) // #nosec G304 -- path from trusted CLI flag
 			if err != nil {
 				metrics.RecordQueueConfigReload(false)
 				logger.Error(err, "Failed to read queues config file; keeping last good queues")
 				return
 			}
-			fingerprint := sha256.Sum256(data)
-			if fingerprint == lastApplied {
-				return
-			}
-
-			var queues []redis.SortedSetQueueConfig
-			if err := json.Unmarshal(data, &queues); err != nil {
+			cfg, err := redis.LoadSortedSetConfigAllowEmptyQueues(data)
+			if err != nil {
 				metrics.RecordQueueConfigReload(false)
 				logger.Error(err, "Failed to parse queues config file; keeping last good queues")
 				return
 			}
+			if reflect.DeepEqual(cfg, lastGood) {
+				return
+			}
+			previous := *lastGood
+			previous.Queues = nil
+			next := *cfg
+			next.Queues = nil
+			if !reflect.DeepEqual(previous, next) {
+				metrics.RecordQueueConfigReload(false)
+				logger.Error(fmt.Errorf("non-queue transport fields changed"), "Rejected transport config reload; restart required")
+				return
+			}
+			for _, queue := range cfg.Queues {
+				if _, ok := pools[queue.WorkerPoolID]; !ok {
+					metrics.RecordQueueConfigReload(false)
+					logger.Error(fmt.Errorf("worker pool %q not found", queue.WorkerPoolID), "Rejected queues config reload; keeping last good queues")
+					return
+				}
+			}
 
-			result, err := flow.ReconfigureQueues(queues)
+			result, err := flow.ReconfigureQueues(cfg.Queues, func(added []pipeline.RequestChannel) error {
+				return policy.AddRequestChannels(added, pools)
+			})
 			if err != nil {
 				metrics.RecordQueueConfigReload(false)
 				logger.Error(err, "Failed to apply queues config; keeping last good queues")
 				return
 			}
-			if len(result.Added) > 0 {
-				if err := policy.AddRequestChannels(result.Added, pools); err != nil {
-					// The flow already consumes the new queues; without a
-					// fan-in update their messages would sit in channels
-					// nobody reads. Retrying the whole file on the next tick
-					// is safe (unchanged queues stay untouched), so the
-					// fingerprint deliberately stays uncommitted. Keep the
-					// exact channels: the next idempotent flow apply will not
-					// report them as Added again.
-					pendingAdded = append([]pipeline.RequestChannel(nil), result.Added...)
-					metrics.RecordQueueConfigReload(false)
-					logger.Error(err, "Failed to extend merge fan-in with new queues; retrying next tick", "added", len(result.Added))
-					return
-				}
-			}
+			*lastGood = *cfg
 
-			lastApplied = fingerprint
 			metrics.RecordQueueConfigReload(true)
 			logger.Info("Applied queues config reload", "added", len(result.Added), "removed", len(result.Removed))
 		}
@@ -119,12 +105,12 @@ func startQueuesConfigReload(
 // flow/policy pair that both support runtime changes. Called once at
 // startup so a miswired deployment fails fast instead of drifting silently.
 func validateQueuesConfigWatch(opts *Options, flow pipeline.Flow, policy pipeline.RequestMergePolicy) (redis.SortedSetQueueReconfigurer, pipeline.DynamicRequestMergePolicy, bool, error) {
-	interval := opts.RedisSortedSet.QueuesConfigWatchInterval
+	interval := opts.Transport.ConfigWatchInterval
 	if interval <= 0 {
 		return nil, nil, false, nil
 	}
-	if opts.RedisSortedSet.QueuesConfigFile == "" {
-		return nil, nil, false, fmt.Errorf("--redis.ss.queues-config-watch-interval requires --redis.ss.queues-config-file")
+	if !opts.usingNewTransport() || opts.Transport.Type != "redis-sortedset" || opts.Transport.ConfigFile == "" || opts.Transport.Config != "" {
+		return nil, nil, false, fmt.Errorf("--transport-config-watch-interval requires --transport redis-sortedset with --transport-config-file")
 	}
 	reconfigurer, ok := flow.(redis.SortedSetQueueReconfigurer)
 	if !ok {

--- a/pkg/server/queues_reload.go
+++ b/pkg/server/queues_reload.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/metrics"
+	"github.com/llm-d/llm-d-async/pkg/redis"
+)
+
+// startQueuesConfigReload periodically re-reads the sorted-set queues config
+// file and applies queue set changes to the running flow: new and modified
+// queues become consumable without a restart, removed queues are drained and
+// their channels closed. The whole pipeline is fingerprint-gated — an
+// unchanged file is a no-op, and a file that fails to read, parse or apply
+// leaves the last good configuration exactly as it was.
+//
+// The merged channels observed by inference pool workers never change: the
+// merge policy learns new sources through AddRequestChannels and forgets
+// removed ones when the flow closes their channels.
+func startQueuesConfigReload(
+	ctx context.Context,
+	path string,
+	interval time.Duration,
+	flow redis.SortedSetQueueReconfigurer,
+	policy pipeline.DynamicRequestMergePolicy,
+	pools map[string]pipeline.WorkerPoolConfig,
+	logger logr.Logger,
+) {
+	logger = logger.WithName("queues-config-reload").WithValues("path", path, "interval", interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		// Unknown initial fingerprint: the first successful pass applies the
+		// file even when it matches the startup config — ReconfigureQueues is
+		// idempotent for identical sets, so this only seeds lastApplied.
+		var lastApplied [32]byte
+
+		reload := func() {
+			data, err := os.ReadFile(path) // #nosec G304 -- path from trusted CLI flag
+			if err != nil {
+				metrics.RecordQueueConfigReload(false)
+				logger.Error(err, "Failed to read queues config file; keeping last good queues")
+				return
+			}
+			fingerprint := sha256.Sum256(data)
+			if fingerprint == lastApplied {
+				return
+			}
+
+			var queues []redis.SortedSetQueueConfig
+			if err := json.Unmarshal(data, &queues); err != nil {
+				metrics.RecordQueueConfigReload(false)
+				logger.Error(err, "Failed to parse queues config file; keeping last good queues")
+				return
+			}
+
+			result, err := flow.ReconfigureQueues(queues)
+			if err != nil {
+				metrics.RecordQueueConfigReload(false)
+				logger.Error(err, "Failed to apply queues config; keeping last good queues")
+				return
+			}
+			if len(result.Added) > 0 {
+				if err := policy.AddRequestChannels(result.Added, pools); err != nil {
+					// The flow already consumes the new queues; without a
+					// fan-in update their messages would sit in channels
+					// nobody reads. Retrying the whole file on the next tick
+					// is safe (unchanged queues stay untouched), so the
+					// fingerprint deliberately stays uncommitted.
+					metrics.RecordQueueConfigReload(false)
+					logger.Error(err, "Failed to extend merge fan-in with new queues; retrying next tick", "added", len(result.Added))
+					return
+				}
+			}
+
+			lastApplied = fingerprint
+			metrics.RecordQueueConfigReload(true)
+			logger.Info("Applied queues config reload", "added", len(result.Added), "removed", len(result.Removed))
+		}
+
+		reload()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reload()
+			}
+		}
+	}()
+}
+
+// validateQueuesConfigWatch enforces that hot reload is only requested in a
+// configuration where it can actually work: file-based queues config and a
+// flow/policy pair that both support runtime changes. Called once at
+// startup so a miswired deployment fails fast instead of drifting silently.
+func validateQueuesConfigWatch(opts *Options, flow pipeline.Flow, policy pipeline.RequestMergePolicy) (redis.SortedSetQueueReconfigurer, pipeline.DynamicRequestMergePolicy, bool, error) {
+	interval := opts.RedisSortedSet.QueuesConfigWatchInterval
+	if interval <= 0 {
+		return nil, nil, false, nil
+	}
+	if opts.RedisSortedSet.QueuesConfigFile == "" {
+		return nil, nil, false, fmt.Errorf("--redis.ss.queues-config-watch-interval requires --redis.ss.queues-config-file")
+	}
+	reconfigurer, ok := flow.(redis.SortedSetQueueReconfigurer)
+	if !ok {
+		return nil, nil, false, fmt.Errorf("queues config hot reload requires the redis sorted-set transport")
+	}
+	dynamicPolicy, ok := policy.(pipeline.DynamicRequestMergePolicy)
+	if !ok {
+		return nil, nil, false, fmt.Errorf("queues config hot reload requires a merge policy supporting runtime channel changes")
+	}
+	return reconfigurer, dynamicPolicy, true, nil
+}

--- a/pkg/server/queues_reload.go
+++ b/pkg/server/queues_reload.go
@@ -32,9 +32,11 @@ func startQueuesConfigReload(
 	policy pipeline.DynamicRequestMergePolicy,
 	pools map[string]pipeline.WorkerPoolConfig,
 	logger logr.Logger,
-) {
+) <-chan struct{} {
 	logger = logger.WithName("queues-config-reload").WithValues("path", path, "interval", interval)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
@@ -42,8 +44,18 @@ func startQueuesConfigReload(
 		// file even when it matches the startup config — ReconfigureQueues is
 		// idempotent for identical sets, so this only seeds lastApplied.
 		var lastApplied [32]byte
+		var pendingAdded []pipeline.RequestChannel
 
 		reload := func() {
+			if len(pendingAdded) > 0 {
+				if err := policy.AddRequestChannels(pendingAdded, pools); err != nil {
+					metrics.RecordQueueConfigReload(false)
+					logger.Error(err, "Failed to retry merge fan-in extension; retrying next tick", "pending", len(pendingAdded))
+					return
+				}
+				pendingAdded = nil
+			}
+
 			data, err := os.ReadFile(path) // #nosec G304 -- path from trusted CLI flag
 			if err != nil {
 				metrics.RecordQueueConfigReload(false)
@@ -74,7 +86,10 @@ func startQueuesConfigReload(
 					// fan-in update their messages would sit in channels
 					// nobody reads. Retrying the whole file on the next tick
 					// is safe (unchanged queues stay untouched), so the
-					// fingerprint deliberately stays uncommitted.
+					// fingerprint deliberately stays uncommitted. Keep the
+					// exact channels: the next idempotent flow apply will not
+					// report them as Added again.
+					pendingAdded = append([]pipeline.RequestChannel(nil), result.Added...)
 					metrics.RecordQueueConfigReload(false)
 					logger.Error(err, "Failed to extend merge fan-in with new queues; retrying next tick", "added", len(result.Added))
 					return
@@ -96,6 +111,7 @@ func startQueuesConfigReload(
 			}
 		}
 	}()
+	return done
 }
 
 // validateQueuesConfigWatch enforces that hot reload is only requested in a

--- a/pkg/server/queues_reload_test.go
+++ b/pkg/server/queues_reload_test.go
@@ -10,21 +10,30 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/llm-d/llm-d-async/api"
 	"github.com/llm-d/llm-d-async/pipeline"
 	"github.com/llm-d/llm-d-async/pkg/redis"
 )
 
 type reconfigStub struct {
-	mu     sync.Mutex
-	calls  [][]redis.SortedSetQueueConfig
-	result redis.QueueReconfigureResult
-	err    error
+	mu       sync.Mutex
+	attempts int
+	calls    [][]redis.SortedSetQueueConfig
+	result   redis.QueueReconfigureResult
+	err      error
 }
 
-func (s *reconfigStub) ReconfigureQueues(queues []redis.SortedSetQueueConfig) (redis.QueueReconfigureResult, error) {
+func (s *reconfigStub) ReconfigureQueues(queues []redis.SortedSetQueueConfig, beforeCommit func([]pipeline.RequestChannel) error) (redis.QueueReconfigureResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.attempts++
+	if s.err != nil {
+		return s.result, s.err
+	}
+	if beforeCommit != nil {
+		if err := beforeCommit(s.result.Added); err != nil {
+			return redis.QueueReconfigureResult{}, err
+		}
+	}
 	s.calls = append(s.calls, queues)
 	return s.result, s.err
 }
@@ -35,26 +44,29 @@ func (s *reconfigStub) callCount() int {
 	return len(s.calls)
 }
 
+func (s *reconfigStub) attemptCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attempts
+}
+
+func (s *reconfigStub) call(index int) []redis.SortedSetQueueConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]redis.SortedSetQueueConfig(nil), s.calls[index]...)
+}
+
 type dynPolicyStub struct {
 	pipeline.RequestMergePolicy
-	mu       sync.Mutex
-	added    [][]pipeline.RequestChannel
-	err      error
-	failures int
+	mu    sync.Mutex
+	added [][]pipeline.RequestChannel
+	err   error
 }
 
 func (s *dynPolicyStub) AddRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.added = append(s.added, channels)
-	if s.failures > 0 {
-		s.failures--
-		err := s.err
-		if s.failures == 0 {
-			s.err = nil
-		}
-		return err
-	}
 	return s.err
 }
 
@@ -62,6 +74,12 @@ func (s *dynPolicyStub) addCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.added)
+}
+
+func (s *dynPolicyStub) setError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
 }
 
 func waitFor(t *testing.T, what string, cond func() bool) {
@@ -82,10 +100,27 @@ func writeQueuesFile(t *testing.T, path, content string) {
 	}
 }
 
+func sortedSetFile(queues string) string {
+	return `{"url":"redis://localhost:6379","queues":` + queues + `}`
+}
+
+func loadTestConfig(t *testing.T, path string) *redis.SortedSetConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read test config: %v", err)
+	}
+	cfg, err := redis.LoadSortedSetConfig(data)
+	if err != nil {
+		t.Fatalf("load test config: %v", err)
+	}
+	return cfg
+}
+
 func TestQueuesConfigReload_AppliesChanges(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "queues.json")
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
 
 	flow := &reconfigStub{}
 	policy := &dynPolicyStub{}
@@ -93,15 +128,13 @@ func TestQueuesConfigReload_AppliesChanges(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
-
-	waitFor(t, "initial apply", func() bool { return flow.callCount() >= 1 })
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, policy, pools, logr.Discard())
 
 	// A changed file is applied again.
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"},{"id":"q2","queue_name":"q2","igw_base_url":"http://gw"}]`)
-	waitFor(t, "second apply", func() bool { return flow.callCount() >= 2 })
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"},{"id":"q2","queue_name":"q2","igw_base_url":"http://gw"}]`))
+	waitFor(t, "second apply", func() bool { return flow.callCount() >= 1 })
 
-	if got := len(flow.calls[1]); got != 2 {
+	if got := len(flow.call(0)); got != 2 {
 		t.Fatalf("second apply carried %d queues, want 2", got)
 	}
 }
@@ -109,7 +142,7 @@ func TestQueuesConfigReload_AppliesChanges(t *testing.T) {
 func TestQueuesConfigReload_UnchangedFileIsNoop(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "queues.json")
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
 
 	flow := &reconfigStub{}
 	policy := &dynPolicyStub{}
@@ -117,11 +150,9 @@ func TestQueuesConfigReload_UnchangedFileIsNoop(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
-
-	waitFor(t, "initial apply", func() bool { return flow.callCount() >= 1 })
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, policy, pools, logr.Discard())
 	time.Sleep(100 * time.Millisecond)
-	if got := flow.callCount(); got != 1 {
+	if got := flow.callCount(); got != 0 {
 		t.Fatalf("unchanged file re-applied %d times, want 1", got)
 	}
 }
@@ -129,7 +160,7 @@ func TestQueuesConfigReload_UnchangedFileIsNoop(t *testing.T) {
 func TestQueuesConfigReload_BadContentKeepsLastGood(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "queues.json")
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
 
 	flow := &reconfigStub{}
 	policy := &dynPolicyStub{}
@@ -137,20 +168,18 @@ func TestQueuesConfigReload_BadContentKeepsLastGood(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
-
-	waitFor(t, "initial apply", func() bool { return flow.callCount() >= 1 })
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, policy, pools, logr.Discard())
 
 	writeQueuesFile(t, path, `{not json`)
 	time.Sleep(150 * time.Millisecond)
-	if got := flow.callCount(); got != 1 {
+	if got := flow.callCount(); got != 0 {
 		t.Fatalf("broken file applied, callCount=%d", got)
 	}
 
 	// Recovery: valid new content applies again.
-	writeQueuesFile(t, path, `[{"id":"q3","queue_name":"q3","igw_base_url":"http://gw"}]`)
-	waitFor(t, "recovery apply", func() bool { return flow.callCount() >= 2 })
-	if got := flow.calls[1][0].ID; got != "q3" {
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q3","queue_name":"q3","igw_base_url":"http://gw"}]`))
+	waitFor(t, "recovery apply", func() bool { return flow.callCount() >= 1 })
+	if got := flow.call(0)[0].ID; got != "q3" {
 		t.Fatalf("recovery carried %q, want q3", got)
 	}
 }
@@ -158,7 +187,7 @@ func TestQueuesConfigReload_BadContentKeepsLastGood(t *testing.T) {
 func TestQueuesConfigReload_ReconfigureErrorKeepsFingerprint(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "queues.json")
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
 
 	flow := &reconfigStub{err: errors.New("boom")}
 	policy := &dynPolicyStub{}
@@ -166,49 +195,106 @@ func TestQueuesConfigReload_ReconfigureErrorKeepsFingerprint(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, policy, pools, logr.Discard())
 
-	waitFor(t, "first failed apply", func() bool { return flow.callCount() >= 1 })
-	waitFor(t, "retries because fingerprint uncommitted", func() bool { return flow.callCount() >= 3 })
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q2","queue_name":"q2","igw_base_url":"http://gw"}]`))
+	waitFor(t, "first failed apply", func() bool { return flow.attemptCount() >= 1 })
+	waitFor(t, "retries because last good is unchanged", func() bool { return flow.attemptCount() >= 3 })
 	if got := policy.addCount(); got != 0 {
 		t.Fatalf("policy must not be extended on a failed apply, got %d calls", got)
 	}
 }
 
-func TestQueuesConfigReload_FanInFailureRetriesWholeFile(t *testing.T) {
+func TestQueuesConfigReload_PolicyErrorDoesNotCommitAndRecovers(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "queues.json")
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
-
-	flow := &reconfigStub{result: redis.QueueReconfigureResult{
-		Added: []pipeline.RequestChannel{{Channel: make(chan *api.InternalRequest)}},
-	}}
-	policy := &dynPolicyStub{err: errors.New("fan-in broken"), failures: 1}
+	path := filepath.Join(dir, "transport.json")
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
+	flow := &reconfigStub{result: redis.QueueReconfigureResult{Added: []pipeline.RequestChannel{{WorkerPoolID: "default"}}}}
+	policy := &dynPolicyStub{err: errors.New("policy unavailable")}
 	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, policy, pools, logr.Discard())
 
-	// Policy failure leaves the fingerprint uncommitted and retains the exact
-	// added channel for retry. Once accepted, the flow is idempotently applied
-	// again and the fingerprint is committed.
-	waitFor(t, "fan-in retry", func() bool { return policy.addCount() >= 2 })
-	waitFor(t, "successful reapply", func() bool { return flow.callCount() >= 2 })
-	policy.mu.Lock()
-	defer policy.mu.Unlock()
-	if policy.added[0][0].Channel != policy.added[1][0].Channel {
-		t.Fatal("fan-in retry did not reuse the pending channel")
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q2","queue_name":"q2","igw_base_url":"http://gw"}]`))
+	waitFor(t, "policy rejection", func() bool { return policy.addCount() >= 1 })
+	if got := flow.callCount(); got != 0 {
+		t.Fatalf("flow committed despite policy error: %d calls", got)
+	}
+
+	policy.setError(nil)
+	waitFor(t, "recovery with unchanged file", func() bool { return flow.callCount() == 1 })
+	if got := flow.call(0)[0].ID; got != "q2" {
+		t.Fatalf("recovery carried %q, want q2", got)
+	}
+}
+
+func TestQueuesConfigReload_RejectsNonQueueChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transport.json")
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
+	flow := &reconfigStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, &dynPolicyStub{}, pools, logr.Discard())
+	writeQueuesFile(t, path, `{"url":"redis://other","queues":[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]}`)
+	time.Sleep(100 * time.Millisecond)
+	if got := flow.callCount(); got != 0 {
+		t.Fatalf("non-queue change was applied %d times", got)
+	}
+}
+
+func TestQueuesConfigReload_UnknownPoolThenCorrection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transport.json")
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
+	flow := &reconfigStub{}
+	policy := &dynPolicyStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, policy, pools, logr.Discard())
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q2","queue_name":"q2","worker_pool_id":"ghost","igw_base_url":"http://gw"}]`))
+	time.Sleep(100 * time.Millisecond)
+	if got := flow.callCount(); got != 0 {
+		t.Fatalf("unknown pool was applied %d times", got)
+	}
+	if got := policy.addCount(); got != 0 {
+		t.Fatalf("policy was called before unknown-pool rejection: %d", got)
+	}
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q2","queue_name":"q2","worker_pool_id":"default","igw_base_url":"http://gw"}]`))
+	waitFor(t, "corrected config", func() bool { return flow.callCount() == 1 })
+}
+
+func TestQueuesConfigReload_ClearsAndReaddsQueues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transport.json")
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
+	flow := &reconfigStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, loadTestConfig(t, path), flow, &dynPolicyStub{}, pools, logr.Discard())
+	writeQueuesFile(t, path, sortedSetFile(`[]`))
+	waitFor(t, "cleared queues", func() bool { return flow.callCount() == 1 })
+	if got := len(flow.call(0)); got != 0 {
+		t.Fatalf("clear carried %d queues, want 0", got)
+	}
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q2","queue_name":"q2","igw_base_url":"http://gw"}]`))
+	waitFor(t, "re-added queue", func() bool { return flow.callCount() == 2 })
+	if got := flow.call(1)[0].ID; got != "q2" {
+		t.Fatalf("re-add carried %q, want q2", got)
 	}
 }
 
 func TestQueuesConfigReload_StopsWithContext(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "queues.json")
-	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+	path := filepath.Join(dir, "transport.json")
+	writeQueuesFile(t, path, sortedSetFile(`[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	done := startQueuesConfigReload(ctx, path, time.Hour, &reconfigStub{}, &dynPolicyStub{},
+	done := startQueuesConfigReload(ctx, path, time.Hour, loadTestConfig(t, path), &reconfigStub{}, &dynPolicyStub{},
 		map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}, logr.Discard())
 	cancel()
 	select {

--- a/pkg/server/queues_reload_test.go
+++ b/pkg/server/queues_reload_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-async/api"
+	"github.com/llm-d/llm-d-async/pipeline"
+	"github.com/llm-d/llm-d-async/pkg/redis"
+)
+
+type reconfigStub struct {
+	mu     sync.Mutex
+	calls  [][]redis.SortedSetQueueConfig
+	result redis.QueueReconfigureResult
+	err    error
+}
+
+func (s *reconfigStub) ReconfigureQueues(queues []redis.SortedSetQueueConfig) (redis.QueueReconfigureResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, queues)
+	return s.result, s.err
+}
+
+func (s *reconfigStub) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+type dynPolicyStub struct {
+	pipeline.RequestMergePolicy
+	mu    sync.Mutex
+	added [][]pipeline.RequestChannel
+	err   error
+}
+
+func (s *dynPolicyStub) AddRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
+	s.mu.Lock()
+	s.added = append(s.added, channels)
+	s.mu.Unlock()
+	return s.err
+}
+
+func (s *dynPolicyStub) addCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.added)
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func writeQueuesFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write queues file: %v", err)
+	}
+}
+
+func TestQueuesConfigReload_AppliesChanges(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queues.json")
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+
+	flow := &reconfigStub{}
+	policy := &dynPolicyStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+
+	waitFor(t, "initial apply", func() bool { return flow.callCount() >= 1 })
+
+	// A changed file is applied again.
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"},{"id":"q2","queue_name":"q2","igw_base_url":"http://gw"}]`)
+	waitFor(t, "second apply", func() bool { return flow.callCount() >= 2 })
+
+	if got := len(flow.calls[1]); got != 2 {
+		t.Fatalf("second apply carried %d queues, want 2", got)
+	}
+}
+
+func TestQueuesConfigReload_UnchangedFileIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queues.json")
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+
+	flow := &reconfigStub{}
+	policy := &dynPolicyStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+
+	waitFor(t, "initial apply", func() bool { return flow.callCount() >= 1 })
+	time.Sleep(100 * time.Millisecond)
+	if got := flow.callCount(); got != 1 {
+		t.Fatalf("unchanged file re-applied %d times, want 1", got)
+	}
+}
+
+func TestQueuesConfigReload_BadContentKeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queues.json")
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+
+	flow := &reconfigStub{}
+	policy := &dynPolicyStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+
+	waitFor(t, "initial apply", func() bool { return flow.callCount() >= 1 })
+
+	writeQueuesFile(t, path, `{not json`)
+	time.Sleep(150 * time.Millisecond)
+	if got := flow.callCount(); got != 1 {
+		t.Fatalf("broken file applied, callCount=%d", got)
+	}
+
+	// Recovery: valid new content applies again.
+	writeQueuesFile(t, path, `[{"id":"q3","queue_name":"q3","igw_base_url":"http://gw"}]`)
+	waitFor(t, "recovery apply", func() bool { return flow.callCount() >= 2 })
+	if got := flow.calls[1][0].ID; got != "q3" {
+		t.Fatalf("recovery carried %q, want q3", got)
+	}
+}
+
+func TestQueuesConfigReload_ReconfigureErrorKeepsFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queues.json")
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+
+	flow := &reconfigStub{err: errors.New("boom")}
+	policy := &dynPolicyStub{}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+
+	waitFor(t, "first failed apply", func() bool { return flow.callCount() >= 1 })
+	waitFor(t, "retries because fingerprint uncommitted", func() bool { return flow.callCount() >= 3 })
+	if got := policy.addCount(); got != 0 {
+		t.Fatalf("policy must not be extended on a failed apply, got %d calls", got)
+	}
+}
+
+func TestQueuesConfigReload_FanInFailureRetriesWholeFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queues.json")
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+
+	flow := &reconfigStub{result: redis.QueueReconfigureResult{
+		Added: []pipeline.RequestChannel{{Channel: make(chan *api.InternalRequest)}},
+	}}
+	policy := &dynPolicyStub{err: errors.New("fan-in broken")}
+	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
+
+	// Policy failure leaves the fingerprint uncommitted, so the same file is
+	// re-submitted on the next tick until the policy accepts it.
+	waitFor(t, "retry loop", func() bool { return flow.callCount() >= 2 })
+}

--- a/pkg/server/queues_reload_test.go
+++ b/pkg/server/queues_reload_test.go
@@ -37,15 +37,24 @@ func (s *reconfigStub) callCount() int {
 
 type dynPolicyStub struct {
 	pipeline.RequestMergePolicy
-	mu    sync.Mutex
-	added [][]pipeline.RequestChannel
-	err   error
+	mu       sync.Mutex
+	added    [][]pipeline.RequestChannel
+	err      error
+	failures int
 }
 
 func (s *dynPolicyStub) AddRequestChannels(channels []pipeline.RequestChannel, pools map[string]pipeline.WorkerPoolConfig) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.added = append(s.added, channels)
-	s.mu.Unlock()
+	if s.failures > 0 {
+		s.failures--
+		err := s.err
+		if s.failures == 0 {
+			s.err = nil
+		}
+		return err
+	}
 	return s.err
 }
 
@@ -174,14 +183,37 @@ func TestQueuesConfigReload_FanInFailureRetriesWholeFile(t *testing.T) {
 	flow := &reconfigStub{result: redis.QueueReconfigureResult{
 		Added: []pipeline.RequestChannel{{Channel: make(chan *api.InternalRequest)}},
 	}}
-	policy := &dynPolicyStub{err: errors.New("fan-in broken")}
+	policy := &dynPolicyStub{err: errors.New("fan-in broken"), failures: 1}
 	pools := map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	startQueuesConfigReload(ctx, path, 10*time.Millisecond, flow, policy, pools, logr.Discard())
 
-	// Policy failure leaves the fingerprint uncommitted, so the same file is
-	// re-submitted on the next tick until the policy accepts it.
-	waitFor(t, "retry loop", func() bool { return flow.callCount() >= 2 })
+	// Policy failure leaves the fingerprint uncommitted and retains the exact
+	// added channel for retry. Once accepted, the flow is idempotently applied
+	// again and the fingerprint is committed.
+	waitFor(t, "fan-in retry", func() bool { return policy.addCount() >= 2 })
+	waitFor(t, "successful reapply", func() bool { return flow.callCount() >= 2 })
+	policy.mu.Lock()
+	defer policy.mu.Unlock()
+	if policy.added[0][0].Channel != policy.added[1][0].Channel {
+		t.Fatal("fan-in retry did not reuse the pending channel")
+	}
+}
+
+func TestQueuesConfigReload_StopsWithContext(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queues.json")
+	writeQueuesFile(t, path, `[{"id":"q1","queue_name":"q1","igw_base_url":"http://gw"}]`)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startQueuesConfigReload(ctx, path, time.Hour, &reconfigStub{}, &dynPolicyStub{},
+		map[string]pipeline.WorkerPoolConfig{"default": {ID: "default", Workers: 1}}, logr.Discard())
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("reload goroutine did not stop with its context")
+	}
 }

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -106,6 +106,10 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	reconfigurer, dynamicPolicy, watchEnabled, err := validateQueuesConfigWatch(opts, flow, policy)
+	if err != nil {
+		return err
+	}
 
 	metrics.Register(metrics.GetAsyncProcessorCollectors(flow.Characteristics().SupportsMessageLatency)...)
 
@@ -175,12 +179,9 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	flow.Start(ctx)
 	healthServer.SetReady()
 
-	reconfigurer, dynamicPolicy, watchEnabled, err := validateQueuesConfigWatch(opts, flow, policy)
-	if err != nil {
-		return err
-	}
+	var queuesReloadDone <-chan struct{}
 	if watchEnabled {
-		startQueuesConfigReload(baseCtx, opts.RedisSortedSet.QueuesConfigFile,
+		queuesReloadDone = startQueuesConfigReload(ctx, opts.RedisSortedSet.QueuesConfigFile,
 			opts.RedisSortedSet.QueuesConfigWatchInterval,
 			reconfigurer, dynamicPolicy, poolsMap, setupLog)
 	}
@@ -193,6 +194,9 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 
 	<-ctx.Done()
 	healthServer.SetNotReady()
+	if queuesReloadDone != nil {
+		<-queuesReloadDone
+	}
 
 	setupLog.Info("Signal received, stopping message consumption")
 	flow.StopConsuming()
@@ -445,13 +449,19 @@ func pollBacklog(ctx context.Context, reporter pipeline.BacklogReporter, interva
 	logger := ctrl.Log.WithName("backlog-poller")
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	type queueLabels struct {
+		id, name, pool string
+	}
+	previous := make(map[queueLabels]struct{})
 
 	poll := func() {
 		stats, err := reporter.QueueBacklog(ctx)
 		if err != nil {
 			logger.V(logging.DEFAULT).Error(err, "Failed to poll broker backlog")
 		}
+		current := make(map[queueLabels]struct{}, len(stats))
 		for _, s := range stats {
+			current[queueLabels{id: s.QueueID, name: s.QueueName, pool: s.PoolName}] = struct{}{}
 			metrics.SetBrokerBacklog(s.QueueID, s.QueueName, s.PoolName, float64(s.Depth))
 			// Nil counts mean the broker cannot report per-item deadlines
 			// (e.g. Cloud Pub/Sub); emit nothing for it. When present they are
@@ -464,6 +474,14 @@ func pollBacklog(ctx context.Context, reporter pipeline.BacklogReporter, interva
 				}
 				metrics.SetDeadlineProximity(s.QueueID, s.QueueName, s.PoolName, counts)
 			}
+		}
+		if err == nil {
+			for labels := range previous {
+				if _, exists := current[labels]; !exists {
+					metrics.RemoveQueueSnapshots(labels.id, labels.name, labels.pool)
+				}
+			}
+			previous = current
 		}
 	}
 

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -102,7 +102,7 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 		return err
 	}
 
-	flow, err := loadFlow(opts, gateFactory, poolsMap)
+	flow, sortedSetConfig, err := loadFlow(opts, gateFactory, poolsMap)
 	if err != nil {
 		return err
 	}
@@ -181,8 +181,8 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 
 	var queuesReloadDone <-chan struct{}
 	if watchEnabled {
-		queuesReloadDone = startQueuesConfigReload(ctx, opts.RedisSortedSet.QueuesConfigFile,
-			opts.RedisSortedSet.QueuesConfigWatchInterval,
+		queuesReloadDone = startQueuesConfigReload(ctx, opts.Transport.ConfigFile,
+			opts.Transport.ConfigWatchInterval, sortedSetConfig,
 			reconfigurer, dynamicPolicy, poolsMap, setupLog)
 	}
 
@@ -194,12 +194,11 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 
 	<-ctx.Done()
 	healthServer.SetNotReady()
+	setupLog.Info("Signal received, stopping message consumption")
+	flow.StopConsuming()
 	if queuesReloadDone != nil {
 		<-queuesReloadDone
 	}
-
-	setupLog.Info("Signal received, stopping message consumption")
-	flow.StopConsuming()
 
 	setupLog.Info("Draining in-flight requests", "timeout", opts.Worker.DrainTimeout)
 	done := make(chan struct{})
@@ -288,7 +287,7 @@ func loadRequestMergePolicy(configPath string, ctx context.Context) (pipeline.Re
 	return policy, nil
 }
 
-func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[string]pipeline.WorkerPoolConfig) (pipeline.Flow, error) {
+func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[string]pipeline.WorkerPoolConfig) (pipeline.Flow, *redis.SortedSetConfig, error) {
 	workerPools := make([]pipeline.WorkerPoolConfig, 0, len(poolsMap))
 	for _, p := range poolsMap {
 		workerPools = append(workerPools, p)
@@ -296,35 +295,39 @@ func loadFlow(opts *Options, gateFactory *flowcontrol.GateFactory, poolsMap map[
 
 	transportType, configBytes, err := opts.resolveTransport()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	switch transportType {
 	case "redis-pubsub":
 		cfg, err := redis.LoadPubSubConfig(configBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return redis.NewRedisMQFlow(*cfg, workerPools)
+		flow, err := redis.NewRedisMQFlow(*cfg, workerPools)
+		return flow, nil, err
 	case "redis-sortedset":
 		cfg, err := redis.LoadSortedSetConfig(configBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return redis.NewRedisSortedSetFlow(*cfg, workerPools, gateFactory)
+		flow, err := redis.NewRedisSortedSetFlow(*cfg, workerPools, gateFactory)
+		return flow, cfg, err
 	case "gcp-pubsub":
 		cfg, err := pubsub.LoadConfig(configBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// The legacy plain gcp-pubsub alias never gated (see legacyUngatedPubSub);
 		// pass a nil factory so a gate_type in a legacy topics file stays inert.
 		if opts.legacyUngatedPubSub() {
-			return pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, nil)
+			flow, err := pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, nil)
+			return flow, nil, err
 		}
-		return pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, gateFactory)
+		flow, err := pubsub.NewGCPPubSubMQFlow(*cfg, workerPools, gateFactory)
+		return flow, nil, err
 	default:
-		return nil, fmt.Errorf("unknown transport: %s", transportType)
+		return nil, nil, fmt.Errorf("unknown transport: %s", transportType)
 	}
 }
 

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -175,6 +175,16 @@ func (r *Runner) Run(ctx context.Context) (err error) {
 	flow.Start(ctx)
 	healthServer.SetReady()
 
+	reconfigurer, dynamicPolicy, watchEnabled, err := validateQueuesConfigWatch(opts, flow, policy)
+	if err != nil {
+		return err
+	}
+	if watchEnabled {
+		startQueuesConfigReload(baseCtx, opts.RedisSortedSet.QueuesConfigFile,
+			opts.RedisSortedSet.QueuesConfigWatchInterval,
+			reconfigurer, dynamicPolicy, poolsMap, setupLog)
+	}
+
 	if reporter, ok := flow.(pipeline.BacklogReporter); ok && opts.Transport.BacklogPollInterval > 0 {
 		go pollBacklog(ctx, reporter, opts.Transport.BacklogPollInterval)
 	} else if !ok {

--- a/pkg/server/runner_test.go
+++ b/pkg/server/runner_test.go
@@ -12,12 +12,14 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/llm-d/llm-d-async/pipeline"
 	"github.com/llm-d/llm-d-async/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -230,12 +232,21 @@ func TestBuildTLSConfig_invalidCertKeyPair(t *testing.T) {
 }
 
 type fakeBacklogReporter struct {
+	mu    sync.Mutex
 	stats []pipeline.QueueBacklogStat
 	err   error
 }
 
 func (f *fakeBacklogReporter) QueueBacklog(context.Context) ([]pipeline.QueueBacklogStat, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return f.stats, f.err
+}
+
+func (f *fakeBacklogReporter) setStats(stats []pipeline.QueueBacklogStat) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stats = stats
 }
 
 func histogramSampleCount(c prometheus.Collector) uint64 {
@@ -306,6 +317,33 @@ func TestPollBacklogSkipsNilDeadlineViews(t *testing.T) {
 
 	if got := histogramSampleCount(metrics.DeadlineProximity); got != 0 {
 		t.Fatalf("DeadlineProximity sample count = %d, want 0", got)
+	}
+}
+
+func TestPollBacklogRemovesDeletedQueueSnapshots(t *testing.T) {
+	metrics.BrokerBacklog.Reset()
+	metrics.DispatchBudget.Reset()
+	metrics.DeadlineProximity.Reset()
+	labels := pipeline.QueueBacklogStat{QueueID: "gone", QueueName: "queue-gone", PoolName: "pool-a", Depth: 3,
+		ExpiringCounts: make([]pipeline.ExpiringCount, len(metrics.DeadlineProximityBuckets()))}
+	reporter := &fakeBacklogReporter{stats: []pipeline.QueueBacklogStat{labels}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pollBacklog(ctx, reporter, 10*time.Millisecond)
+	waitFor(t, "initial backlog snapshot", func() bool {
+		return testutil.CollectAndCount(metrics.BrokerBacklog) == 1
+	})
+	reporter.setStats(nil)
+	waitFor(t, "deleted backlog snapshot cleanup", func() bool {
+		return testutil.CollectAndCount(metrics.BrokerBacklog) == 0
+	})
+
+	if got := testutil.CollectAndCount(metrics.BrokerBacklog); got != 0 {
+		t.Fatalf("deleted queue backlog still exposes %d series", got)
+	}
+	if got := testutil.CollectAndCount(metrics.DeadlineProximity); got != 0 {
+		t.Fatalf("deleted queue deadline snapshot still exposes %d series", got)
 	}
 }
 

--- a/release-notes.d/unreleased/407.md
+++ b/release-notes.d/unreleased/407.md
@@ -1,0 +1,10 @@
+---
+pr: 407
+url: https://github.com/llm-d/llm-d-async/pull/407
+author: todayim
+date: 2026-08-25
+---
+Redis sorted-set queue-list configurations can now be reloaded at runtime with
+`--redis.ss.queues-config-watch-interval`, preserving unchanged consumers,
+in-flight result routing, and Redis backlog while adding, updating, or removing
+queues.

--- a/release-notes.d/unreleased/407.md
+++ b/release-notes.d/unreleased/407.md
@@ -5,6 +5,10 @@ author: todayim
 date: 2026-08-25
 ---
 Redis sorted-set queue-list configurations can now be reloaded at runtime with
-`--redis.ss.queues-config-watch-interval`, preserving unchanged consumers,
-in-flight result routing, and Redis backlog while adding, updating, or removing
-queues.
+`--transport redis-sortedset`, `--transport-config-file`, and
+`--transport-config-watch-interval`. The watched file is a complete transport
+configuration and only its `queues` field may change; URL, queue names,
+polling, batch, tracing, and other transport fields require a restart.
+Unchanged consumers, in-flight result routing, and Redis backlog are preserved
+while queues are added, updated, or removed. Invalid JSON and unknown worker
+pools leave the last-good queue set active and can recover on a later tick.

--- a/test/integration/merge_policy_test.go
+++ b/test/integration/merge_policy_test.go
@@ -65,24 +65,24 @@ func TestRandomRobinPolicy_ConcurrentProducers(t *testing.T) {
 		}(chIdx)
 	}
 
-	// Consume all messages from the merged channel.
+	// Consume the expected messages from the merged channel. Dynamic fan-in
+	// channels stay open after their sources close so queues can be added later.
 	received := make(map[string]bool)
-	done := make(chan struct{})
-	go func() {
-		for msg := range mergedChan {
+	const expected = numChannels * msgsPerChannel
+	deadline := time.After(10 * time.Second)
+	for len(received) < expected {
+		select {
+		case msg := <-mergedChan:
+			if msg.InternalRequest == nil || msg.InternalRequest.PublicRequest == nil {
+				t.Fatal("merged channel returned an invalid message")
+			}
 			received[msg.InternalRequest.PublicRequest.ReqID()] = true
+		case <-deadline:
+			t.Fatalf("Timed out waiting for merged messages: got %d of %d", len(received), expected)
 		}
-		close(done)
-	}()
-
-	wg.Wait()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("Timed out waiting for merged channel to close")
 	}
+	wg.Wait()
 
-	expected := numChannels * msgsPerChannel
 	assert.Equal(t, expected, len(received), "Expected %d unique messages, got %d", expected, len(received))
 
 	// Verify every expected message was received.


### PR DESCRIPTION
## What does this PR do?

Adds opt-in hot reload for the legacy Redis sorted-set queue-list file through `--redis.ss.queues-config-watch-interval`.

- Periodically re-reads `--redis.ss.queues-config-file`, fingerprints the content, and applies only changed generations.
- Adds a runtime queue registry to `RedisSortedSetFlow`: unchanged queues retain their channel, gate, and consumer; added or modified queues start consuming without a restart; removed queues stop cleanly and leave their Redis backlog intact.
- Extends random-robin and tier-priority merge policies with dynamic source fan-in while keeping each worker pool merged channel stable.
- Preserves the result destination and TTL captured when a request leaves Redis, so a concurrent config change cannot reroute an in-flight result.
- Retries partially applied fan-in updates, ties the watcher to the runner lifecycle, validates the feature before readiness, and removes stale queue snapshot metrics.
- Exposes reload success/error counts and the timestamp of the last successful apply.

The watcher is disabled by default. This first version intentionally targets the existing `--redis.ss.queues-config-file` queue-list surface; whole `--transport-config-file` reload is out of scope.

## Why is this change needed?

Redis sorted-set queue definitions are currently fixed at process startup. Adding, removing, or changing a backlog queue requires restarting the async processor, interrupting consumption and making queue routing updates operationally expensive.

Hot reload lets operators change the active queue set while preserving unchanged workers, queued Redis data, in-flight result routing, and worker-pool dispatch channels. Invalid files and failed applies keep the last good generation active and are retried.

## How was this tested?

- [x] Unit tests added/updated (API routing, merge policies, metrics, Redis reconfiguration, watcher lifecycle/retry, backlog metric cleanup)
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed
- [x] Relevant package suites pass: `go test ./api ./pkg/server ./pkg/redis ./pkg/metrics ./pkg/async/mergepolicy/...`
- [x] Targeted race tests pass for Redis reconfiguration, watcher reload, backlog cleanup, and both dynamic merge policies
- [x] `go vet` passes for all affected packages
- [x] `golangci-lint` reports 0 issues

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally
- [x] Linters pass (`make lint` equivalent)
- [ ] Documentation updated (if applicable)

## Related Issues

None found. This is an independent operational enhancement.

## Release note

```release-note
Redis sorted-set queue-list configurations can now be reloaded at runtime with `--redis.ss.queues-config-watch-interval`, preserving unchanged consumers, in-flight result routing, and Redis backlog while adding, updating, or removing queues.
```
