### PR TITLE
fix: honor context cancellation while waiting for results

### DIFF
--- a/producer/redis_sortedset_producer.go
+++ b/producer/redis_sortedset_producer.go
@@ -257,22 +257,31 @@ func newRequestToken() (string, error) {
 }
 
 // GetResult retrieves a result from the Redis list, blocking until one is available.
+// Cancellation is checked between one-second blocking waits, so an empty queue
+// can delay observing cancellation by approximately one second.
 func (p *RedisSortedSetProducer) GetResult(ctx context.Context) (*api.ResultMessage, error) {
-	// Use BRPOP (blocking right pop) to wait for a result
-	result, err := p.client.BRPop(ctx, 0, p.resultQueueName).Result()
-	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, err
+	// A zero BRPOP timeout blocks indefinitely: go-redis does not interrupt an
+	// in-flight read when the context is cancelled. Bound each empty wait so we
+	// can check the context without leaving a background pop consuming results.
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("failed to get result: %w", err)
 		}
-		return nil, fmt.Errorf("failed to get result: %w", err)
-	}
+		result, err := p.client.BRPop(ctx, time.Second, p.resultQueueName).Result()
+		if errors.Is(err, redis.Nil) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get result: %w", err)
+		}
 
-	// BRPOP returns [queueName, value]
-	if len(result) != 2 {
-		return nil, errors.New("unexpected BRPOP result format")
-	}
+		// BRPOP returns [queueName, value]
+		if len(result) != 2 {
+			return nil, errors.New("unexpected BRPOP result format")
+		}
 
-	return p.parseResult(result[1])
+		return p.parseResult(result[1])
+	}
 }
 
 // parseResult parses a JSON result message.

--- a/producer/redis_sortedset_producer_test.go
+++ b/producer/redis_sortedset_producer_test.go
@@ -312,6 +312,75 @@ func TestGetResultWithContextTimeout(t *testing.T) {
 	})
 }
 
+func TestGetResultWhileWaitingContextEnds(t *testing.T) {
+	for _, deadline := range []bool{false, true} {
+		name := "cancel"
+		if deadline {
+			name = "deadline"
+		}
+		t.Run(name, func(t *testing.T) {
+			producer, mr := setupTestProducer(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			want := context.Canceled
+			if deadline {
+				cancel()
+				ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+				want = context.DeadlineExceeded
+			}
+			defer cancel()
+			commands := mr.CommandCount()
+			done := make(chan error, 1)
+			go func() {
+				_, err := producer.GetResult(ctx)
+				done <- err
+			}()
+			require.Eventually(t, func() bool { return mr.CommandCount() > commands }, time.Second, time.Millisecond)
+			if !deadline {
+				cancel()
+			}
+			select {
+			case err := <-done:
+				require.ErrorIs(t, err, want)
+			case <-time.After(2 * time.Second):
+				t.Fatal("GetResult did not return after its context ended")
+			}
+			// A completed wait must release its connection and leave later results
+			// available to the next caller.
+			_, err := mr.Lpush("test-result-queue", `{"id":"next-call"}`)
+			require.NoError(t, err)
+			result, err := producer.GetResult(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, "next-call", result.ID)
+		})
+	}
+}
+
+func TestGetResultWaitsAcrossEmptyPolls(t *testing.T) {
+	producer, mr := setupTestProducer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	commands := mr.CommandCount()
+	type response struct {
+		result *api.ResultMessage
+		err    error
+	}
+	done := make(chan response, 1)
+	go func() {
+		result, err := producer.GetResult(ctx)
+		done <- response{result, err}
+	}()
+	require.Eventually(t, func() bool { return mr.CommandCount() >= commands+2 }, 3*time.Second, time.Millisecond)
+	_, err := mr.Lpush("test-result-queue", `{"id":"after-empty-poll"}`)
+	require.NoError(t, err)
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		require.Equal(t, "after-empty-poll", got.result.ID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetResult did not return the queued result")
+	}
+}
+
 func TestMultipleTenantsIsolation(t *testing.T) {
 	// Start mini Redis
 	mr, err := miniredis.Run()

--- a/release-notes.d/unreleased/434.md
+++ b/release-notes.d/unreleased/434.md
@@ -1,0 +1,7 @@
+---
+pr: 434
+url: https://github.com/llm-d/llm-d-async/pull/434
+author: git-jxj
+date: 2026-09-05
+---
+Redis producer GetResult now observes context cancellation while waiting on an empty result queue, with approximately one second of cancellation latency.


### PR DESCRIPTION
## What does this PR do?

Use one-second blocking Redis reads in `GetResult`, checking the caller's context between empty reads. Results received by a read are still returned to the caller.

## Why is this change needed?

`GetResult` promises to stop when its context is cancelled, but `BRPOP` with a zero timeout blocks indefinitely on an empty queue. Both a deadline and cancellation after the read starts leave callers waiting until a result arrives. The bounded reads allow cancellation to be observed after approximately one second without leaving a background consumer behind.

## How was this tested?

- [x] Unit tests added/updated: cancellation during a read, deadline expiry, subsequent reads on the same producer, and results arriving after an empty poll.
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed: Redis 6.0.16 reproduced both hangs before the fix; afterwards both calls returned their context errors in about one second, and a result published after 1.3 seconds was delivered normally.

Validation: `make test-all` (with `NO_PROXY=*` for the local IPv6 health endpoint), producer `go test -race ./...`, pipeline `go test ./...`, and all pre-commit hooks. The root-module lint hook and producer-module lint with `--new-from-rev HEAD` pass. A full producer-module lint run also has pre-existing findings on unmodified upstream.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Related to #151.

## Release note

```release-note
Redis producer GetResult now observes context cancellation while waiting on an empty result queue, with approximately one second of cancellation latency.
```
