### PR TITLE
docs: document Redis deployment requirements

### DIFF
--- a/docs/guides/e2e-deploy.md
+++ b/docs/guides/e2e-deploy.md
@@ -154,6 +154,41 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install redis bitnami/valkey -n redis --create-namespace --set auth.enabled=false
 ```
 
+### Deployment requirements
+
+The processor has two hard requirements on its Redis (or Valkey) that the commands above do
+not configure. Both come from how the processor talks to and relies on this store, not from
+this guide's dev setup, so they apply to any deployment.
+
+**Standalone server only.** `pkg/redis/redis_conn.go` parses `REDIS_URL` into `*redis.Options`
+and every call site builds a standalone `redis.NewClient` from it: there is no
+`NewClusterClient` or `NewFailoverClient` path anywhere in the codebase. Point the processor at
+a standalone Redis or Valkey instance, not a Redis Cluster and not a Sentinel-fronted deployment;
+it will not follow a Sentinel failover or route Cluster slots.
+
+**Keys must never be evicted.** The processor infers correctness from whether a key still
+exists: cancellation markers, active-token markers, quota counters, and result mailboxes are
+all read this way. If Redis evicts one of these keys under memory pressure, the processor reads
+that as "never existed" or "already consumed" instead of an explicit error, silently producing a
+wrong result rather than a visible failure. Preventing eviction takes two settings together:
+
+- `maxmemory` set to a real value (not `0`/unlimited)
+- `maxmemory-policy noeviction`
+
+Set the `maxmemory` limit comfortably below the container's memory limit: Redis forks to
+write an RDB snapshot (`BGSAVE`), and that fork can be OOM-killed if `maxmemory` leaves no
+headroom for it. The reference install commands above set neither, so the queue grows without
+bound and nothing gets evicted only because nothing is enforcing a memory ceiling in the first
+place; on a memory-constrained deployment set both explicitly, for example:
+
+```bash
+helm install redis bitnami/redis -n redis --create-namespace --set auth.enabled=false \
+    --set commonConfiguration="maxmemory 512mb\nmaxmemory-policy noeviction"
+```
+
+Size `maxmemory` and persistence (AOF/RDB) for your expected queue depth and result retention;
+this guide's dev install is not a sizing reference.
+
 ## Step 9: Deploy Async Processor with dispatch budget gate
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Adds a "Deployment requirements" section to `docs/guides/e2e-deploy.md` documenting the two hard requirements the processor has on its Redis (or Valkey), which were not written down anywhere before this.

## Why is this change needed?

The processor's connection code (`pkg/redis/redis_conn.go`) only ever builds a standalone `redis.NewClient`, so it cannot talk to a Redis Cluster or follow a Sentinel failover. Separately, the processor decides correctness by checking whether a key still exists (cancellation markers, active-token markers, quota counters, result mailboxes), so an evicted key silently becomes a wrong answer instead of a visible error. Preventing eviction needs `maxmemory` set to a real value together with `maxmemory-policy noeviction`. The docs only ever showed a bare `helm install redis bitnami/redis ...` line with neither requirement mentioned, so a reader following this guide has no way to know about either constraint. Reported in issue #421, which also references the same requirements being documented for the coordinator step in llm-d-router#2325.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

Docs-only change. Verified the claims against the current code: `pkg/redis/redis_conn.go` and every `redis.NewClient` call site in the repo confirm standalone-only, no cluster/sentinel client exists anywhere.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`) — docs-only change, full suite not run
- [ ] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #421

## Release note

```release-note
NONE
```
