### PR TITLE
test(e2e): switch the EPP image to llm-d-router's endpoint picker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,8 @@ undeploy-ap-on-k8s:
 #   GAIE_ROOT        — GAIE checkout; enables local EPP build and CRDs
 #   SIM_ROOT         — llm-d-inference-sim checkout; enables local sim build
 #   AP_IMAGE         — async-processor image tag        (default: $(IMAGE_TAG_BASE)/llm-d-async:e2e-test)
-#   EPP_IMAGE        — EPP image tag                    (default: registry.k8s.io/.../epp:v1.5.0)
+#   EPP_IMAGE        — EPP image tag                    (default: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0)
+#   GAIE_VERSION     — GAIE release for CRD fetch       (default: v1.5.0; must match the EPP image's pinned gaie)
 #   SIM_IMAGE        — inference-sim image tag          (default: ghcr.io/llm-d/llm-d-inference-sim:v0.0.0-test)
 #   REDIS_IMAGE      — Redis/Valkey image for E2E MQ    (default: valkey/valkey:8-alpine)
 #   CONTAINER_TOOL   — container runtime                (default: docker)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -63,12 +63,16 @@ var (
 
 	containerRuntime = detectContainerRuntime()
 	apImage          = env.GetEnvString("AP_IMAGE", "ghcr.io/llm-d/llm-d-async:e2e-test", ginkgo.GinkgoLogr)
-	eppImage         = env.GetEnvString("EPP_IMAGE", "registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0", ginkgo.GinkgoLogr)
-	simImage         = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
-	redisImage       = env.GetEnvString("REDIS_IMAGE", "valkey/valkey:8-alpine", ginkgo.GinkgoLogr)
-	pubsubImage      = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:513.0.0-emulators", ginkgo.GinkgoLogr)
-	gaieRoot         = os.Getenv("GAIE_ROOT")
-	simRoot          = os.Getenv("SIM_ROOT")
+	eppImage         = env.GetEnvString("EPP_IMAGE", "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0", ginkgo.GinkgoLogr)
+	// gaieVersion selects the gateway-api-inference-extension release whose
+	// CRDs are fetched; decoupled from the EPP image tag because the image now
+	// comes from llm-d-router, which pins its own gaie version in go.mod.
+	gaieVersion = env.GetEnvString("GAIE_VERSION", "v1.5.0", ginkgo.GinkgoLogr)
+	simImage    = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
+	redisImage  = env.GetEnvString("REDIS_IMAGE", "valkey/valkey:8-alpine", ginkgo.GinkgoLogr)
+	pubsubImage = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:513.0.0-emulators", ginkgo.GinkgoLogr)
+	gaieRoot    = os.Getenv("GAIE_ROOT")
+	simRoot     = os.Getenv("SIM_ROOT")
 
 	testConfig *testutils.TestConfig
 
@@ -524,7 +528,7 @@ var gaieInferencePoolCRDs = []string{
 
 // inferencePoolCRDs returns paths to the CRD files.
 // When GAIE_ROOT is set, CRDs are read from the local checkout;
-// otherwise they are fetched from the GAIE GitHub release matching the EPP_IMAGE tag.
+// otherwise they are fetched from the GAIE GitHub release at GAIE_VERSION.
 func inferencePoolCRDs() []string {
 	if gaieRoot != "" {
 		base := filepath.Join(gaieRoot, "config", "crd", "bases")
@@ -538,7 +542,7 @@ func inferencePoolCRDs() []string {
 }
 
 func fetchGAIECRDs() []string {
-	version := eppImage[strings.LastIndex(eppImage, ":")+1:]
+	version := gaieVersion
 
 	cacheDir := filepath.Join(projectRoot(), ".cache", "gaie-crds", version)
 	paths := make([]string, len(gaieInferencePoolCRDs))


### PR DESCRIPTION
## What does this PR do?

Switches the e2e suite's default EPP image from the archived upstream gaie image to llm-d-router's endpoint picker, and decouples the gaie CRD fetch from the image tag:

- `EPP_IMAGE` default: `registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0` → `ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0`.
- New `GAIE_VERSION` env var (default `v1.5.0`) drives `fetchGAIECRDs()`; previously the gaie release was derived from the `EPP_IMAGE` tag, which breaks once the image tag is a router version.
- Makefile env-var docs updated. The `GAIE_ROOT` local-build and local-CRD paths are unaffected.

## Why is this change needed?

Fixes #389:

1. **arm64 was broken.** Every `registry.k8s.io/gateway-api-inference-extension/epp` tag is an amd64-only single manifest (gaie's Dockerfile hardcodes `GOARCH=amd64`), so `make test-e2e` fails in `[BeforeSuite]` on Apple Silicon while loading the image into Kind.
2. **Stale source.** gaie archived the EPP; the code now lives in llm-d/llm-d-router. The harness should track the image we actually ship against.

Drop-in compatibility verified: router `v0.9.0` pins `sigs.k8s.io/gateway-api-inference-extension v1.5.0` (checked `go.mod` at the tag), so the InferencePool v1 API, `EndpointPickerConfig`, EPP flags, and the stock plugins in `test/e2e/yaml/epp.yaml` / `epp-config-fc.yaml` are unchanged. Image multi-arch verified against the ghcr manifest index: `linux/amd64` + `linux/arm64`.

## How was this tested?

- [x] `gofmt` / `go vet` on the e2e package
- [ ] Full `make test-e2e` was not run in this environment (no local Docker daemon); relying on the e2e CI job for the amd64 run. arm64 validation on Apple Silicon would be appreciated from anyone with a local Kind setup — this PR is what unblocks it.

## Related Issues

Fixes #389
