### PR TITLE
test(e2e): fix nightly e2e test failures and timeouts

### DIFF
--- a/.github/workflows/ci-e2e-tests.yaml
+++ b/.github/workflows/ci-e2e-tests.yaml
@@ -72,6 +72,7 @@ jobs:
         env:
           E2E_SKIP_CLEANUP: "true"
           SIM_IMAGE: ghcr.io/llm-d/llm-d-inference-sim:v0.9.1
+          PUBSUB_IMAGE: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
         run: make test-e2e
 
       - name: Collect KIND cluster logs

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ undeploy-ap-on-k8s:
 #   GAIE_VERSION     — GAIE release for CRD fetch       (default: v1.5.0; must match the EPP image's pinned gaie)
 #   SIM_IMAGE        — inference-sim image tag          (default: ghcr.io/llm-d/llm-d-inference-sim:v0.0.0-test)
 #   REDIS_IMAGE      — Redis/Valkey image for E2E MQ    (default: valkey/valkey:8-alpine)
+#   PUBSUB_IMAGE     — Pub/Sub emulator image tag       (default: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators)
 #   CONTAINER_TOOL   — container runtime                (default: docker)
 #   E2E_SKIP_CLEANUP — set "true" to keep the Kind cluster after tests
 #
@@ -174,11 +175,12 @@ undeploy-ap-on-k8s:
 #   E2E_INTEGRATION_SIM_PORT, E2E_INTEGRATION_ENVOY_PORT,
 #   E2E_INTEGRATION_ENVOY_ADMIN_PORT
 E2E_IMG ?= $(IMAGE_TAG_BASE)/llm-d-async:e2e-test
+PUBSUB_IMAGE ?= gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e integration tests against a Kind cluster
 	@command -v kind >/dev/null 2>&1 || { echo "kind is not installed"; exit 1; }
-	CONTAINER_TOOL=$(CONTAINER_TOOL) AP_IMAGE=$(E2E_IMG) go test ./test/e2e/ -timeout 30m -v -ginkgo.v \
+	CONTAINER_TOOL=$(CONTAINER_TOOL) AP_IMAGE=$(E2E_IMG) PUBSUB_IMAGE=$(PUBSUB_IMAGE) go test ./test/e2e/ -timeout 30m -v -ginkgo.v \
 		$(if $(FOCUS),-ginkgo.focus="$(FOCUS)",) \
 		$(if $(SKIP),-ginkgo.skip="$(SKIP)",)
 

--- a/test/e2e/e2e_benchmark_test.go
+++ b/test/e2e/e2e_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"os/exec"
 	"strings"
 	"sync"
@@ -308,7 +309,7 @@ var _ = ginkgo.Describe("Async Processor Performance Benchmark E2E", ginkgo.Orde
 		ginkgo.By("Waiting for all messages to be processed by pub/sub with prometheus gate")
 		gomega.Eventually(func() int64 {
 			return receivedCount.Load()
-		}, 5*time.Minute, 1*time.Second).Should(gomega.Equal(int64(numRequests)))
+		}, 10*time.Minute, 1*time.Second).Should(gomega.Equal(int64(numRequests)))
 
 		elapsedTime := time.Since(startTime)
 		monitorCancel()
@@ -362,4 +363,12 @@ func patchSimArgs(args []string) {
 	session, err = gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Eventually(session).WithTimeout(120 * time.Second).Should(gexec.Exit(0))
+
+	// Ensure the newly rolled-out sim pod is ready and accepting requests on simAdminURL
+	gomega.Eventually(func(g gomega.Gomega) {
+		resp, err := http.Get(simAdminURL + "/metrics")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
+		g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+	}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -70,7 +70,7 @@ var (
 	gaieVersion = env.GetEnvString("GAIE_VERSION", "v1.5.0", ginkgo.GinkgoLogr)
 	simImage    = env.GetEnvString("SIM_IMAGE", "ghcr.io/llm-d/llm-d-inference-sim:v0.10.0", ginkgo.GinkgoLogr)
 	redisImage  = env.GetEnvString("REDIS_IMAGE", "valkey/valkey:8-alpine", ginkgo.GinkgoLogr)
-	pubsubImage = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:513.0.0-emulators", ginkgo.GinkgoLogr)
+	pubsubImage = env.GetEnvString("PUBSUB_IMAGE", "gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators", ginkgo.GinkgoLogr)
 	gaieRoot    = os.Getenv("GAIE_ROOT")
 	simRoot     = os.Getenv("SIM_ROOT")
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -220,7 +220,9 @@ func setSimWaitingRequests(simAdminURL string, waitingRequests int) {
 		"waiting-requests": waitingRequests,
 	})
 	gomega.EventuallyWithOffset(1, func() error {
-		req, err := http.NewRequest(http.MethodPost, simAdminURL+"/fake_metrics", bytes.NewReader(body))
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, simAdminURL+"/fake_metrics", bytes.NewReader(body))
 		if err != nil {
 			return err
 		}
@@ -234,7 +236,7 @@ func setSimWaitingRequests(simAdminURL string, waitingRequests int) {
 			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 		}
 		return nil
-	}, 10*time.Second, 500*time.Millisecond).Should(gomega.Succeed())
+	}, 30*time.Second, 500*time.Millisecond).Should(gomega.Succeed())
 }
 
 // sendProbeRequest sends a minimal inference request through Envoy → EPP to trigger


### PR DESCRIPTION
### Description

Fixes the nightly E2E test failures tracked in #405.

### Root Cause & Changes

1. **Pub/Sub Emulator Docker Image Tag Not Found**:
   - `test/e2e/e2e_suite_test.go` defaulted `PUBSUB_IMAGE` to `gcr.io/google.com/cloudsdktool/google-cloud-cli:513.0.0-emulators`. That specific versioned tag was pruned upstream by Google, causing `BeforeSuite` image pulling to fail immediately with `manifest unknown: Failed to fetch "513.0.0-emulators"`.
   - **Fix**: Switched default image to `gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators` (the supported floating tag). Added `PUBSUB_IMAGE` configuration to the `Makefile` and passed it in `.github/workflows/ci-e2e-tests.yaml`.

2. **Pub/Sub Benchmark Flaky Timeout**:
   - In `test/e2e/e2e_benchmark_test.go`, the Pub/Sub benchmark (`measure clearing time and saturation under load with pub/sub transport and prometheus gate`) had a 5-minute timeout for 5,000 requests. Under CI load with the emulator, it finished ~4,515 requests right around the 5m mark and timed out.
   - **Fix**: Increased timeout from `5*time.Minute` to `10*time.Minute` to match the requests' deadline and the other benchmark tests.

3. **Sim Deployment Rollout Readiness & Connection Timeout Flakiness**:
   - In `test/e2e/e2e_benchmark_test.go`, `patchSimArgs` only waited for `deployment/llm-sim` rollout status without verifying that the NodePort endpoint was ready and receiving requests.
   - In `test/e2e/utils_test.go`, `setSimWaitingRequests` used a 10s `Eventually` timeout while `httpClient` also had a 10s timeout. A single hanging connection during pod recreation consumed the entire `Eventually` window without retrying.
   - **Fix**:
     - Added an HTTP readiness check on `simAdminURL + "/metrics"` in `patchSimArgs` after rollout completes.
     - Added a 3-second context timeout per request attempt in `setSimWaitingRequests` and extended the `Eventually` window to 30 seconds to allow multiple clean retries.

Fixes #405
