### PR TITLE
fix: correct 'Unparseable' typo to 'Unparsable'

### DIFF
--- a/pkg/redis/sortedset_impl.go
+++ b/pkg/redis/sortedset_impl.go
@@ -815,10 +815,10 @@ func (r *RedisSortedSetFlow) processMessagesWithConfig(ctx context.Context, msgC
 		member := z.Member.(string)
 		ir, deadline, ok := r.parseMessage(member, logger)
 		if !ok || ir == nil || ir.PublicRequest == nil {
-			// Unparseable entry: no request identity survives to redeliver,
+			// Unparsable entry: no request identity survives to redeliver,
 			// so remove it rather than letting it wedge the peek window.
 			if err := r.rdb.ZRem(ctx, queueName, member).Err(); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to remove unparseable message", "queue", queueName)
+				logger.V(logutil.DEFAULT).Error(err, "Failed to remove unparsable message", "queue", queueName)
 			}
 			continue
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes the two typos reported by the nightly typo scan (issue #430): `Unparseable`/`unparseable` corrected to `Unparsable`/`unparsable` in `pkg/redis/sortedset_impl.go`. Both occurrences are in a comment and a log message, not an identifier, so there is no API or behavioral change.

## Why is this change needed?

The repo's nightly `typos` scan (llm-d-infra CI) flagged these two occurrences and opened issue #430 asking for the fix.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

`go build ./pkg/redis/...`, `go vet ./pkg/redis/...`, and `go test ./pkg/redis/...` all pass. Confirmed no other occurrences of the misspelling remain in the package.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`) — ran `go test ./pkg/redis/...` directly instead, full multi-module suite not run
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #430

## Release note

```release-note
NONE
```
